### PR TITLE
e2e: verify PFCP release upon heartbeat timeout

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -146,8 +146,20 @@ test:release:
   - mkdir artifacts junit-output
   # TODO: nightly run without E2E_QUICK
   # TODO: make UDP tests less flaky and reenable them for PGW
+  # TODO: make tests more stable on CI and remove E2E_FLAKE_ATTEMPTS
+  # TODO: before E2E_FLAKE_ATTEMPTS are removed, detect VPP crashes
+  # and always fail hard in this case, even if any retries could
+  # succeed
   - |
-    if ! make ${TEST_TARGET} E2E_RETEST=y E2E_ARTIFACTS_DIR=$PWD/artifacts E2E_JUNIT_DIR=$PWD/junit-output E2E_PARALLEL=y E2E_PARALLEL_NODES=3 E2E_QUICK=y E2E_SKIP='PGW.*counts UDP'; then
+    if ! make ${TEST_TARGET} \
+              E2E_RETEST=y \
+              E2E_ARTIFACTS_DIR=$PWD/artifacts \
+              E2E_JUNIT_DIR=$PWD/junit-output \
+              E2E_PARALLEL=y \
+              E2E_PARALLEL_NODES=3 \
+              E2E_QUICK=y \
+              E2E_SKIP='PGW.*counts UDP' \
+              E2E_FLAKE_ATTEMPTS=3; then
       mkdir test-out
       tar -cvzf test-out/vpp-test.tar.gz artifacts || true
       ls -l test-out/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -161,7 +161,7 @@ test:release:
               E2E_SKIP='PGW.*counts UDP' \
               E2E_FLAKE_ATTEMPTS=3; then
       mkdir test-out
-      tar -cvzf test-out/vpp-test.tar.gz artifacts || true
+      tar -cvzf test-out/vpp-test.tar.gz artifacts test/e2e/ginkgo*.log || true
       ls -l test-out/
       exit 1
     fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -145,9 +145,9 @@ test:release:
   - sysctl vm.nr_hugepages=0
   - mkdir artifacts junit-output
   # TODO: nightly run without E2E_QUICK
-  # TODO: get rid of E2E_FLAKE_ATTEMPTS. The tests need to be less flaky.
+  # TODO: make UDP tests less flaky and reenable them for PGW
   - |
-    if ! make ${TEST_TARGET} E2E_RETEST=y E2E_ARTIFACTS_DIR=$PWD/artifacts E2E_JUNIT_DIR=$PWD/junit-output E2E_PARALLEL=y E2E_PARALLEL_NODES=8 E2E_QUICK=y; then
+    if ! make ${TEST_TARGET} E2E_RETEST=y E2E_ARTIFACTS_DIR=$PWD/artifacts E2E_JUNIT_DIR=$PWD/junit-output E2E_PARALLEL=y E2E_PARALLEL_NODES=3 E2E_QUICK=y E2E_SKIP='PGW.*counts UDP'; then
       mkdir test-out
       tar -cvzf test-out/vpp-test.tar.gz artifacts || true
       ls -l test-out/

