### PR TITLE
Fix releasing PFCP associations

### DIFF
--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -438,7 +438,7 @@ pfcp_release_association (upf_node_assoc_t * n)
       continue;
     hash_unset (psm->request_q, msg->seq_no);
     mhash_unset (&psm->response_q, msg->request_key, NULL);
-    upf_pfcp_server_stop_msg_timer (msg);
+    upf_pfcp_server_stop_timer (msg->timer);
     pfcp_msg_pool_put (psm, msg);
   }));
   /* *INDENT-ON* */
@@ -1024,7 +1024,7 @@ pfcp_disable_session (upf_session_t * sx, int drop_msgs)
 
 	hash_unset (psm->request_q, msg->seq_no);
 	mhash_unset (&psm->response_q, msg->request_key, NULL);
-	upf_pfcp_server_stop_msg_timer (msg);
+	upf_pfcp_server_stop_timer (msg->timer);
 	pfcp_msg_pool_put (psm, msg);
       }));
       /* *INDENT-ON* */

--- a/upf/upf_pfcp_api.c
+++ b/upf/upf_pfcp_api.c
@@ -442,7 +442,7 @@ handle_heartbeat_response (pfcp_msg_t * req, pfcp_simple_response_t * msg)
   n = pool_elt_at_index (gtm->nodes, req->node);
 
   if (msg->response.recovery_time_stamp > n->recovery_time_stamp)
-    pfcp_release_association (n);
+    upf_pfcp_server_deferred_release_association (req->node);
   else if (msg->response.recovery_time_stamp < n->recovery_time_stamp)
     {
       /* 3GPP TS 23.007, Sect. 19A:
@@ -520,7 +520,7 @@ handle_association_setup_request (pfcp_msg_t * req,
        * PFCP Association Setup Response message.
        *
        */
-      pfcp_release_association (n);
+      upf_pfcp_server_deferred_release_association (n - gtm->nodes);
     }
 
   n =

--- a/upf/upf_pfcp_server.c
+++ b/upf/upf_pfcp_server.c
@@ -290,7 +290,7 @@ upf_pfcp_server_rx_msg (pfcp_msg_t * msg)
 
 	req = pfcp_msg_pool_elt_at_index (psm, p[0]);
 	hash_unset (psm->request_q, msg->seq_no);
-	upf_pfcp_server_stop_msg_timer (req);
+	upf_pfcp_server_stop_timer (req->timer);
 
 	msg->node = req->node;
 
@@ -484,7 +484,7 @@ restart_response_timer (pfcp_msg_t * msg)
   upf_debug ("Msg Seq No: %u, idx %u\n", msg->seq_no, id);
 
   if (msg->timer != ~0)
-    upf_pfcp_server_stop_msg_timer (msg);
+    upf_pfcp_server_stop_timer (msg->timer);
   msg->timer =
     upf_pfcp_server_start_timer (PFCP_SERVER_RESPONSE, id, RESPONSE_TIMEOUT);
 }
@@ -1040,31 +1040,11 @@ static void upf_validate_session_timers ()
 
 #endif
 
-void upf_pfcp_server_stop_msg_timer (pfcp_msg_t * msg)
+void upf_pfcp_server_stop_timer (u32 handle)
 {
   pfcp_server_main_t *psm = &pfcp_server_main;
-  u32 id_resp, *exp_id, id_t1;
 
-  if (msg->timer == ~0)
-    return;
-
-  id_t1 = ((0x80 | PFCP_SERVER_T1) << 24) | msg->seq_no;
-  id_resp =
-    ((0x80 | PFCP_SERVER_RESPONSE) << 24) | pfcp_msg_get_index (psm, msg);
-
-  /*
-   * Prevent timer handlers from being invoked in case the expiration
-   * has already been registered for the current iteration of
-   * pfcp_process() loop
-   */
-  vec_foreach (exp_id, psm->expired)
-  {
-    if (*exp_id == id_t1 || *exp_id == id_resp)
-      *exp_id = ~0;
-  }
-
-  TW (tw_timer_stop) (&psm->timer, msg->timer);
-  msg->timer = ~0;
+  TW (tw_timer_stop) (&psm->timer, handle);
 }
 
 u32 upf_pfcp_server_start_timer (u8 type, u32 id, u32 seconds)
@@ -1115,6 +1095,7 @@ static uword
   pfcp_server_main_t *psm = &pfcp_server_main;
   uword event_type, *event_data = 0;
   upf_main_t *gtm = &upf_main;
+  u32 *expired = NULL;
   u32 last_expired;
 
   pfcp_msg_pool_init (psm);
@@ -1143,8 +1124,8 @@ static uword
 
       /* run the timing wheel first, to that the internal base for new and updated timers
        * is set to now */
