### PR TITLE
e2e: add test for the GTP Proxy case

### DIFF
--- a/hack/buildenv.sh
+++ b/hack/buildenv.sh
@@ -39,6 +39,7 @@ else
          -e E2E_QUICK="${E2E_QUICK:-}" \
          -e E2E_FLAKE_ATTEMPTS="${E2E_FLAKE_ATTEMPTS:-}" \
          -e E2E_DISPATCH_TRACE="${E2E_DISPATCH_TRACE:-}" \
+         -e E2E_PAUSE_ON_ERROR="${E2E_PAUSE_ON_ERROR:-}" \
          -w /src/vpp \
          "${build_image}" \
          "$@"

--- a/hack/buildenv.sh
+++ b/hack/buildenv.sh
@@ -38,6 +38,7 @@ else
          -e E2E_JUNIT_DIR="${E2E_JUNIT_DIR:-}" \
          -e E2E_QUICK="${E2E_QUICK:-}" \
          -e E2E_FLAKE_ATTEMPTS="${E2E_FLAKE_ATTEMPTS:-}" \
+         -e E2E_DISPATCH_TRACE="${E2E_DISPATCH_TRACE:-}" \
          -w /src/vpp \
          "${build_image}" \
          "$@"

--- a/hack/buildenv.sh
+++ b/hack/buildenv.sh
@@ -38,6 +38,7 @@ else
          -e E2E_JUNIT_DIR="${E2E_JUNIT_DIR:-}" \
          -e E2E_QUICK="${E2E_QUICK:-}" \
          -e E2E_FLAKE_ATTEMPTS="${E2E_FLAKE_ATTEMPTS:-}" \
+         -e E2E_TRACE="${E2E_TRACE:-}" \
          -e E2E_DISPATCH_TRACE="${E2E_DISPATCH_TRACE:-}" \
          -e E2E_PAUSE_ON_ERROR="${E2E_PAUSE_ON_ERROR:-}" \
          -w /src/vpp \

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -18,6 +18,7 @@ cd "$(dirname "${BASH_SOURCE}")/.."
 : "${E2E_QUICK:=}"
 : "${E2E_FLAKE_ATTEMPTS:=}"
 : "${E2E_DISPATCH_TRACE:=}"
+: "${E2E_PAUSE_ON_ERROR:=}"
 
 if grep -q '^gtp ' /proc/modules; then
   echo >&2 "* Using kernel GTP-U support for IPv4 PGW tests"
@@ -83,6 +84,10 @@ fi
 
 if [[ ${E2E_JUNIT_DIR} ]]; then
   ginkgo_args+=(-junit-output "${E2E_JUNIT_DIR}")
+fi
+
+if [[ ${E2E_PAUSE_ON_ERROR} ]]; then
+  ginkgo_args+=(-pause)
 fi
 
 ginkgo "${ginkgo_args[@]}"

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -17,6 +17,7 @@ cd "$(dirname "${BASH_SOURCE}")/.."
 : "${E2E_JUNIT_DIR:=}"
 : "${E2E_QUICK:=}"
 : "${E2E_FLAKE_ATTEMPTS:=}"
+: "${E2E_DISPATCH_TRACE:=}"
 
 if grep -q '^gtp ' /proc/modules; then
   echo >&2 "* Using kernel GTP-U support for IPv4 PGW tests"
@@ -26,6 +27,7 @@ else
 fi
 
 export UPG_TEST_QUICK="${E2E_QUICK}"
+export VPP_DISPATCH_TRACE="${E2E_DISPATCH_TRACE}"
 
 case ${E2E_TARGET} in
   debug)

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -17,6 +17,7 @@ cd "$(dirname "${BASH_SOURCE}")/.."
 : "${E2E_JUNIT_DIR:=}"
 : "${E2E_QUICK:=}"
 : "${E2E_FLAKE_ATTEMPTS:=}"
+: "${E2E_TRACE:=}"
 : "${E2E_DISPATCH_TRACE:=}"
 : "${E2E_PAUSE_ON_ERROR:=}"
 
@@ -28,6 +29,7 @@ else
 fi
 
 export UPG_TEST_QUICK="${E2E_QUICK}"
+export VPP_TRACE="${E2E_TRACE}"
 export VPP_DISPATCH_TRACE="${E2E_DISPATCH_TRACE}"
 
 case ${E2E_TARGET} in

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -33,6 +33,7 @@ The make commands accept following variables:
 * `E2E_QUICK`: do shorter tests (pass less traffic)
 * `E2E_FLAKE_ATTEMPTS`: retry failed tests specified amount of times
 * `E2E_DISPATCH_TRACE`: store the VPP dispatch trace as `dispatch-trace.pcap` in the test dir
