### PR TITLE
Fix deleting the PFCP responses for a session

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,7 +151,7 @@ test:release:
               E2E_ARTIFACTS_DIR=$PWD/artifacts \
               E2E_JUNIT_DIR=$PWD/junit-output \
               E2E_PARALLEL=y \
-              E2E_PARALLEL_NODES=3 \
+              E2E_PARALLEL_NODES=5 \
               E2E_QUICK=y; then
       mkdir test-out
       tar -cvzf test-out/vpp-test.tar.gz artifacts test/e2e/ginkgo*.log || true

--- a/test/e2e/upg_e2e.go
+++ b/test/e2e/upg_e2e.go
@@ -431,6 +431,9 @@ var _ = ginkgo.Describe("PFCP Association Release", func() {
 	})
 })
 
+const leakTestNumSessions = 10000
+const leakTestNumIterations = 3
+
 var _ = ginkgo.Describe("Multiple PFCP Sessions", func() {
 	ginkgo.Context("[TDF]", func() {
 		// FIXME: these tests may crash UPG in UPGIPModeV6 (bad PFCP requests)
@@ -440,13 +443,13 @@ var _ = ginkgo.Describe("Multiple PFCP Sessions", func() {
 			_, err := f.VPP.Ctl("memory-trace main-heap on")
 			framework.ExpectNoError(err)
 			var ueIPs []net.IP
-			for i := 0; i < 10000; i++ {
+			for i := 0; i < leakTestNumSessions; i++ {
 				ueIPs = append(ueIPs, f.AddUEIP())
 			}
-			for i := 0; i < 3; i++ {
-				ginkgo.By("creating 10000 sessions")
+			for i := 0; i < leakTestNumIterations; i++ {
+				framework.Logf("creating %d sessions", leakTestNumSessions)
 				var seids []pfcp.SEID
-				for j := 0; j < 10000; j++ {
+				for j := 0; j < leakTestNumSessions; j++ {
 					sessionCfg := &framework.SessionConfig{
 						IdBase: 1,
 						UEIP:   ueIPs[j],
@@ -457,7 +460,7 @@ var _ = ginkgo.Describe("Multiple PFCP Sessions", func() {
 					seids = append(seids, seid)
 				}
 
-				ginkgo.By("deleting 10000 sessions")
+				framework.Logf("deleting %d sessions", leakTestNumSessions)
 				for _, seid := range seids {
 					deleteSession(f, seid, false)
 				}

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -399,11 +399,9 @@ pfcp_new_association (session_handle_t session_handle,
 void
 pfcp_release_association (upf_node_assoc_t * n)
 {
-  pfcp_server_main_t *psm = &pfcp_server_main;
   upf_main_t *gtm = &upf_main;
   u32 node_id = n - gtm->nodes;
   u32 idx = n->sessions;
-  pfcp_msg_t *msg;
 
   switch (n->node_id.type)
     {
@@ -428,7 +426,7 @@ pfcp_release_association (upf_node_assoc_t * n)
 
       idx = sx->assoc.next;
 
-      if (pfcp_disable_session (sx, false) != 0)
+      if (pfcp_disable_session (sx) != 0)
 	clib_error ("failed to remove UPF session 0x%016" PRIx64,
 		    sx->cp_seid);
       pfcp_free_session (sx);
@@ -436,17 +434,7 @@ pfcp_release_association (upf_node_assoc_t * n)
 
   ASSERT (n->sessions == ~0);
 
-  /* *INDENT-OFF* */
-  pool_foreach (msg, psm->msg_pool,
-  ({
-    if (!msg->is_valid_pool_item || msg->node != node_id)
-      continue;
-    hash_unset (psm->request_q, msg->seq_no);
-    mhash_unset (&psm->response_q, msg->request_key, NULL);
-    upf_pfcp_server_stop_timer (msg->timer);
-    pfcp_msg_pool_put (psm, msg);
-  }));
-  /* *INDENT-ON* */
+  upf_pfcp_server_deferred_free_msgs_by_node(node_id);
 
   vlib_decrement_simple_counter (&gtm->upf_simple_counters[UPF_ASSOC_COUNTER],
 				 vlib_get_thread_index (), 0, 1);
@@ -989,7 +977,7 @@ pfcp_free_rules (upf_session_t * sx, int rule)
 }
 
 int
-pfcp_disable_session (upf_session_t * sx, int drop_msgs)
+pfcp_disable_session (upf_session_t * sx)
 {
   struct rules *active = pfcp_get_rules (sx, PFCP_ACTIVE);
   pfcp_server_main_t *psm = &pfcp_server_main;
@@ -1026,26 +1014,6 @@ pfcp_disable_session (upf_session_t * sx, int drop_msgs)
     upf_pfcp_session_stop_urr_time (&urr->traffic_timer, now);
   }
   upf_pfcp_session_stop_up_inactivity_timer (&active->inactivity_timer);
-
-  if (drop_msgs)
-    {
-      u32 si = sx - gtm->sessions;
-      pfcp_msg_t *msg;
-
-      /* *INDENT-OFF* */
-      pool_foreach (msg, psm->msg_pool,
-      ({
-	if (!msg->is_valid_pool_item || msg->session_index != si)
-	  continue;
-
-	hash_unset (psm->request_q, msg->seq_no);
-	mhash_unset (&psm->response_q, msg->request_key, NULL);
-	upf_pfcp_server_stop_timer (msg->timer);
-	pfcp_msg_pool_put (psm, msg);
-      }));
-      /* *INDENT-ON* */
-
-    }
 
   vlib_decrement_simple_counter (&gtm->upf_simple_counters
 				 [UPF_SESSIONS_COUNTER],

--- a/upf/upf_pfcp.h
+++ b/upf/upf_pfcp.h
@@ -31,7 +31,7 @@ upf_session_t *pfcp_create_session (upf_node_assoc_t * assoc,
 				    uint64_t cp_seid,
 				    const ip46_address_t * cp_address);
 void pfcp_update_session (upf_session_t * sx);
-int pfcp_disable_session (upf_session_t * sx, int drop_msgs);
+int pfcp_disable_session (upf_session_t * sx);
 void pfcp_free_session (upf_session_t * sx);
 
 #define pfcp_rule_vector_fns(t)						\

--- a/upf/upf_pfcp_server.c
+++ b/upf/upf_pfcp_server.c
@@ -387,6 +387,7 @@ static void
 request_t1_expired (u32 seq_no)
 {
   pfcp_server_main_t *psm = &pfcp_server_main;
+  upf_main_t *gtm = &upf_main;
   pfcp_msg_t *msg;
   uword *p;
 
@@ -417,8 +418,12 @@ request_t1_expired (u32 seq_no)
       hash_unset (psm->request_q, msg->seq_no);
       pfcp_msg_pool_put (psm, msg);
 
-      if (type == PFCP_HEARTBEAT_REQUEST)
-	upf_pfcp_server_deferred_release_association (msg->node);
+      if (type == PFCP_HEARTBEAT_REQUEST 
+ 	  && !pool_is_free_index (gtm->nodes, msg->node))
+	{
+	  upf_node_assoc_t *n = pool_elt_at_index (gtm->nodes, msg->node);
+	  pfcp_release_association (n);
+	}
     }
 }
 
@@ -1052,19 +1057,16 @@ u32 upf_pfcp_server_start_timer (u8 type, u32 id, u32 seconds)
 			      interval);
 }
 
-void upf_pfcp_server_deferred_release_association (u32 node)
+void upf_pfcp_server_deferred_free_msgs_by_node (u32 node)
 {
-  upf_main_t *gtm = &upf_main;
   pfcp_server_main_t *psm = &pfcp_server_main;
+  hash_set (psm->free_msgs_by_node, node, 1);
+}
 
-  if (!pool_is_free_index (gtm->nodes, node))
-    {
-      /*
-       * Delay releasing the association till the end of the loop
-       * to avoid problems with stopping just expired timers
-       */
-      vec_add1 (psm->release_node_assoc, node);
-    }
+void upf_pfcp_server_deferred_free_msgs_by_sidx (u32 sidx)
+{
+  pfcp_server_main_t *psm = &pfcp_server_main;
+  hash_set (psm->free_msgs_by_sidx, sidx, 1);
 }
 
 void upf_server_send_heartbeat (u32 node_idx)
@@ -1105,7 +1107,7 @@ static uword
   upf_main_t *gtm = &upf_main;
   u32 *expired = NULL;
   u32 last_expired;
-  u32 *node;
+  pfcp_msg_t *msg;
 
   pfcp_msg_pool_init (psm);
   psm->timer.last_run_time = psm->now = unix_time_now ();
@@ -1257,24 +1259,32 @@ static uword
 	}
 
       /*
-       * Release node associations after the loop, because this may
+       * Free messages that must be freed after the loop, because this may
        * involve stopping timers which already have fired, so they're
        * currently collected in the 'expired' vector. If handlers for
        * these timers are invoked, they may end up handling messages
        * that were freed (put to the msg_pool).
        */
-      vec_foreach (node, psm->release_node_assoc)
-      {
-	if (!pool_is_free_index (gtm->nodes, *node))
-	  {
-	    upf_node_assoc_t *n = pool_elt_at_index (gtm->nodes, *node);
-	    pfcp_release_association (n);
-	  }
-      }
+
+      /* *INDENT-OFF* */
+      pool_foreach (msg, psm->msg_pool,
+      ({
+	if (!msg->is_valid_pool_item ||
+	    (!hash_get(psm->free_msgs_by_node, msg->node) &&
+	     !hash_get(psm->free_msgs_by_sidx, msg->session_index)))
+	  continue;
+
+	hash_unset (psm->request_q, msg->seq_no);
+	mhash_unset (&psm->response_q, msg->request_key, NULL);
+	upf_pfcp_server_stop_timer (msg->timer);
+	pfcp_msg_pool_put (psm, msg);
+      }));
+      /* *INDENT-ON* */
 
       vec_reset_length (expired);
       vec_reset_length (event_data);
-      vec_reset_length (psm->release_node_assoc);
+      hash_free (psm->free_msgs_by_node);
+      hash_free (psm->free_msgs_by_sidx);
 
 #if CLIB_DEBUG > 10
       upf_validate_session_timers ();


### PR DESCRIPTION
**NOTE:** Before merging this PR, #48 must be merged, after which this PR needs to be carefully rebased by hand.

A response expiration timer firing at the same time as a session is
being deleted was causing UPG to crash.

This PR also adds an E2E test case that verifies the fix.

Fixes #44.