### PR TITLE
Reclassify flows upon session modification

### DIFF
--- a/upf/upf.h
+++ b/upf/upf.h
@@ -627,6 +627,8 @@ typedef struct
   u32 dpo_locks;
 
   f64 unix_time_start;
+
+  u16 generation;
 } upf_session_t;
 
 

--- a/upf/upf_pfcp.h
+++ b/upf/upf_pfcp.h
@@ -125,6 +125,20 @@ upf_nwi_fib_index (fib_protocol_t proto, u32 nwi_index)
     return ~0;
 }
 
+static_always_inline u32
+flow_pdr_idx (flow_entry_t * flow, flow_direction_t direction,
+			  struct rules *r)
+{
+  upf_pdr_t *pdr;
+  u32 pdr_id = flow_pdr_id (flow, direction);
+
+  if (pdr_id == ~0)
+    return ~0;
+
+  pdr = pfcp_get_pdr_by_id (r, pdr_id);
+  return pdr ? pdr - r->pdr : ~0;
+}
+
 #endif /* _UPF_PFCP_H_ */
 
 /*

--- a/upf/upf_pfcp_api.c
+++ b/upf/upf_pfcp_api.c
@@ -2442,7 +2442,7 @@ handle_session_establishment_request (pfcp_msg_t * req,
     goto out_send_resp;
 
   r = pfcp_update_apply (sess);
-  upf_debug ("Appy: %d\n", r);
+  upf_debug ("Apply: %d\n", r);
 
   pfcp_update_finish (sess);
 
@@ -2597,6 +2597,9 @@ handle_session_modification_request (pfcp_msg_t * req,
 
       if ((r = pfcp_update_apply (sess)) != 0)
 	goto out_update_finish;
+
+      /* TODO: perhaps only increase it on PDR updates */
+      sess->generation++;
     }
 
   active = pfcp_get_rules (sess, PFCP_ACTIVE);


### PR DESCRIPTION
This adds generation id to the session which is checked against the
flow. If the generation id does not match, the flow is re-classified.

In order to enable flow re-classification in case of app detection,
the URI that was extracted by ADF code is now stored in the flow.

Formely, the traffic on flows for modified sessions could result
in crashes such as this:

```
/src/vpp/src/plugins/upf/upf_input.c:152 (upf_input) assertion `(((upf_buffer_opaque_t *)((u8 *)((b)->opaque2) + ((uword) & (((vnet_buffer_opaque_t *) 0)->unused))))->gtpu.pdr_idx) < vec_len (active->pdr)' fails
```

Fixes #14.