+* `E2E_PAUSE_ON_ERROR`: pause on error for interactive debugging
 
 An example with multiple flags:
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -32,6 +32,7 @@ The make commands accept following variables:
 * `E2E_JUNIT_DIR`: target directory for test reports in JUnit XML format
 * `E2E_QUICK`: do shorter tests (pass less traffic)
 * `E2E_FLAKE_ATTEMPTS`: retry failed tests specified amount of times
+* `E2E_DISPATCH_TRACE`: store the VPP dispatch trace as `dispatch-trace.pcap` in the test dir
 
 An example with multiple flags:
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -32,6 +32,7 @@ The make commands accept following variables:
 * `E2E_JUNIT_DIR`: target directory for test reports in JUnit XML format
 * `E2E_QUICK`: do shorter tests (pass less traffic)
 * `E2E_FLAKE_ATTEMPTS`: retry failed tests specified amount of times
+* `E2E_TRACE`: enable VPP trace
 * `E2E_DISPATCH_TRACE`: store the VPP dispatch trace as `dispatch-trace.pcap` in the test dir
 * `E2E_PAUSE_ON_ERROR`: pause on error for interactive debugging
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -126,8 +126,10 @@ func (f *Framework) AfterEach() {
 	if f.VPP != nil {
 		ExpectNoError(f.VPP.VerifyVPPAlive())
 		defer func() {
-			f.VPP.TearDown()
-			f.VPP = nil
+			if f.VPP != nil {
+				f.VPP.TearDown()
+				f.VPP = nil
+			}
 		}()
 
 		if f.PFCP != nil {
@@ -141,6 +143,8 @@ func (f *Framework) AfterEach() {
 			ExpectNoError(f.GTPU.Stop())
 			f.GTPU = nil
 		}
+		f.VPP.TearDown()
+		f.VPP = nil
 	}
 
 	if f.VPPCfg != nil && f.VPPCfg.BaseDir != "" {

--- a/test/e2e/framework/gtpu.go
+++ b/test/e2e/framework/gtpu.go
@@ -19,8 +19,8 @@ type GTPUConfig struct {
 	GRXNS      *network.NetNS
 	UENS       *network.NetNS
 	UEIP       net.IP
-	SGWGRXIP   net.IP
-	PGWGRXIP   net.IP
+	SGWIP      net.IP
+	PGWIP      net.IP
 	TEIDPGWs5u uint32
 	TEIDSGWs5u uint32
 	LinkName   string
@@ -29,7 +29,7 @@ type GTPUConfig struct {
 }
 
 func (cfg GTPUConfig) ipv6() bool {
-	return cfg.UEIP.To4() == nil || cfg.SGWGRXIP.To4() == nil || cfg.PGWGRXIP.To4() == nil
+	return cfg.UEIP.To4() == nil || cfg.SGWIP.To4() == nil || cfg.PGWIP.To4() == nil
 }
 
 func (cfg GTPUConfig) gtpuTunnelType() sgw.SGWGTPUTunnelType {
@@ -57,7 +57,7 @@ type GTPU struct {
 func NewGTPU(cfg GTPUConfig) (*GTPU, error) {
 	cfg.SetDefaults()
 	up, err := sgw.NewUserPlaneServer(sgw.UserPlaneConfig{
-		S5uIP: cfg.SGWGRXIP,
+		S5uIP: cfg.SGWIP,
 		GTPUTunnel: sgw.SGWGTPUTunnel{
 			Type:          cfg.gtpuTunnelType(),
 			InterfaceName: cfg.LinkName,
@@ -96,7 +96,7 @@ func (gtpu *GTPU) Start(ctx context.Context) error {
 
 	session := sgw.NewSimpleSession(sgw.SimpleSessionConfig{
 		UNodeAddr: &net.UDPAddr{
-			IP:   gtpu.cfg.PGWGRXIP,
+			IP:   gtpu.cfg.PGWIP,
 			Port: sgw.GTPU_PORT,
 		},
 		TEIDPGWs5u: gtpu.cfg.TEIDPGWs5u,

--- a/test/e2e/network/netns.go
+++ b/test/e2e/network/netns.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"regexp"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
@@ -213,7 +214,7 @@ func (netns *NetNS) ListenTCP(ctx context.Context, address string) (net.Listener
 	err := netns.Do(func() error {
 		var innerErr error
 		network := "tcp4"
-		if netns.ipv6 {
+		if netns.ipv6 || strings.HasPrefix(address, "[") {
 			network = "tcp6"
 		}
 		l, innerErr = netns.listenConfig().Listen(context.Background(), network, address)
@@ -258,4 +259,8 @@ func (netns *NetNS) AddRoute(dst *net.IPNet, gw net.IP) error {
 
 		return nil
 	})
+}
+
+func (netns *NetNS) SetIPv6() {
+	netns.ipv6 = true
 }

--- a/test/e2e/vpp/vpp.go
+++ b/test/e2e/vpp/vpp.go
@@ -426,6 +426,10 @@ func (vi *VPPInstance) SetupNamespaces() error {
 				"nsPath":  ns.Path(),
 				"OtherIP": *nsCfg.OtherIP,
 			}).Info("netns created")
+
+			if nsCfg.OtherIP != nil && nsCfg.OtherIP.IP.To4() == nil {
+				ns.SetIPv6()
+			}
 		}
 
 		vi.namespaces[nsCfg.Name] = ns

--- a/test/e2e/vpp/vpp.go
+++ b/test/e2e/vpp/vpp.go
@@ -356,7 +356,9 @@ func (vi *VPPInstance) stopDispatchTrace() {
 }
 
 func (vi *VPPInstance) TearDown() {
-	vi.Ctl("show trace")
+	if vi.startupCfg.Trace {
+		vi.Ctl("show trace")
+	}
 	vi.stopDispatchTrace()
 	if err := vi.stopVPP(); err != nil {
 		vi.log.WithError(err).Error("error stopping VPP")
@@ -544,6 +546,9 @@ func (vi *VPPInstance) Configure() error {
 		allCmds = append(allCmds, vi.interfaceCmds(nsCfg)...)
 	}
 	allCmds = append(allCmds, vi.cfg.SetupCommands...)
+	if vi.startupCfg.Trace {
+		allCmds = append(allCmds, "trace add af-packet-input 10000")
+	}
 	return vi.runCmds(allCmds...)
 }
 

--- a/test/e2e/vpp/vppstartup.go
+++ b/test/e2e/vpp/vppstartup.go
@@ -74,6 +74,7 @@ type VPPStartupConfig struct {
 	APIPrefix     string
 	MainCore      int
 	UseGDB        bool
+	Trace         bool
 	DispatchTrace bool
 }
 
@@ -87,6 +88,7 @@ func (cfg *VPPStartupConfig) SetFromEnv() {
 		cfg.PluginPath = pluginPath
 	}
 	cfg.UseGDB = os.Getenv("VPP_NO_GDB") == ""
+	cfg.Trace = os.Getenv("VPP_TRACE") != ""
 	cfg.DispatchTrace = os.Getenv("VPP_DISPATCH_TRACE") != ""
 	cfg.SetDefaults()
 }

--- a/test/e2e/vpp/vppstartup.go
+++ b/test/e2e/vpp/vppstartup.go
@@ -65,15 +65,16 @@ func init() {
 }
 
 type VPPStartupConfig struct {
-	BinaryPath string
-	PluginPath string
-	CLISock    string
-	APISock    string
-	StatsSock  string
-	VPPLog     string
-	APIPrefix  string
-	MainCore   int
-	UseGDB     bool
+	BinaryPath    string
+	PluginPath    string
+	CLISock       string
+	APISock       string
+	StatsSock     string
+	VPPLog        string
+	APIPrefix     string
+	MainCore      int
+	UseGDB        bool
+	DispatchTrace bool
 }
 
 func (cfg *VPPStartupConfig) SetFromEnv() {
@@ -86,6 +87,7 @@ func (cfg *VPPStartupConfig) SetFromEnv() {
 		cfg.PluginPath = pluginPath
 	}
 	cfg.UseGDB = os.Getenv("VPP_NO_GDB") == ""
+	cfg.DispatchTrace = os.Getenv("VPP_DISPATCH_TRACE") != ""
 	cfg.SetDefaults()
 }
 


### PR DESCRIPTION
Verify GTP-U <-> GTP-U case in addition to existing TDF and PGW test cases.
Make sure any GTP-U extensions are passed as-is, too.

In addition to that, several handy env vars are added for e2e tests (bundled in this PR as there's no such thing as PR chaining):
* `E2E_DISPATCH_TRACE` - store VPP dispatch trace in the test artifacts
* `E2E_TRACE` - enable VPP packet trace during test execution
* `E2E_PAUSE_ON_ERROR` - pause tests upon error, making it possible to debug them interactively