### PR TITLE
Improve stability of E2E tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -145,11 +145,6 @@ test:release:
   - sysctl vm.nr_hugepages=0
   - mkdir artifacts junit-output
   # TODO: nightly run without E2E_QUICK
-  # TODO: make UDP tests less flaky and reenable them for PGW
-  # TODO: make tests more stable on CI and remove E2E_FLAKE_ATTEMPTS
-  # TODO: before E2E_FLAKE_ATTEMPTS are removed, detect VPP crashes
-  # and always fail hard in this case, even if any retries could
-  # succeed
   - |
     if ! make ${TEST_TARGET} \
               E2E_RETEST=y \
@@ -157,9 +152,7 @@ test:release:
               E2E_JUNIT_DIR=$PWD/junit-output \
               E2E_PARALLEL=y \
               E2E_PARALLEL_NODES=3 \
-              E2E_QUICK=y \
-              E2E_SKIP='PGW.*counts UDP' \
-              E2E_FLAKE_ATTEMPTS=3; then
+              E2E_QUICK=y; then
       mkdir test-out
       tar -cvzf test-out/vpp-test.tar.gz artifacts test/e2e/ginkgo*.log || true
       ls -l test-out/

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -100,6 +100,18 @@ func (f *Framework) BeforeEach() {
 	ExpectNoError(f.VPP.Configure())
 	ExpectNoError(f.VPP.VerifyVPPAlive())
 
+	// TODO: use go-ping instead of 'ping'
+	for _, nsCfg := range f.VPPCfg.Namespaces {
+		if nsCfg.VPPIP == nil {
+			continue
+		}
+		ns := f.VPP.GetNS(nsCfg.Name)
+		cmd := exec.Command("nsenter", "--net="+ns.Path(), "ping", "-c", "3", nsCfg.VPPIP.IP.String())
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		ExpectNoError(cmd.Run())
+	}
+
 	if f.PFCPCfg != nil {
 		f.PFCPCfg.Namespace = f.VPP.GetNS("cp")
 		f.PFCP = pfcp.NewPFCPConnection(*f.PFCPCfg)

--- a/test/e2e/framework/upgmode.go
+++ b/test/e2e/framework/upgmode.go
@@ -58,7 +58,7 @@ func pgwVPPConfigIPv4() vpp.VPPConfig {
 			},
 			{
 				Name:          "ue",
-				OtherIP:       MustParseIPNet("10.0.1.3/24"),
+				OtherIP:       MustParseIPNet("10.1.0.3/16"),
 				OtherLinkName: "access",
 				SkipVPPConfig: true,
 				// using L3 capture because of tun
@@ -69,8 +69,8 @@ func pgwVPPConfigIPv4() vpp.VPPConfig {
 			{
 				Name:          "grx",
 				VPPMac:        MustParseMAC("fa:8a:78:4d:42:01"),
-				VPPIP:         MustParseIPNet("10.0.3.2/24"),
-				OtherIP:       MustParseIPNet("10.0.3.3/24"),
+				VPPIP:         MustParseIPNet("10.0.2.2/24"),
+				OtherIP:       MustParseIPNet("10.0.2.3/24"),
 				VPPLinkName:   "grx0",
 				OtherLinkName: "grx1",
 				Table:         100,
@@ -79,16 +79,16 @@ func pgwVPPConfigIPv4() vpp.VPPConfig {
 			{
 				Name:          "sgi",
 				VPPMac:        MustParseMAC("fa:8a:78:4d:19:01"),
-				VPPIP:         MustParseIPNet("10.0.2.2/24"),
-				OtherIP:       MustParseIPNet("10.0.2.3/24"),
+				VPPIP:         MustParseIPNet("10.0.1.2/24"),
+				OtherIP:       MustParseIPNet("10.0.1.3/24"),
 				VPPLinkName:   "sgi0",
 				OtherLinkName: "sgi1",
 				Table:         200,
 				MTU:           1500,
 				NSRoutes: []vpp.RouteConfig{
 					{
-						Dst: MustParseIPNet("10.0.1.0/24"),
-						Gw:  MustParseIP("10.0.2.2"),
+						Dst: MustParseIPNet("10.1.0.0/16"),
+						Gw:  MustParseIP("10.0.1.2"),
 					},
 				},
 			},
@@ -124,16 +124,6 @@ func pgwVPPConfigIPv6() vpp.VPPConfig {
 				OtherLinkName: "cp1",
 				Table:         0,
 			},
-			// FIXME: zero udp checksum on Session Modification Responses
-			// {
-			// 	Name:          "cp",
-			// 	VPPMac:        MustParseMAC("fa:8a:78:4d:5b:5b"),
-			// 	VPPIP:         MustParseIPNet("2001:db8:10::2/64"),
-			// 	OtherIP:       MustParseIPNet("2001:db8:10::3/64"),
-			// 	VPPLinkName:   "cp0",
-			// 	OtherLinkName: "cp1",
-			// 	Table:         0,
-			// },
 			{
 				Name:          "ue",
 				OtherIP:       MustParseIPNet("2001:db8:11::3/64"),
@@ -203,29 +193,29 @@ func tdfVPPConfigIPv4() vpp.VPPConfig {
 			{
 				Name:          "ue",
 				VPPMac:        MustParseMAC("fa:8a:78:4d:18:01"),
-				VPPIP:         MustParseIPNet("10.0.1.2/24"),
-				OtherIP:       MustParseIPNet("10.0.1.3/24"),
+				VPPIP:         MustParseIPNet("10.1.0.2/16"),
+				OtherIP:       MustParseIPNet("10.1.0.3/16"),
 				VPPLinkName:   "access0",
 				OtherLinkName: "access1",
 				Table:         100,
 				NSRoutes: []vpp.RouteConfig{
 					{
-						Gw: MustParseIP("10.0.1.2"),
+						Gw: MustParseIP("10.1.0.2"),
 					},
 				},
 			},
 			{
 				Name:          "sgi",
 				VPPMac:        MustParseMAC("fa:8a:78:4d:19:01"),
-				VPPIP:         MustParseIPNet("10.0.2.2/24"),
-				OtherIP:       MustParseIPNet("10.0.2.3/24"),
+				VPPIP:         MustParseIPNet("10.0.1.2/24"),
+				OtherIP:       MustParseIPNet("10.0.1.3/24"),
 				VPPLinkName:   "sgi0",
 				OtherLinkName: "sgi1",
 				Table:         200,
 				NSRoutes: []vpp.RouteConfig{
 					{
-						Dst: MustParseIPNet("10.0.1.0/24"),
-						Gw:  MustParseIP("10.0.2.2"),
+						Dst: MustParseIPNet("10.1.0.0/16"),
+						Gw:  MustParseIP("10.0.1.2"),
 					},
 				},
 			},
@@ -262,16 +252,6 @@ func tdfVPPConfigIPv6() vpp.VPPConfig {
 				OtherLinkName: "cp1",
 				Table:         0,
 			},
-			// FIXME: zero udp checksum on Session Modification Responses
-			// {
-			// 	Name:          "cp",
-			// 	VPPMac:        MustParseMAC("fa:8a:78:4d:5b:5b"),
-			// 	VPPIP:         MustParseIPNet("2001:db8:10::2/64"),
-			// 	OtherIP:       MustParseIPNet("2001:db8:10::3/64"),
-			// 	VPPLinkName:   "cp0",
-			// 	OtherLinkName: "cp1",
-			// 	Table:         0,
-			// },
 			{
 				Name:          "ue",
 				VPPMac:        MustParseMAC("fa:8a:78:4d:18:01"),

--- a/test/e2e/traffic/icmp.go
+++ b/test/e2e/traffic/icmp.go
@@ -67,6 +67,8 @@ func (p *ICMPPing) Run(ctx context.Context, ns *network.NetNS) error {
 		pinger.SetPrivileged(true)
 		pinger.Count = p.cfg.PacketCount
 		pinger.Size = p.cfg.PacketSize
+		pinger.Interval = 1 * time.Second
+		pinger.Timeout = time.Duration(pinger.Count)*pinger.Interval + 3*time.Second
 		pinger.OnSend = func(pkt *ping.Packet) {
 			p.rec.RecordStats(TrafficStats{ClientSent: pkt.Nbytes})
 		}

--- a/test/e2e/upg_e2e.go
+++ b/test/e2e/upg_e2e.go
@@ -369,13 +369,13 @@ var _ = ginkgo.Describe("Multiple PFCP Sessions", func() {
 			_, err := f.VPP.Ctl("memory-trace main-heap on")
 			framework.ExpectNoError(err)
 			var ueIPs []net.IP
-			for i := 0; i < 100; i++ {
+			for i := 0; i < 10000; i++ {
 				ueIPs = append(ueIPs, f.AddUEIP())
 			}
-			for i := 0; i < 100; i++ {
-				ginkgo.By("creating 100 sessions")
+			for i := 0; i < 3; i++ {
+				ginkgo.By("creating 10000 sessions")
 				var seids []pfcp.SEID
-				for j := 0; j < 100; j++ {
+				for j := 0; j < 10000; j++ {
 					sessionCfg := &framework.SessionConfig{
 						IdBase: 1,
 						UEIP:   ueIPs[j],
@@ -386,14 +386,14 @@ var _ = ginkgo.Describe("Multiple PFCP Sessions", func() {
 					seids = append(seids, seid)
 				}
 
-				ginkgo.By("deleting 100 sessions")
+				ginkgo.By("deleting 10000 sessions")
 				for _, seid := range seids {
 					deleteSession(f, seid, false)
 				}
 			}
 
-			ginkgo.By("Waiting 10 seconds for the queues to be emptied")
-			time.Sleep(10 * time.Second)
+			ginkgo.By("Waiting 40 seconds for the queues to be emptied")
+			time.Sleep(40 * time.Second)
 
 			memTraceOut, err := f.VPP.Ctl("show memory main-heap")
 			framework.ExpectNoError(err)


### PR DESCRIPTION
This PR includes the following e2e fixes:
* VPP ARP cache is pre-populated, reducing flakes in ICMP / UDP tests
* added proper timeouts for ICMP tests so they don't hang forever in case of failure
* made it possible to create much larger number of sessions at once, and updated the leak test to create 10k sessions at once
* stop skipping any tests on CI
* disabled flake retries on CI

Improving the leak test has uncovered a new issue (#44), so the CI still may fail intermittently on that test, but that is to be fixed shortly.