--- a/0008-Follow-symlinks-while-checking-timestamps-during-bui.patch
+++ b/0008-Follow-symlinks-while-checking-timestamps-during-bui.patch
@@ -1,0 +1,25 @@
+From e04f4cd4790a9a3ae09e54ad0ac2bee1346cf26c Mon Sep 17 00:00:00 2001
+From: Ivan Shvedunov <ivan.shvedunov@travelping.com>
+Date: Thu, 19 Nov 2020 12:27:37 +0300
+Subject: [PATCH] Follow symlinks while checking timestamps during builds
+
+---
+ build-root/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build-root/Makefile b/build-root/Makefile
+index e5db8b8fe..dba405f96 100644
+--- a/build-root/Makefile
++++ b/build-root/Makefile
+@@ -416,7 +416,7 @@ find_filter += -and -not -path '*/.mu_build_*'
+ find_newer_filtered_fn =			\
+   (! -f $(1)					\
+     || -n $(call find_newer_files_fn,$(1),$(3))	\
+-    || -n "`find -H $(2)			\
++    || -n "`find -L $(2)			\
+ 	      -type f				\
+               -and -newer $(1)			\
+ 	      -and \( $(4) \)			\
+-- 
+2.28.0
+

--- a/hack/buildenv.sh
+++ b/hack/buildenv.sh
@@ -28,9 +28,11 @@ else
          -e LC_ALL=C.UTF-8 \
          -e LANG=C.UTF-8 \
          -e E2E_RETEST="${E2E_RETEST:=}" \
+         -e E2E_VERBOSE="${E2E_VERBOSE:-}" \
          -e E2E_PARALLEL="${E2E_PARALLEL:-}" \
          -e E2E_PARALLEL_NODES="${E2E_PARALLEL_NODES:-}" \
          -e E2E_FOCUS="${E2E_FOCUS:-}" \
+         -e E2E_SKIP="${E2E_SKIP:-}" \
          -e E2E_TARGET="${E2E_TARGET:-}" \
          -e E2E_ARTIFACTS_DIR="${E2E_ARTIFACTS_DIR:-}" \
          -e E2E_JUNIT_DIR="${E2E_JUNIT_DIR:-}" \

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -10,6 +10,8 @@ cd "$(dirname "${BASH_SOURCE}")/.."
 : "${E2E_PARALLEL:=}"
 : "${E2E_PARALLEL_NODES:=10}"
 : "${E2E_FOCUS:=}"
+: "${E2E_SKIP:=}"
+: "${E2E_VERBOSE:=}"
 : "${E2E_TARGET:=debug}"
 : "${E2E_ARTIFACTS_DIR:=}"
 : "${E2E_JUNIT_DIR:=}"
@@ -51,12 +53,20 @@ cd test/e2e
 
 ginkgo_args=(-trace -progress -reportPassed)
 
+if [[ ${E2E_VERBOSE} ]]; then
+  ginkgo_args+=(-v)
+fi
+
 if [[ ${E2E_PARALLEL} ]]; then
   ginkgo_args+=(-nodes "${E2E_PARALLEL_NODES}")
 fi
 
 if [[ ${E2E_FOCUS} ]]; then
   ginkgo_args+=(-focus "${E2E_FOCUS}")
+fi
+
+if [[ ${E2E_SKIP} ]]; then
+  ginkgo_args+=(-skip "${E2E_SKIP}")
 fi
 
 if [[ ${E2E_FLAKE_ATTEMPTS} ]]; then

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -51,7 +51,7 @@ esac
 
 cd test/e2e
 
-ginkgo_args=(-trace -progress -reportPassed)
+ginkgo_args=(-trace -progress -reportPassed -debug)
 
 if [[ ${E2E_VERBOSE} ]]; then
   ginkgo_args+=(-v)

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -21,9 +21,11 @@ The tests are invoked from the top project directory using either
 The make commands accept following variables:
 
 * `E2E_RETEST`: if non-empty, don't build UPG before starting the tests
+* `E2E_VERBOSE`: if non-empty, enable verbose output for the tests
 * `E2E_PARALLEL`: if non-empty, run tests in parallel
 * `E2E_PARALLEL_NODES`: specify the number of parallel processes (nodes) for parallel testing
-* `E2E_FOCUS`: an optional regexp for selecting a subset of tests by name
+* `E2E_FOCUS`: an optional regexp for selecting a subset of tests to run by name
+* `E2E_SKIP`: an optional regexp for selecting a subset of tests to skip by name
 * `E2E_ARTIFACTS_DIR`: target directory for test artifacts (note, must
   start with /src in case of Docker env, where `/src` corresponds to
   the project root)

--- a/test/e2e/network/netns.go
+++ b/test/e2e/network/netns.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/travelping/upg-vpp/test/e2e/ns"
 	"github.com/vishvananda/netlink"
 	nns "github.com/vishvananda/netns"
-	"github.com/travelping/upg-vpp/test/e2e/ns"
 )
 
 var (
@@ -69,7 +69,7 @@ func (netns *NetNS) AddAddress(linkName string, address *net.IPNet) error {
 		}
 
 		if err := netlink.AddrAdd(veth, &netlink.Addr{IPNet: address}); err != nil {
-			return errors.Errorf("failed to set address for the bridge: %v", err)
+			return errors.Errorf("failed to set address for the veth: %v", err)
 		}
 
 		return nil


### PR DESCRIPTION
Add a e2e test that checks that UPG releases PFCP associations correctly upon heartbeat timeout and removes all of the sessions. It also checks that the problem mentioned in #4 is resolved.

Required by #27.
Should be merged after #28 (includes commits from that PR).