### PR TITLE
Fix GTP-U corruption and handling corrupt GTP-U packets

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -38,6 +38,7 @@ type Framework struct {
 	GTPU             *GTPU
 	Context          context.Context
 	GTPUMTU          int
+	TPDUHook         TPDUHook
 	numExtraCNodeIPs uint32
 	numExtraUEIPs    uint32
 }
@@ -84,6 +85,7 @@ func (f *Framework) BeforeEach() {
 			TEIDSGWs5u: TEIDSGWs5u,
 			LinkName:   f.VPPCfg.GetNamespaceLinkName("ue"),
 			MTU:        f.GTPUMTU,
+			TPDUHook:   f.TPDUHook,
 		})
 		ExpectNoError(err)
 		ExpectNoError(f.GTPU.Start(f.VPP.Context(context.Background())))

--- a/test/e2e/sgw/config.go
+++ b/test/e2e/sgw/config.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/vishvananda/netns"
+	"github.com/wmnsk/go-gtp/gtpv1/message"
 )
 
 type SGWGTPUTunnelType string
@@ -27,12 +28,18 @@ type SGWGTPUTunnel struct {
 	MTU           int               `yaml:"mtu",default:"1300"`
 }
 
+type TPDUHook func(tpdu *message.TPDU, fromPGW bool)
+
 type UserPlaneConfig struct {
 	S5uIP      net.IP
 	GTPUTunnel SGWGTPUTunnel
 	GRXNetNS   NetNS
 	UENetNS    NetNS
 	AddRule    bool
+	// Specify a hook function to run on ougtoing and incoming
+	// encapsulated T-PDUs. If this hook is non-nil, userspace
+	// GTP mode must always be used
+	TPDUHook TPDUHook
 }
 
 func (cfg *UserPlaneConfig) SetDefaults() {

--- a/test/e2e/sgw/uplane.go
+++ b/test/e2e/sgw/uplane.go
@@ -89,6 +89,9 @@ func NewUserPlaneServer(cfg UserPlaneConfig, restartCounter uint8) (up *UserPlan
 
 	switch cfg.GTPUTunnel.Type {
 	case SGWGTPUTunnelTypeKernel:
+		if cfg.TPDUHook != nil {
+			return nil, errors.New("can't use TPDUHook in kernel mode")
+		}
 		up.tunnel = NewKernelTunnel(up, cfg.GTPUTunnel)
 	case SGWGTPUTunnelTypeTun:
 		up.tunnel = NewTunTunnel(up, cfg.GTPUTunnel)

--- a/test/e2e/sgw/uplane_handlers.go
+++ b/test/e2e/sgw/uplane_handlers.go
@@ -45,8 +45,11 @@ func (up *UserPlaneServer) handleErrorIndication(msg *message.ErrorIndication) e
 }
 
 func (up *UserPlaneServer) handleTPDU(msg *message.TPDU, src *net.UDPAddr) error {
-	teid := msg.TEID()
+	if up.cfg.TPDUHook != nil {
+		up.cfg.TPDUHook(msg, true)
+	}
 
+	teid := msg.TEID()
 	if s := up.getSessionBySTEID(teid); s == nil {
 		return errors.Errorf("Received TPDU for unknown session s5c_teid: 0x%.8x", teid)
 	} else {

--- a/test/e2e/sgw/uplane_tun.go
+++ b/test/e2e/sgw/uplane_tun.go
@@ -106,7 +106,11 @@ func (tt *TunTunnel) handleTunnelIncoming(data []byte) {
 		return
 	}
 
-	if err := tt.up.WriteTo(s.UNodeAddr(), message.NewTPDU(s.TEIDPGWs5u(), data)); err != nil {
+	m := message.NewTPDU(s.TEIDPGWs5u(), data)
+	if tt.up.cfg.TPDUHook != nil {
+		tt.up.cfg.TPDUHook(m, false)
+	}
+	if err := tt.up.WriteTo(s.UNodeAddr(), m); err != nil {
 		tt.up.logger.WithError(err).Errorf("Failed to write TPDU message")
 	}
 }

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -84,19 +84,25 @@ STRUCT_OFFSET_OF (vnet_buffer_opaque_t, unused)))
  * upf-ip[46]-proxy-server-output)
  */
 #define UPF_BUFFER_F_GTPU_INITIALIZED VNET_BUFFER_F_AVAIL1
-#define UPF_ENTER_SUBGRAPH(b)					\
-  do {								\
-    ASSERT (!(b->flags & UPF_BUFFER_F_GTPU_INITIALIZED));	\
-    b->flags |= UPF_BUFFER_F_GTPU_INITIALIZED;			\
-    upf_buffer_opaque (b)->gtpu.hdr_flags = 0;			\
+#define UPF_ENTER_SUBGRAPH(b, sidx, is_ip4)				\
+  do {									\
+    ASSERT (!((b)->flags & UPF_BUFFER_F_GTPU_INITIALIZED));		\
+    clib_memset(upf_buffer_opaque (b), 0, sizeof(upf_buffer_opaque_t));	\
+    b->flags |= UPF_BUFFER_F_GTPU_INITIALIZED;				\
+    upf_buffer_opaque (b)->gtpu.session_index = sidx;			\
+    upf_buffer_opaque (b)->gtpu.flags =					\
+      is_ip4 ? BUFFER_GTP_UDP_IP4 : BUFFER_GTP_UDP_IP6;			\
   } while (0)
 #define UPF_CHECK_INNER_NODE(b) ASSERT (b->flags & UPF_BUFFER_F_GTPU_INITIALIZED)
 
 #else
 
-#define UPF_ENTER_SUBGRAPH(b)			\
-  do {						\
-    upf_buffer_opaque (b)->gtpu.hdr_flags = 0;	\
+#define UPF_ENTER_SUBGRAPH(b, sidx, is_ip4)				\
+  do {									\
+    clib_memset(upf_buffer_opaque (b), 0, sizeof(upf_buffer_opaque_t)); \
+    upf_buffer_opaque (b)->gtpu.session_index = sidx;			\
+    upf_buffer_opaque (b)->gtpu.flags =					\
+      is_ip4 ? BUFFER_GTP_UDP_IP4 : BUFFER_GTP_UDP_IP6;			\
   } while (0)
 #define UPF_CHECK_INNER_NODE(b)
 

--- a/upf/upf_classify.c
+++ b/upf/upf_classify.c
@@ -448,6 +448,7 @@ upf_classify_fn (vlib_main_t * vm, vlib_node_runtime_t * node,
 	  n_left_to_next -= 1;
 
 	  b = vlib_get_buffer (vm, bi);
+          UPF_CHECK_INNER_NODE (b);
 
 	  /* Get next node index and adj index from tunnel next_dpo */
 	  sidx = upf_buffer_opaque (b)->gtpu.session_index;

--- a/upf/upf_flow_node.c
+++ b/upf/upf_flow_node.c
@@ -162,7 +162,9 @@ upf_flow_process (vlib_main_t * vm, vlib_node_runtime_t * node,
 	  bi0 = to_next[0] = from[0];
 	  bi1 = to_next[1] = from[1];
 	  b0 = vlib_get_buffer (vm, bi0);
+          UPF_CHECK_INNER_NODE (b0);
 	  b1 = vlib_get_buffer (vm, bi1);
+          UPF_CHECK_INNER_NODE (b1);
 
 	  created0 = created1 = 0;
 	  is_reverse0 = is_reverse1 = 0;
@@ -325,6 +327,7 @@ upf_flow_process (vlib_main_t * vm, vlib_node_runtime_t * node,
 
 	  bi0 = to_next[0] = from[0];
 	  b0 = vlib_get_buffer (vm, bi0);
+          UPF_CHECK_INNER_NODE (b0);
 
 	  if (PREDICT_FALSE
 	      (pool_is_free_index

--- a/upf/upf_forward.c
+++ b/upf/upf_forward.c
@@ -131,6 +131,7 @@ upf_forward (vlib_main_t * vm, vlib_node_runtime_t * node,
 	  n_left_to_next -= 1;
 
 	  b = vlib_get_buffer (vm, bi);
+          UPF_CHECK_INNER_NODE (b);
 
 	  /* Get next node index and adj index from tunnel next_dpo */
 	  sidx = upf_buffer_opaque (b)->gtpu.session_index;

--- a/upf/upf_gtpu_decap.c
+++ b/upf/upf_gtpu_decap.c
@@ -162,7 +162,9 @@ upf_gtpu_input (vlib_main_t * vm,
 	  n_left_from -= 2;
 
 	  b0 = vlib_get_buffer (vm, bi0);
+	  UPF_ENTER_SUBGRAPH (b0);
 	  b1 = vlib_get_buffer (vm, bi1);
+	  UPF_ENTER_SUBGRAPH (b1);
 
 	  vnet_buffer (b0)->l4_hdr_offset = b0->current_data;
 	  vnet_buffer (b1)->l4_hdr_offset = b1->current_data;
@@ -603,6 +605,7 @@ upf_gtpu_input (vlib_main_t * vm,
 	  n_left_to_next -= 1;
 
 	  b0 = vlib_get_buffer (vm, bi0);
+	  UPF_ENTER_SUBGRAPH (b0);
 
 	  vnet_buffer (b0)->l4_hdr_offset = b0->current_data;
 
@@ -1055,6 +1058,7 @@ VLIB_NODE_FN (upf_gtp_error_ind_node) (vlib_main_t * vm,
       n_errors_left -= 1;
 
       b = vlib_get_buffer (vm, bi);
+      UPF_ENTER_SUBGRAPH (b);
       vlib_buffer_reset (b);
       vlib_buffer_advance (b, vnet_buffer (b)->l4_hdr_offset);
       gtpu = vlib_buffer_get_current (b);
@@ -1229,6 +1233,7 @@ VLIB_NODE_FN (upf_gtp_ip4_echo_req_node) (vlib_main_t * vm,
 	  n_left_to_next -= 1;
 
 	  p0 = vlib_get_buffer (vm, bi0);
+	  UPF_CHECK_INNER_NODE (p0);
 	  ip0 = vlib_buffer_get_current (p0);
 	  udp0 = ip4_next_header (ip0);
 
@@ -1378,6 +1383,7 @@ VLIB_NODE_FN (upf_gtp_ip6_echo_req_node) (vlib_main_t * vm,
 	  n_left_to_next -= 1;
 
 	  p0 = vlib_get_buffer (vm, bi0);
+	  UPF_CHECK_INNER_NODE (p0);
 	  ip0 = vlib_buffer_get_current (p0);
 	  udp0 = ip6_next_header (ip0);
 
@@ -1563,7 +1569,9 @@ ip_gtpu_upf_bypass_inline (vlib_main_t * vm,
 	  n_left_to_next -= 2;
 
 	  b0 = vlib_get_buffer (vm, bi0);
+	  UPF_ENTER_SUBGRAPH (b0);
 	  b1 = vlib_get_buffer (vm, bi1);
+	  UPF_ENTER_SUBGRAPH (b1);
 	  if (is_ip4)
 	    {
 	      ip40 = vlib_buffer_get_current (b0);

--- a/upf/upf_gtpu_decap.c
+++ b/upf/upf_gtpu_decap.c
@@ -162,9 +162,7 @@ upf_gtpu_input (vlib_main_t * vm,
 	  n_left_from -= 2;
 
 	  b0 = vlib_get_buffer (vm, bi0);
-	  UPF_ENTER_SUBGRAPH (b0);
 	  b1 = vlib_get_buffer (vm, bi1);
-	  UPF_ENTER_SUBGRAPH (b1);
 
 	  vnet_buffer (b0)->l4_hdr_offset = b0->current_data;
 	  vnet_buffer (b1)->l4_hdr_offset = b1->current_data;
@@ -215,11 +213,13 @@ upf_gtpu_input (vlib_main_t * vm,
 	      switch (gtpu0->type)
 		{
 		case GTPU_TYPE_ERROR_IND:
+		  UPF_ENTER_SUBGRAPH (b0, ~0, is_ip4);
 		  next0 = UPF_GTPU_INPUT_NEXT_ERROR_INDICATION;
 		  break;
 
 		case GTPU_TYPE_ECHO_REQUEST:
 		case GTPU_TYPE_ECHO_RESPONSE:
+		  UPF_ENTER_SUBGRAPH (b0, ~0, is_ip4);
 		  next0 = upf_gtpu_signalling_msg (gtpu0, &error0);
 		  break;
 
@@ -340,19 +340,16 @@ upf_gtpu_input (vlib_main_t * vm,
 	    }
 
 	  hdr_len0 += gtpu_hdr_len0;
+	  UPF_ENTER_SUBGRAPH (b0, session_index0, is_ip4);
 	  upf_buffer_opaque (b0)->gtpu.data_offset = hdr_len0;
 	  upf_buffer_opaque (b0)->gtpu.ext_hdr_len =
 	    gtpu_hdr_len0 - (sizeof (gtpu_header_t) - 4);
 	  upf_buffer_opaque (b0)->gtpu.hdr_flags = gtpu0->ver_flags;
-	  upf_buffer_opaque (b0)->gtpu.is_proxied = 0;
 	  upf_buffer_opaque (b0)->gtpu.teid =
 	    clib_net_to_host_u32 (gtpu0->teid);
-	  upf_buffer_opaque (b0)->gtpu.session_index = session_index0;
 	  upf_buffer_opaque (b0)->gtpu.pdr_idx =
 	    !(pfcp_get_rules (t0, PFCP_ACTIVE)->flags & PFCP_CLASSIFY) ?
 	    rule_index0 : ~0;
-	  upf_buffer_opaque (b0)->gtpu.flags =
-	    is_ip4 ? BUFFER_GTP_UDP_IP4 : BUFFER_GTP_UDP_IP6;
 	  upf_buffer_opaque (b0)->gtpu.flow_id = ~0;
 
 	  if (PREDICT_FALSE ((hdr_len0 + sizeof (*ip4_0)) >=
@@ -402,11 +399,13 @@ upf_gtpu_input (vlib_main_t * vm,
 	      switch (gtpu1->type)
 		{
 		case GTPU_TYPE_ERROR_IND:
+		  UPF_ENTER_SUBGRAPH (b1, ~0, is_ip4);
 		  next1 = UPF_GTPU_INPUT_NEXT_ERROR_INDICATION;
 		  break;
 
 		case GTPU_TYPE_ECHO_REQUEST:
 		case GTPU_TYPE_ECHO_RESPONSE:
+		  UPF_ENTER_SUBGRAPH (b1, ~0, is_ip4);
 		  next1 = upf_gtpu_signalling_msg (gtpu1, &error1);
 		  break;
 
@@ -527,19 +526,16 @@ upf_gtpu_input (vlib_main_t * vm,
 	    }
 
 	  hdr_len1 += gtpu_hdr_len1;
+	  UPF_ENTER_SUBGRAPH (b1, session_index1, is_ip4);
 	  upf_buffer_opaque (b1)->gtpu.data_offset = hdr_len1;
 	  upf_buffer_opaque (b1)->gtpu.ext_hdr_len =
 	    gtpu_hdr_len1 - (sizeof (gtpu_header_t) - 4);
 	  upf_buffer_opaque (b1)->gtpu.hdr_flags = gtpu1->ver_flags;
-	  upf_buffer_opaque (b1)->gtpu.is_proxied = 0;
 	  upf_buffer_opaque (b1)->gtpu.teid =
 	    clib_net_to_host_u32 (gtpu1->teid);
-	  upf_buffer_opaque (b1)->gtpu.session_index = session_index1;
 	  upf_buffer_opaque (b1)->gtpu.pdr_idx =
 	    !(pfcp_get_rules (t1, PFCP_ACTIVE)->flags & PFCP_CLASSIFY) ?
 	    rule_index1 : ~0;
-	  upf_buffer_opaque (b1)->gtpu.flags =
-	    is_ip4 ? BUFFER_GTP_UDP_IP4 : BUFFER_GTP_UDP_IP6;
 	  upf_buffer_opaque (b1)->gtpu.flow_id = ~0;
 
 	  if (PREDICT_FALSE ((hdr_len1 + sizeof (*ip4_1)) >=
@@ -605,7 +601,6 @@ upf_gtpu_input (vlib_main_t * vm,
 	  n_left_to_next -= 1;
 
 	  b0 = vlib_get_buffer (vm, bi0);
-	  UPF_ENTER_SUBGRAPH (b0);
 
 	  vnet_buffer (b0)->l4_hdr_offset = b0->current_data;
 
@@ -643,11 +638,13 @@ upf_gtpu_input (vlib_main_t * vm,
 	      switch (gtpu0->type)
 		{
 		case GTPU_TYPE_ERROR_IND:
+		  UPF_ENTER_SUBGRAPH (b0, ~0, is_ip4);
 		  next0 = UPF_GTPU_INPUT_NEXT_ERROR_INDICATION;
 		  break;
 
 		case GTPU_TYPE_ECHO_REQUEST:
 		case GTPU_TYPE_ECHO_RESPONSE:
+		  UPF_ENTER_SUBGRAPH (b0, ~0, is_ip4);
 		  next0 = upf_gtpu_signalling_msg (gtpu0, &error0);
 		  break;
 
@@ -767,19 +764,16 @@ upf_gtpu_input (vlib_main_t * vm,
 	    }
 
 	  hdr_len0 += gtpu_hdr_len0;
+	  UPF_ENTER_SUBGRAPH (b0, session_index0, is_ip4);
 	  upf_buffer_opaque (b0)->gtpu.data_offset = hdr_len0;
 	  upf_buffer_opaque (b0)->gtpu.ext_hdr_len =
 	    gtpu_hdr_len0 - (sizeof (gtpu_header_t) - 4);
 	  upf_buffer_opaque (b0)->gtpu.hdr_flags = gtpu0->ver_flags;
-	  upf_buffer_opaque (b0)->gtpu.is_proxied = 0;
 	  upf_buffer_opaque (b0)->gtpu.teid =
 	    clib_net_to_host_u32 (gtpu0->teid);
-	  upf_buffer_opaque (b0)->gtpu.session_index = session_index0;
 	  upf_buffer_opaque (b0)->gtpu.pdr_idx =
 	    !(pfcp_get_rules (t0, PFCP_ACTIVE)->flags & PFCP_CLASSIFY) ?
 	    rule_index0 : ~0;
-	  upf_buffer_opaque (b0)->gtpu.flags =
-	    (is_ip4) ? BUFFER_GTP_UDP_IP4 : BUFFER_GTP_UDP_IP6;
 	  upf_buffer_opaque (b0)->gtpu.flow_id = ~0;
 
 	  if (PREDICT_FALSE ((hdr_len0 + sizeof (*ip4_0)) >=
@@ -1058,7 +1052,7 @@ VLIB_NODE_FN (upf_gtp_error_ind_node) (vlib_main_t * vm,
       n_errors_left -= 1;
 
       b = vlib_get_buffer (vm, bi);
-      UPF_ENTER_SUBGRAPH (b);
+      UPF_CHECK_INNER_NODE (b);
       vlib_buffer_reset (b);
       vlib_buffer_advance (b, vnet_buffer (b)->l4_hdr_offset);
       gtpu = vlib_buffer_get_current (b);
@@ -1569,9 +1563,7 @@ ip_gtpu_upf_bypass_inline (vlib_main_t * vm,
 	  n_left_to_next -= 2;
 
 	  b0 = vlib_get_buffer (vm, bi0);
-	  UPF_ENTER_SUBGRAPH (b0);
 	  b1 = vlib_get_buffer (vm, bi1);
-	  UPF_ENTER_SUBGRAPH (b1);
 	  if (is_ip4)
 	    {
 	      ip40 = vlib_buffer_get_current (b0);

--- a/upf/upf_gtpu_decap.c
+++ b/upf/upf_gtpu_decap.c
@@ -319,6 +319,13 @@ upf_gtpu_input (vlib_main_t * vm,
 
 		  while ((u8 *) ext < end && ext->type != 0)
 		    {
+		      if (PREDICT_FALSE (!ext->len))
+			{
+			  error0 = UPF_GTPU_ERROR_LENGTH_ERROR;
+			  next0 = UPF_GTPU_INPUT_NEXT_DROP;
+			  goto trace0;
+			}
+
 		      /* gtpu_ext_header_t is 4 bytes and the len is in units of 4 */
 		      gtpu_hdr_len0 += ext->len * 4;
 		      ext += ext->len * 4 / sizeof (*ext);
@@ -499,6 +506,13 @@ upf_gtpu_input (vlib_main_t * vm,
 
 		  while ((u8 *) ext < end && ext->type != 0)
 		    {
+		      if (PREDICT_FALSE (!ext->len))
+			{
+			  error1 = UPF_GTPU_ERROR_LENGTH_ERROR;
+			  next1 = UPF_GTPU_INPUT_NEXT_DROP;
+			  goto trace1;
+			}
+
 		      /* gtpu_ext_header_t is 4 bytes and the len is in units of 4 */
 		      gtpu_hdr_len1 += ext->len * 4;
 		      ext += ext->len * 4 / sizeof (*ext);
@@ -731,6 +745,13 @@ upf_gtpu_input (vlib_main_t * vm,
 
 		  while ((u8 *) ext < end && ext->type != 0)
 		    {
+		      if (PREDICT_FALSE (!ext->len))
+			{
+			  error0 = UPF_GTPU_ERROR_LENGTH_ERROR;
+			  next0 = UPF_GTPU_INPUT_NEXT_DROP;
+			  goto trace00;
+			}
+
 		      /* gtpu_ext_header_t is 4 bytes and the len is in units of 4 */
 		      gtpu_hdr_len0 += ext->len * 4;
 		      ext += ext->len * 4 / sizeof (*ext);

--- a/upf/upf_gtpu_encap.c
+++ b/upf/upf_gtpu_encap.c
@@ -230,6 +230,11 @@ upf_encap_inline (vlib_main_t * vm,
 	  b2 = vlib_get_buffer (vm, bi2);
 	  b3 = vlib_get_buffer (vm, bi3);
 
+          UPF_CHECK_INNER_NODE (b0);
+          UPF_CHECK_INNER_NODE (b1);
+          UPF_CHECK_INNER_NODE (b2);
+          UPF_CHECK_INNER_NODE (b3);
+
 	  flow_hash0 = vnet_l2_compute_flow_hash (b0);
 	  flow_hash1 = vnet_l2_compute_flow_hash (b1);
 	  flow_hash2 = vnet_l2_compute_flow_hash (b2);
@@ -612,6 +617,7 @@ upf_encap_inline (vlib_main_t * vm,
 	  n_left_to_next -= 1;
 
 	  b0 = vlib_get_buffer (vm, bi0);
+          UPF_CHECK_INNER_NODE (b0);
 
 	  flow_hash0 = vnet_l2_compute_flow_hash (b0);
 

--- a/upf/upf_input.c
+++ b/upf/upf_input.c
@@ -138,6 +138,7 @@ upf_input (vlib_main_t * vm, vlib_node_runtime_t * node,
 	  n_left_to_next -= 1;
 
 	  b = vlib_get_buffer (vm, bi);
+          UPF_CHECK_INNER_NODE (b);
 
 	  /* Get next node index and adj index from tunnel next_dpo */
 	  sidx = upf_buffer_opaque (b)->gtpu.session_index;

--- a/upf/upf_proxy_accept.c
+++ b/upf/upf_proxy_accept.c
@@ -215,6 +215,7 @@ upf_proxy_accept_inline (vlib_main_t * vm, vlib_node_runtime_t * node,
       n_left_from -= 1;
 
       b = vlib_get_buffer (vm, bi);
+      UPF_CHECK_INNER_NODE (b);
 
       flow_id = upf_buffer_opaque (b)->gtpu.flow_id;
       upf_debug ("flow_id: 0x%08x", flow_id);

--- a/upf/upf_proxy_input.c
+++ b/upf/upf_proxy_input.c
@@ -313,6 +313,7 @@ upf_proxy_input (vlib_main_t * vm, vlib_node_runtime_t * node,
 	  n_left_to_next -= 1;
 
 	  b = vlib_get_buffer (vm, bi);
+          UPF_CHECK_INNER_NODE (b);
 
 	  error = 0;
 	  next = UPF_FORWARD_NEXT_DROP;

--- a/upf/upf_proxy_output.c
+++ b/upf/upf_proxy_output.c
@@ -146,6 +146,7 @@ upf_proxy_output (vlib_main_t * vm, vlib_node_runtime_t * node,
 	  n_left_to_next -= 1;
 
 	  b = vlib_get_buffer (vm, bi);
+          UPF_ENTER_SUBGRAPH (b);
 
 	  error = 0;
 

--- a/upf/upf_proxy_output.c
+++ b/upf/upf_proxy_output.c
@@ -146,7 +146,6 @@ upf_proxy_output (vlib_main_t * vm, vlib_node_runtime_t * node,
 	  n_left_to_next -= 1;
 
 	  b = vlib_get_buffer (vm, bi);
-          UPF_ENTER_SUBGRAPH (b);
 
 	  error = 0;
 
@@ -184,15 +183,11 @@ upf_proxy_output (vlib_main_t * vm, vlib_node_runtime_t * node,
 	      goto stats;
 	    }
 
-	  upf_buffer_opaque (b)->gtpu.session_index = flow->session_index;
+	  UPF_ENTER_SUBGRAPH (b, flow->session_index, is_ip4);
 	  upf_buffer_opaque (b)->gtpu.flow_id = flow_id;
 	  upf_buffer_opaque (b)->gtpu.is_reverse =
 	    direction ^ flow->is_reverse;
 	  upf_buffer_opaque (b)->gtpu.is_proxied = 1;
-	  upf_buffer_opaque (b)->gtpu.data_offset = 0;
-	  upf_buffer_opaque (b)->gtpu.teid = 0;
-	  upf_buffer_opaque (b)->gtpu.flags =
-	    is_ip4 ? BUFFER_HAS_IP4_HDR : BUFFER_HAS_IP6_HDR;
 
 	  /* mostly borrowed from vnet/interface_output.c calc_checksums */
 	  if (is_ip4)

--- a/upf/upf_tcp_forward.c
+++ b/upf/upf_tcp_forward.c
@@ -243,6 +243,7 @@ upf_tcp_forward (vlib_main_t * vm, vlib_node_runtime_t * node,
 	  n_left_to_next -= 1;
 
 	  b = vlib_get_buffer (vm, bi);
+          UPF_CHECK_INNER_NODE (b);
 
 	  error = 0;
 	  next = UPF_TCP_FORWARD_NEXT_FORWARD;


### PR DESCRIPTION
**! #45 needs to be merged before this one !**
(and this one needs to be updated if #45 changes)

Fixes #42: clear GTPU hdr_flags upon a buffer entering the UPG subgraph. In addition to that, make sure that all of the entrypoints to the UPG subgraph are known by checking the entry nodes and the inner nodes.

Fixes #43: fix endless loop upon zero GTP-U ext length during decap

An E2E test that reproduces both problems is included.
