### PR TITLE
Handle duplicate UE IP+TEIDs across multiple sessions

### DIFF
--- a/upf/upf.h
+++ b/upf/upf.h
@@ -885,6 +885,14 @@ int vnet_upf_tdf_ul_table_add_del (u32 vrf, fib_protocol_t fproto,
 void upf_session_dpo_add_or_lock (dpo_proto_t dproto, upf_session_t * sx,
 				  dpo_id_t * dpo);
 
+const dpo_id_t *upf_get_session_dpo_ip4 (upf_nwi_t * nwi,
+					 ip4_address_t * ip4);
+
+const dpo_id_t *upf_get_session_dpo_ip6 (upf_nwi_t * nwi,
+					 ip6_address_t * ip6);
+
+dpo_type_t upf_session_dpo_get_type (void);
+
 static_always_inline void
 upf_vnet_buffer_l3_hdr_offset_is_current (vlib_buffer_t * b)
 {


### PR DESCRIPTION
This patch makes sure that a PDIs don't conflict for the PDIs for the
same NWI from other sessions based on UE IPs and TEIDs. This is not
yet a complete implementation of the spec in this respect b/c other
IEs in PDI also need to be taken into account.

Previously, adding many duplicate UE IPs could cause UPG to
crash (about 255) due to FIB entry src count limit, and, in addition
to that, deleting sessions with duplicate UEs could lead to an
assertion failure due to a bad session reference.

Now, if a conflict is detected, the corresponding Session Establishment Request
or Session Modification Request fails with "rule creation/modification failure" as the cause.

Fixes #25.

- [X] detect duplicate UE IP+TEIDs across multiple sessions
- [X] E2E test for TDF case (no TEIDs, just UE IPs)
- [x] E2E test for GTP-U case
- [x] verify session modification
- [x] get rid of unrelated indent changes