-      psm->expired =
-	TW (tw_timer_expire_timers_vec) (&psm->timer, psm->now, psm->expired);
+      expired =
+	TW (tw_timer_expire_timers_vec) (&psm->timer, psm->now, expired);
 
       switch (event_type)
 	{
@@ -1218,27 +1199,20 @@ static uword
 	  break;
 	}
 
-      vec_sort_with_function (psm->expired, timer_id_cmp);
+      vec_sort_with_function (expired, timer_id_cmp);
       last_expired = ~0;
 
-      for (int i = 0; i < vec_len (psm->expired); i++)
+      for (int i = 0; i < vec_len (expired); i++)
 	{
-	  /*
-	   * Check if the timer has been stopped while handling other
-	   * timers in this iteration of the upf_process() loop
-	   */
-	  if (psm->expired[i] == ~0)
-	    continue;
-
-	  switch (psm->expired[i] >> 24)
+	  switch (expired[i] >> 24)
 	    {
 	    case 0 ... 0x7f:
-	      if (last_expired == psm->expired[i])
+	      if (last_expired == expired[i])
 		continue;
-	      last_expired = psm->expired[i];
+	      last_expired = expired[i];
 
 	      {
-		const u32 si = psm->expired[i] & 0x7FFFFFFF;
+		const u32 si = expired[i] & 0x7FFFFFFF;
 		upf_session_t *sx;
 
 		if (pool_is_free_index (gtm->sessions, si))
@@ -1251,29 +1225,29 @@ static uword
 
 	    case 0x80 | PFCP_SERVER_HB_TIMER:
 	      upf_debug ("PFCP Server Heartbeat Timeout: %u",
-			 psm->expired[i] & 0x00FFFFFF);
-	      upf_server_send_heartbeat (psm->expired[i] & 0x00FFFFFF);
+			 expired[i] & 0x00FFFFFF);
+	      upf_server_send_heartbeat (expired[i] & 0x00FFFFFF);
 	      break;
 
 	    case 0x80 | PFCP_SERVER_T1:
 	      upf_debug ("PFCP Server T1 Timeout: %u",
-			 psm->expired[i] & 0x00FFFFFF);
-	      request_t1_expired (psm->expired[i] & 0x00FFFFFF);
+			 expired[i] & 0x00FFFFFF);
+	      request_t1_expired (expired[i] & 0x00FFFFFF);
 	      break;
 
 	    case 0x80 | PFCP_SERVER_RESPONSE:
 	      upf_debug ("PFCP Server Response Timeout: %u",
-			 psm->expired[i] & 0x00FFFFFF);
-	      response_expired (psm->expired[i] & 0x00FFFFFF);
+			 expired[i] & 0x00FFFFFF);
+	      response_expired (expired[i] & 0x00FFFFFF);
 	      break;
 
 	    default:
-	      upf_debug ("timeout for unknown id: %u", psm->expired[i] >> 24);
+	      upf_debug ("timeout for unknown id: %u", expired[i] >> 24);
 	      break;
 	    }
 	}
 
-      vec_reset_length (psm->expired);
+      vec_reset_length (expired);
       vec_reset_length (event_data);
 
 #if CLIB_DEBUG > 10

--- a/upf/upf_pfcp_server.h
+++ b/upf/upf_pfcp_server.h
@@ -101,8 +101,6 @@ typedef struct
   vlib_frame_t *ip_lookup_tx_frames[2];
 
   vlib_main_t *vlib_main;
-
-  u32 *expired;
 } pfcp_server_main_t;
 
 typedef struct
@@ -130,7 +128,7 @@ void upf_pfcp_session_start_stop_urr_time (u32 si, urr_time_t * t,
 					   u8 start_it);
 
 u32 upf_pfcp_server_start_timer (u8 type, u32 id, u32 seconds);
-void upf_pfcp_server_stop_msg_timer (pfcp_msg_t * msg);
+void upf_pfcp_server_stop_timer (u32 handle);
 
 int upf_pfcp_send_request (upf_session_t * sx, u8 type,
 			   struct pfcp_group *grp);

--- a/upf/upf_pfcp_server.h
+++ b/upf/upf_pfcp_server.h
@@ -101,6 +101,8 @@ typedef struct
   vlib_frame_t *ip_lookup_tx_frames[2];
 
   vlib_main_t *vlib_main;
+
+  u32 *release_node_assoc;
 } pfcp_server_main_t;
 
 typedef struct
@@ -129,6 +131,7 @@ void upf_pfcp_session_start_stop_urr_time (u32 si, urr_time_t * t,
 
 u32 upf_pfcp_server_start_timer (u8 type, u32 id, u32 seconds);
 void upf_pfcp_server_stop_timer (u32 handle);
+void upf_pfcp_server_deferred_release_association (u32 node);
 
 int upf_pfcp_send_request (upf_session_t * sx, u8 type,
 			   struct pfcp_group *grp);


### PR DESCRIPTION
This fixes expired timer conflict in a cleaner way than #7, reverting
previous PFCP timer changes.