### PR TITLE
add verbose PFCP error reporting

### DIFF
--- a/upf/pfcp.c
+++ b/upf/pfcp.c
@@ -6662,40 +6662,40 @@ static struct pfcp_group_ie_def pfcp_association_setup_request_group[] =
 
 static struct pfcp_group_ie_def pfcp_association_setup_response_group[] =
   {
-    [ASSOCIATION_SETUP_RESPONSE_NODE_ID] = {
+    [ASSOCIATION_PROCEDURE_RESPONSE_NODE_ID] = {
       .type = PFCP_IE_NODE_ID,
-      .offset = offsetof(pfcp_association_setup_response_t, response.node_id)
+      .offset = offsetof(pfcp_association_procedure_response_t, node_id)
     },
-    [ASSOCIATION_SETUP_RESPONSE_CAUSE] = {
+    [ASSOCIATION_PROCEDURE_RESPONSE_CAUSE] = {
       .type = PFCP_IE_CAUSE,
-      .offset = offsetof(pfcp_association_setup_response_t, response.cause)
+      .offset = offsetof(pfcp_association_procedure_response_t, cause)
     },
-    [ASSOCIATION_SETUP_RESPONSE_RECOVERY_TIME_STAMP] = {
+    [ASSOCIATION_PROCEDURE_RESPONSE_RECOVERY_TIME_STAMP] = {
       .type = PFCP_IE_RECOVERY_TIME_STAMP,
-      .offset = offsetof(pfcp_association_setup_response_t, recovery_time_stamp)
+      .offset = offsetof(pfcp_association_procedure_response_t, recovery_time_stamp)
     },
-    [ASSOCIATION_SETUP_RESPONSE_CP_FUNCTION_FEATURES] = {
+    [ASSOCIATION_PROCEDURE_RESPONSE_CP_FUNCTION_FEATURES] = {
       .type = PFCP_IE_CP_FUNCTION_FEATURES,
-      .offset = offsetof(pfcp_association_setup_response_t, cp_function_features)
+      .offset = offsetof(pfcp_association_procedure_response_t, cp_function_features)
     },
-    [ASSOCIATION_SETUP_RESPONSE_UP_FUNCTION_FEATURES] = {
+    [ASSOCIATION_PROCEDURE_RESPONSE_UP_FUNCTION_FEATURES] = {
       .type = PFCP_IE_UP_FUNCTION_FEATURES,
-      .offset = offsetof(pfcp_association_setup_response_t, up_function_features)
+      .offset = offsetof(pfcp_association_procedure_response_t, up_function_features)
     },
-    [ASSOCIATION_SETUP_RESPONSE_USER_PLANE_IP_RESOURCE_INFORMATION] = {
+    [ASSOCIATION_PROCEDURE_RESPONSE_USER_PLANE_IP_RESOURCE_INFORMATION] = {
       .type = PFCP_IE_USER_PLANE_IP_RESOURCE_INFORMATION,
       .is_array = true,
-      .offset = offsetof(pfcp_association_setup_response_t, user_plane_ip_resource_information)
+      .offset = offsetof(pfcp_association_procedure_response_t, user_plane_ip_resource_information)
     },
-    [ASSOCIATION_SETUP_RESPONSE_TP_BUILD_ID] = {
+    [ASSOCIATION_PROCEDURE_RESPONSE_TP_BUILD_ID] = {
       .type = PFCP_IE_TP_BUILD_ID,
       .vendor = VENDOR_TRAVELPING,
-      .offset = offsetof(pfcp_association_setup_response_t, tp_build_id)
+      .offset = offsetof(pfcp_association_procedure_response_t, tp_build_id)
     },
-    [ASSOCIATION_SETUP_RESPONSE_UE_IP_ADDRESS_POOL_IDENTITY] = {
+    [ASSOCIATION_PROCEDURE_RESPONSE_UE_IP_ADDRESS_POOL_IDENTITY] = {
       .type = PFCP_IE_UE_IP_ADDRESS_POOL_IDENTITY,
       .is_array = true,
-      .offset = offsetof(pfcp_association_setup_response_t, ue_ip_address_pool_identity)
+      .offset = offsetof(pfcp_association_procedure_response_t, ue_ip_address_pool_identity)
     },
   };
 
@@ -6744,21 +6744,21 @@ static struct pfcp_group_ie_def pfcp_association_update_request_group[] =
 
 static struct pfcp_group_ie_def pfcp_association_update_response_group[] =
   {
-    [ASSOCIATION_UPDATE_RESPONSE_NODE_ID] = {
+    [ASSOCIATION_PROCEDURE_RESPONSE_NODE_ID] = {
       .type = PFCP_IE_NODE_ID,
-      .offset = offsetof(pfcp_association_update_response_t, response.node_id)
+      .offset = offsetof(pfcp_association_procedure_response_t, node_id)
     },
-    [ASSOCIATION_UPDATE_RESPONSE_CAUSE] = {
+    [ASSOCIATION_PROCEDURE_RESPONSE_CAUSE] = {
       .type = PFCP_IE_CAUSE,
-      .offset = offsetof(pfcp_association_update_response_t, response.cause)
+      .offset = offsetof(pfcp_association_procedure_response_t, cause)
     },
-    [ASSOCIATION_UPDATE_RESPONSE_CP_FUNCTION_FEATURES] = {
+    [ASSOCIATION_PROCEDURE_RESPONSE_CP_FUNCTION_FEATURES] = {
       .type = PFCP_IE_CP_FUNCTION_FEATURES,
-      .offset = offsetof(pfcp_association_update_response_t, cp_function_features)
+      .offset = offsetof(pfcp_association_procedure_response_t, cp_function_features)
     },
-    [ASSOCIATION_UPDATE_RESPONSE_UP_FUNCTION_FEATURES] = {
+    [ASSOCIATION_PROCEDURE_RESPONSE_UP_FUNCTION_FEATURES] = {
       .type = PFCP_IE_UP_FUNCTION_FEATURES,
-      .offset = offsetof(pfcp_association_update_response_t, up_function_features)
+      .offset = offsetof(pfcp_association_procedure_response_t, up_function_features)
     },
   };
 
@@ -7228,10 +7228,10 @@ static struct pfcp_ie_def msg_specs[] =
 
     [PFCP_ASSOCIATION_SETUP_RESPONSE] =
     {
-      .length = sizeof(pfcp_association_setup_response_t),
-      .mandatory = (BIT(ASSOCIATION_SETUP_RESPONSE_NODE_ID) |
-		    BIT(ASSOCIATION_SETUP_RESPONSE_CAUSE) |
-		    BIT(ASSOCIATION_SETUP_RESPONSE_RECOVERY_TIME_STAMP)),
+      .length = sizeof(pfcp_association_procedure_response_t),
+      .mandatory = (BIT(ASSOCIATION_PROCEDURE_RESPONSE_NODE_ID) |
+		    BIT(ASSOCIATION_PROCEDURE_RESPONSE_CAUSE) |
+		    BIT(ASSOCIATION_PROCEDURE_RESPONSE_RECOVERY_TIME_STAMP)),
       .size = ARRAY_LEN(pfcp_association_setup_response_group),
       .group = pfcp_association_setup_response_group,
     },
@@ -7246,9 +7246,9 @@ static struct pfcp_ie_def msg_specs[] =
 
     [PFCP_ASSOCIATION_UPDATE_RESPONSE] =
     {
-      .length = sizeof(pfcp_association_update_response_t),
-      .mandatory = (BIT(ASSOCIATION_UPDATE_RESPONSE_NODE_ID) |
-		    BIT(ASSOCIATION_UPDATE_RESPONSE_CAUSE)),
+      .length = sizeof(pfcp_association_procedure_response_t),
+      .mandatory = (BIT(ASSOCIATION_PROCEDURE_RESPONSE_NODE_ID) |
+		    BIT(ASSOCIATION_PROCEDURE_RESPONSE_CAUSE)),
       .size = ARRAY_LEN(pfcp_association_update_response_group),
       .group = pfcp_association_update_response_group,
     },

--- a/upf/pfcp.c
+++ b/upf/pfcp.c
@@ -6873,48 +6873,48 @@ static struct pfcp_group_ie_def pfcp_session_establishment_request_group[] =
 
 static struct pfcp_group_ie_def pfcp_session_establishment_response_group[] =
   {
-    [SESSION_ESTABLISHMENT_RESPONSE_NODE_ID] = {
+    [SESSION_PROCEDURE_RESPONSE_NODE_ID] = {
       .type = PFCP_IE_NODE_ID,
-      .offset = offsetof(pfcp_session_establishment_response_t, response.node_id)
+      .offset = offsetof(pfcp_session_procedure_response_t, node_id)
     },
-    [SESSION_ESTABLISHMENT_RESPONSE_CAUSE] = {
+    [SESSION_PROCEDURE_RESPONSE_CAUSE] = {
       .type = PFCP_IE_CAUSE,
-      .offset = offsetof(pfcp_session_establishment_response_t, response.cause)
+      .offset = offsetof(pfcp_session_procedure_response_t, cause)
     },
-    [SESSION_ESTABLISHMENT_RESPONSE_OFFENDING_IE] = {
+    [SESSION_PROCEDURE_RESPONSE_OFFENDING_IE] = {
       .type = PFCP_IE_OFFENDING_IE,
-      .offset = offsetof(pfcp_session_establishment_response_t, response.offending_ie)
+      .offset = offsetof(pfcp_session_procedure_response_t, offending_ie)
     },
-    [SESSION_ESTABLISHMENT_RESPONSE_UP_F_SEID] = {
+    [SESSION_PROCEDURE_RESPONSE_UP_F_SEID] = {
       .type = PFCP_IE_F_SEID,
-      .offset = offsetof(pfcp_session_establishment_response_t, up_f_seid)
+      .offset = offsetof(pfcp_session_procedure_response_t, up_f_seid)
     },
-    [SESSION_ESTABLISHMENT_RESPONSE_CREATED_PDR] = {
+    [SESSION_PROCEDURE_RESPONSE_CREATED_PDR] = {
       .type = PFCP_IE_CREATED_PDR,
       .is_array = true,
-      .offset = offsetof(pfcp_session_establishment_response_t, created_pdr)
+      .offset = offsetof(pfcp_session_procedure_response_t, created_pdr)
     },
-    [SESSION_ESTABLISHMENT_RESPONSE_LOAD_CONTROL_INFORMATION] = {
+    [SESSION_PROCEDURE_RESPONSE_LOAD_CONTROL_INFORMATION] = {
       .type = PFCP_IE_LOAD_CONTROL_INFORMATION,
-      .offset = offsetof(pfcp_session_establishment_response_t, load_control_information)
+      .offset = offsetof(pfcp_session_procedure_response_t, load_control_information)
     },
-    [SESSION_ESTABLISHMENT_RESPONSE_OVERLOAD_CONTROL_INFORMATION] = {
+    [SESSION_PROCEDURE_RESPONSE_OVERLOAD_CONTROL_INFORMATION] = {
       .type = PFCP_IE_OVERLOAD_CONTROL_INFORMATION,
-      .offset = offsetof(pfcp_session_establishment_response_t, overload_control_information)
+      .offset = offsetof(pfcp_session_procedure_response_t, overload_control_information)
     },
-    [SESSION_ESTABLISHMENT_RESPONSE_FQ_CSID] = {
+    [SESSION_PROCEDURE_RESPONSE_FQ_CSID] = {
       .type = PFCP_IE_FQ_CSID,
       .is_array = true,
-      .offset = offsetof(pfcp_session_establishment_response_t, fq_csid)
+      .offset = offsetof(pfcp_session_procedure_response_t, fq_csid)
     },
-    [SESSION_ESTABLISHMENT_RESPONSE_FAILED_RULE_ID] = {
+    [SESSION_PROCEDURE_RESPONSE_FAILED_RULE_ID] = {
       .type = PFCP_IE_FAILED_RULE_ID,
-      .offset = offsetof(pfcp_session_establishment_response_t, failed_rule_id)
+      .offset = offsetof(pfcp_session_procedure_response_t, failed_rule_id)
     },
-    [SESSION_ESTABLISHMENT_RESPONSE_CREATED_TRAFFIC_ENDPOINT] = {
+    [SESSION_PROCEDURE_RESPONSE_CREATED_TRAFFIC_ENDPOINT] = {
       .type = PFCP_IE_CREATED_TRAFFIC_ENDPOINT,
       .is_array = true,
-      .offset = offsetof(pfcp_session_establishment_response_t, created_traffic_endpoint)
+      .offset = offsetof(pfcp_session_procedure_response_t, created_traffic_endpoint)
     },
   };
 
@@ -7059,69 +7059,69 @@ static struct pfcp_group_ie_def pfcp_session_modification_request_group[] =
 
 static struct pfcp_group_ie_def pfcp_session_modification_response_group[] =
   {
-    [SESSION_MODIFICATION_RESPONSE_CAUSE] = {
+    [SESSION_PROCEDURE_RESPONSE_CAUSE] = {
       .type = PFCP_IE_CAUSE,
-      .offset = offsetof(pfcp_session_modification_response_t, response.cause)
+      .offset = offsetof(pfcp_session_procedure_response_t, cause)
     },
-    [SESSION_MODIFICATION_RESPONSE_OFFENDING_IE] = {
+    [SESSION_PROCEDURE_RESPONSE_OFFENDING_IE] = {
       .type = PFCP_IE_OFFENDING_IE,
-      .offset = offsetof(pfcp_session_modification_response_t, response.offending_ie)
+      .offset = offsetof(pfcp_session_procedure_response_t, offending_ie)
     },
-    [SESSION_MODIFICATION_RESPONSE_CREATED_PDR] = {
+    [SESSION_PROCEDURE_RESPONSE_CREATED_PDR] = {
       .type = PFCP_IE_CREATED_PDR,
       .is_array = true,
-      .offset = offsetof(pfcp_session_modification_response_t, created_pdr)
+      .offset = offsetof(pfcp_session_procedure_response_t, created_pdr)
     },
-    [SESSION_MODIFICATION_RESPONSE_LOAD_CONTROL_INFORMATION] = {
+    [SESSION_PROCEDURE_RESPONSE_LOAD_CONTROL_INFORMATION] = {
       .type = PFCP_IE_LOAD_CONTROL_INFORMATION,
-      .offset = offsetof(pfcp_session_modification_response_t, load_control_information)
+      .offset = offsetof(pfcp_session_procedure_response_t, load_control_information)
     },
-    [SESSION_MODIFICATION_RESPONSE_OVERLOAD_CONTROL_INFORMATION] = {
+    [SESSION_PROCEDURE_RESPONSE_OVERLOAD_CONTROL_INFORMATION] = {
       .type = PFCP_IE_OVERLOAD_CONTROL_INFORMATION,
-      .offset = offsetof(pfcp_session_modification_response_t, overload_control_information)
+      .offset = offsetof(pfcp_session_procedure_response_t, overload_control_information)
     },
-    [SESSION_MODIFICATION_RESPONSE_USAGE_REPORT] = {
+    [SESSION_PROCEDURE_RESPONSE_USAGE_REPORT] = {
       .type = PFCP_IE_USAGE_REPORT_SMR,
       .is_array = true,
-      .offset = offsetof(pfcp_session_modification_response_t, usage_report)
+      .offset = offsetof(pfcp_session_procedure_response_t, usage_report)
     },
-    [SESSION_MODIFICATION_RESPONSE_FAILED_RULE_ID] = {
+    [SESSION_PROCEDURE_RESPONSE_FAILED_RULE_ID] = {
       .type = PFCP_IE_FAILED_RULE_ID,
-      .offset = offsetof(pfcp_session_modification_response_t, failed_rule_id)
+      .offset = offsetof(pfcp_session_procedure_response_t, failed_rule_id)
     },
-    [SESSION_MODIFICATION_RESPONSE_ADDITIONAL_USAGE_REPORTS_INFORMATION] = {
+    [SESSION_PROCEDURE_RESPONSE_ADDITIONAL_USAGE_REPORTS_INFORMATION] = {
       .type = PFCP_IE_ADDITIONAL_USAGE_REPORTS_INFORMATION,
-      .offset = offsetof(pfcp_session_modification_response_t, additional_usage_reports_information)
+      .offset = offsetof(pfcp_session_procedure_response_t, additional_usage_reports_information)
     },
-    [SESSION_MODIFICATION_RESPONSE_CREATED_TRAFFIC_ENDPOINT] = {
+    [SESSION_PROCEDURE_RESPONSE_CREATED_TRAFFIC_ENDPOINT] = {
       .type = PFCP_IE_CREATED_TRAFFIC_ENDPOINT,
       .is_array = true,
-      .offset = offsetof(pfcp_session_modification_response_t, created_traffic_endpoint)
+      .offset = offsetof(pfcp_session_procedure_response_t, created_traffic_endpoint)
     },
   };
 
 static struct pfcp_group_ie_def pfcp_session_deletion_response_group[] =
   {
-    [SESSION_DELETION_RESPONSE_CAUSE] = {
+    [SESSION_PROCEDURE_RESPONSE_CAUSE] = {
       .type = PFCP_IE_CAUSE,
-      .offset = offsetof(pfcp_session_deletion_response_t, response.cause)
+      .offset = offsetof(pfcp_session_procedure_response_t, cause)
     },
-    [SESSION_DELETION_RESPONSE_OFFENDING_IE] = {
+    [SESSION_PROCEDURE_RESPONSE_OFFENDING_IE] = {
       .type = PFCP_IE_OFFENDING_IE,
-      .offset = offsetof(pfcp_session_deletion_response_t, response.offending_ie)
+      .offset = offsetof(pfcp_session_procedure_response_t, offending_ie)
     },
-    [SESSION_DELETION_RESPONSE_LOAD_CONTROL_INFORMATION] = {
+    [SESSION_PROCEDURE_RESPONSE_LOAD_CONTROL_INFORMATION] = {
       .type = PFCP_IE_LOAD_CONTROL_INFORMATION,
-      .offset = offsetof(pfcp_session_deletion_response_t, load_control_information)
+      .offset = offsetof(pfcp_session_procedure_response_t, load_control_information)
     },
-    [SESSION_DELETION_RESPONSE_OVERLOAD_CONTROL_INFORMATION] = {
+    [SESSION_PROCEDURE_RESPONSE_OVERLOAD_CONTROL_INFORMATION] = {
       .type = PFCP_IE_OVERLOAD_CONTROL_INFORMATION,
-      .offset = offsetof(pfcp_session_deletion_response_t, overload_control_information)
+      .offset = offsetof(pfcp_session_procedure_response_t, overload_control_information)
     },
-    [SESSION_DELETION_RESPONSE_USAGE_REPORT] = {
+    [SESSION_PROCEDURE_RESPONSE_USAGE_REPORT] = {
       .type = PFCP_IE_USAGE_REPORT_SDR,
       .is_array = true,
-      .offset = offsetof(pfcp_session_deletion_response_t, usage_report)
+      .offset = offsetof(pfcp_session_procedure_response_t, usage_report)
     },
   };
 
@@ -7318,10 +7318,10 @@ static struct pfcp_ie_def msg_specs[] =
 
     [PFCP_SESSION_ESTABLISHMENT_RESPONSE] =
     {
-      .length = sizeof(pfcp_session_establishment_response_t),
-      .mandatory = (BIT(SESSION_ESTABLISHMENT_RESPONSE_NODE_ID) |
-		    BIT(SESSION_ESTABLISHMENT_RESPONSE_CAUSE) |
-		    BIT(SESSION_ESTABLISHMENT_RESPONSE_UP_F_SEID)),
+      .length = sizeof(pfcp_session_procedure_response_t),
+      .mandatory = (BIT(SESSION_PROCEDURE_RESPONSE_NODE_ID) |
+		    BIT(SESSION_PROCEDURE_RESPONSE_CAUSE) |
+		    BIT(SESSION_PROCEDURE_RESPONSE_UP_F_SEID)),
       .size = ARRAY_LEN(pfcp_session_establishment_response_group),
       .group = pfcp_session_establishment_response_group,
     },
@@ -7337,8 +7337,8 @@ static struct pfcp_ie_def msg_specs[] =
 
     [PFCP_SESSION_MODIFICATION_RESPONSE] =
     {
-      .length = sizeof(pfcp_session_modification_response_t),
-      .mandatory = BIT(SESSION_MODIFICATION_RESPONSE_CAUSE),
+      .length = sizeof(pfcp_session_procedure_response_t),
+      .mandatory = BIT(SESSION_PROCEDURE_RESPONSE_CAUSE),
       .size = ARRAY_LEN(pfcp_session_modification_response_group),
       .group = pfcp_session_modification_response_group,
     },
@@ -7350,8 +7350,8 @@ static struct pfcp_ie_def msg_specs[] =
 
     [PFCP_SESSION_DELETION_RESPONSE] =
     {
-      .length = sizeof(pfcp_session_deletion_response_t),
-      .mandatory = BIT(SESSION_DELETION_RESPONSE_CAUSE),
+      .length = sizeof(pfcp_session_procedure_response_t),
+      .mandatory = BIT(SESSION_PROCEDURE_RESPONSE_CAUSE),
       .size = ARRAY_LEN(pfcp_session_deletion_response_group),
       .group = pfcp_session_deletion_response_group,
     },

--- a/upf/pfcp.c
+++ b/upf/pfcp.c
@@ -4627,6 +4627,20 @@ encode_alternative_smf_ip_address (void *p, u8 ** vec)
 #define decode_tp_end_time decode_sntp_time_stamp_ie
 #define encode_tp_end_time encode_sntp_time_stamp_ie
 
+#define format_tp_error_message format_simple_vec_ie
+#define decode_tp_error_message decode_simple_vec_ie
+#define encode_tp_error_message encode_simple_vec_ie
+#define free_tp_error_message free_simple_vec_ie
+
+#define format_tp_file_name format_simple_vec_ie
+#define decode_tp_file_name decode_simple_vec_ie
+#define encode_tp_file_name encode_simple_vec_ie
+#define free_tp_file_name free_simple_vec_ie
+
+#define format_tp_line_number format_u32_ie
+#define decode_tp_line_number decode_u32_ie
+#define encode_tp_line_number encode_u32_ie
+
 /* Grouped Information Elements */
 
 
@@ -5956,6 +5970,25 @@ static struct pfcp_group_ie_def pfcp_update_access_forwarding_action_information
     },
   };
 
+static struct pfcp_group_ie_def pfcp_tp_error_report_group[] =
+  {
+    [TP_ERROR_REPORT_TP_ERROR_MESSAGE] = {
+      .type = PFCP_IE_TP_ERROR_MESSAGE,
+      .vendor = VENDOR_TRAVELPING,
+      .offset = offsetof(pfcp_tp_error_report_t, error_message)
+    },
+    [TP_ERROR_REPORT_TP_FILE_NAME] = {
+      .type = PFCP_IE_TP_FILE_NAME,
+      .vendor = VENDOR_TRAVELPING,
+      .offset = offsetof(pfcp_tp_error_report_t, file_name)
+    },
+    [TP_ERROR_REPORT_TP_LINE_NUMBER] = {
+      .type = PFCP_IE_TP_LINE_NUMBER,
+      .vendor = VENDOR_TRAVELPING,
+      .offset = offsetof(pfcp_tp_error_report_t, line_number)
+    },
+  };
+
 /**********************************************************/
 
 #define SIMPLE_IE(IE, TYPE, NAME)			\
@@ -6545,6 +6578,17 @@ static struct pfcp_ie_def vendor_tp_specs[] =
    SIMPLE_IE(PFCP_IE_TP_NOW, tp_now, "TP: Now"),
    SIMPLE_IE(PFCP_IE_TP_START_TIME, tp_start_time, "TP: Start Time"),
    SIMPLE_IE(PFCP_IE_TP_END_TIME, tp_end_time, "TP: Start Time"),
+   [PFCP_IE_TP_ERROR_REPORT] =
+   {
+     .name = "TP: Error Report",
+     .length = sizeof(pfcp_tp_error_report_t),
+     .mandatory = BIT(TP_ERROR_REPORT_TP_ERROR_MESSAGE),
+     .size = ARRAY_LEN(pfcp_tp_error_report_group),
+     .group = pfcp_tp_error_report_group,
+    },
+   SIMPLE_IE_FREE(PFCP_IE_TP_ERROR_MESSAGE, tp_error_message, "TP: Error Message"),
+   SIMPLE_IE_FREE(PFCP_IE_TP_FILE_NAME, tp_file_name, "TP: File Name"),
+   SIMPLE_IE(PFCP_IE_TP_LINE_NUMBER, tp_line_number, "TP: Line Number"),
   };
 
 /**********************************************************/
@@ -6600,6 +6644,11 @@ static struct pfcp_group_ie_def pfcp_simple_response_group[] =
     [PFCP_RESPONSE_RECOVERY_TIME_STAMP] = {
       .type = PFCP_IE_RECOVERY_TIME_STAMP,
       .offset = offsetof(pfcp_simple_response_t, response.recovery_time_stamp)
+    },
+    [PFCP_RESPONSE_TP_ERROR_REPORT] = {
+      .type = PFCP_IE_TP_ERROR_REPORT,
+      .vendor = VENDOR_TRAVELPING,
+      .offset = offsetof(pfcp_simple_response_t, response.tp_error_report)
     },
   };
 
@@ -6669,6 +6718,11 @@ static struct pfcp_group_ie_def pfcp_association_setup_response_group[] =
     [ASSOCIATION_PROCEDURE_RESPONSE_CAUSE] = {
       .type = PFCP_IE_CAUSE,
       .offset = offsetof(pfcp_association_procedure_response_t, cause)
+    },
+    [ASSOCIATION_PROCEDURE_RESPONSE_TP_ERROR_REPORT] = {
+      .type = PFCP_IE_TP_ERROR_REPORT,
+      .vendor = VENDOR_TRAVELPING,
+      .offset = offsetof(pfcp_association_procedure_response_t, tp_error_report)
     },
     [ASSOCIATION_PROCEDURE_RESPONSE_RECOVERY_TIME_STAMP] = {
       .type = PFCP_IE_RECOVERY_TIME_STAMP,
@@ -6751,6 +6805,11 @@ static struct pfcp_group_ie_def pfcp_association_update_response_group[] =
     [ASSOCIATION_PROCEDURE_RESPONSE_CAUSE] = {
       .type = PFCP_IE_CAUSE,
       .offset = offsetof(pfcp_association_procedure_response_t, cause)
+    },
+    [ASSOCIATION_PROCEDURE_RESPONSE_TP_ERROR_REPORT] = {
+      .type = PFCP_IE_TP_ERROR_REPORT,
+      .vendor = VENDOR_TRAVELPING,
+      .offset = offsetof(pfcp_association_procedure_response_t, tp_error_report)
     },
     [ASSOCIATION_PROCEDURE_RESPONSE_CP_FUNCTION_FEATURES] = {
       .type = PFCP_IE_CP_FUNCTION_FEATURES,
@@ -6884,6 +6943,11 @@ static struct pfcp_group_ie_def pfcp_session_establishment_response_group[] =
     [SESSION_PROCEDURE_RESPONSE_OFFENDING_IE] = {
       .type = PFCP_IE_OFFENDING_IE,
       .offset = offsetof(pfcp_session_procedure_response_t, offending_ie)
+    },
+    [SESSION_PROCEDURE_RESPONSE_TP_ERROR_REPORT] = {
+      .type = PFCP_IE_TP_ERROR_REPORT,
+      .vendor = VENDOR_TRAVELPING,
+      .offset = offsetof(pfcp_session_procedure_response_t, tp_error_report)
     },
     [SESSION_PROCEDURE_RESPONSE_UP_F_SEID] = {
       .type = PFCP_IE_F_SEID,
@@ -7067,6 +7131,11 @@ static struct pfcp_group_ie_def pfcp_session_modification_response_group[] =
       .type = PFCP_IE_OFFENDING_IE,
       .offset = offsetof(pfcp_session_procedure_response_t, offending_ie)
     },
+    [SESSION_PROCEDURE_RESPONSE_TP_ERROR_REPORT] = {
+      .type = PFCP_IE_TP_ERROR_REPORT,
+      .vendor = VENDOR_TRAVELPING,
+      .offset = offsetof(pfcp_session_procedure_response_t, tp_error_report)
+    },
     [SESSION_PROCEDURE_RESPONSE_CREATED_PDR] = {
       .type = PFCP_IE_CREATED_PDR,
       .is_array = true,
@@ -7109,6 +7178,11 @@ static struct pfcp_group_ie_def pfcp_session_deletion_response_group[] =
     [SESSION_PROCEDURE_RESPONSE_OFFENDING_IE] = {
       .type = PFCP_IE_OFFENDING_IE,
       .offset = offsetof(pfcp_session_procedure_response_t, offending_ie)
+    },
+    [SESSION_PROCEDURE_RESPONSE_TP_ERROR_REPORT] = {
+      .type = PFCP_IE_TP_ERROR_REPORT,
+      .vendor = VENDOR_TRAVELPING,
+      .offset = offsetof(pfcp_session_procedure_response_t, tp_error_report)
     },
     [SESSION_PROCEDURE_RESPONSE_LOAD_CONTROL_INFORMATION] = {
       .type = PFCP_IE_LOAD_CONTROL_INFORMATION,
@@ -7171,6 +7245,11 @@ static struct pfcp_group_ie_def pfcp_session_report_response_group[] =
     [SESSION_REPORT_RESPONSE_OFFENDING_IE] = {
       .type = PFCP_IE_OFFENDING_IE,
       .offset = offsetof(pfcp_session_report_response_t, response.offending_ie)
+    },
+    [SESSION_REPORT_RESPONSE_TP_ERROR_REPORT] = {
+      .type = PFCP_IE_TP_ERROR_REPORT,
+      .vendor = VENDOR_TRAVELPING,
+      .offset = offsetof(pfcp_session_report_response_t, response.tp_error_report)
     },
     [SESSION_REPORT_RESPONSE_UPDATE_BAR] = {
       .type = PFCP_IE_UPDATE_BAR_RESPONSE,

--- a/upf/pfcp.h
+++ b/upf/pfcp.h
@@ -2305,34 +2305,6 @@ typedef struct
 
 enum
 {
-  ASSOCIATION_SETUP_RESPONSE_NODE_ID = PFCP_RESPONSE_NODE_ID,
-  ASSOCIATION_SETUP_RESPONSE_CAUSE = PFCP_RESPONSE_CAUSE,
-  ASSOCIATION_SETUP_RESPONSE_RECOVERY_TIME_STAMP =
-    PFCP_RESPONSE_RECOVERY_TIME_STAMP,
-  ASSOCIATION_SETUP_RESPONSE_UP_FUNCTION_FEATURES,
-  ASSOCIATION_SETUP_RESPONSE_CP_FUNCTION_FEATURES,
-  ASSOCIATION_SETUP_RESPONSE_USER_PLANE_IP_RESOURCE_INFORMATION,
-  ASSOCIATION_SETUP_RESPONSE_TP_BUILD_ID,
-  ASSOCIATION_SETUP_RESPONSE_UE_IP_ADDRESS_POOL_IDENTITY,
-  ASSOCIATION_SETUP_RESPONSE_LAST = ASSOCIATION_SETUP_REQUEST_TP_BUILD_ID
-};
-
-typedef struct
-{
-  struct pfcp_group grp;
-  struct pfcp_response response;
-
-  pfcp_recovery_time_stamp_t recovery_time_stamp;
-  pfcp_cp_function_features_t cp_function_features;
-  pfcp_up_function_features_t up_function_features;
-    pfcp_user_plane_ip_resource_information_t
-    * user_plane_ip_resource_information;
-  pfcp_tp_build_id_t tp_build_id;
-  pfcp_ue_ip_address_pool_identity_t *ue_ip_address_pool_identity;
-} pfcp_association_setup_response_t;
-
-enum
-{
   ASSOCIATION_UPDATE_REQUEST_NODE_ID = PFCP_REQUEST_NODE_ID,
   ASSOCIATION_UPDATE_REQUEST_CP_FUNCTION_FEATURES,
   ASSOCIATION_UPDATE_REQUEST_UP_FUNCTION_FEATURES,
@@ -2364,25 +2336,6 @@ typedef struct
 
 enum
 {
-  ASSOCIATION_UPDATE_RESPONSE_NODE_ID = PFCP_RESPONSE_NODE_ID,
-  ASSOCIATION_UPDATE_RESPONSE_CAUSE = PFCP_RESPONSE_CAUSE,
-  ASSOCIATION_UPDATE_RESPONSE_UP_FUNCTION_FEATURES,
-  ASSOCIATION_UPDATE_RESPONSE_CP_FUNCTION_FEATURES,
-  ASSOCIATION_UPDATE_RESPONSE_LAST =
-    ASSOCIATION_UPDATE_RESPONSE_CP_FUNCTION_FEATURES
-};
-
-typedef struct
-{
-  struct pfcp_group grp;
-  struct pfcp_response response;
-
-  pfcp_cp_function_features_t cp_function_features;
-  pfcp_up_function_features_t up_function_features;
-} pfcp_association_update_response_t;
-
-enum
-{
   ASSOCIATION_RELEASE_REQUEST_NODE_ID = PFCP_REQUEST_NODE_ID,
   ASSOCIATION_RELEASE_REQUEST_LAST = ASSOCIATION_RELEASE_REQUEST_NODE_ID
 };
@@ -2393,6 +2346,35 @@ typedef struct
   struct pfcp_request request;
 
 } pfcp_association_release_request_t;
+
+enum
+{
+  ASSOCIATION_PROCEDURE_RESPONSE_NODE_ID,
+  ASSOCIATION_PROCEDURE_RESPONSE_CAUSE,
+  ASSOCIATION_PROCEDURE_RESPONSE_RECOVERY_TIME_STAMP,
+  ASSOCIATION_PROCEDURE_RESPONSE_UP_FUNCTION_FEATURES,
+  ASSOCIATION_PROCEDURE_RESPONSE_CP_FUNCTION_FEATURES,
+  ASSOCIATION_PROCEDURE_RESPONSE_USER_PLANE_IP_RESOURCE_INFORMATION,
+  ASSOCIATION_PROCEDURE_RESPONSE_TP_BUILD_ID,
+  ASSOCIATION_PROCEDURE_RESPONSE_UE_IP_ADDRESS_POOL_IDENTITY,
+  ASSOCIATION_PROCEDURE_RESPONSE_LAST =
+    ASSOCIATION_PROCEDURE_RESPONSE_UE_IP_ADDRESS_POOL_IDENTITY
+};
+
+typedef struct
+{
+  struct pfcp_group grp;
+
+  pfcp_node_id_t node_id;
+  pfcp_cause_t cause;
+  pfcp_recovery_time_stamp_t recovery_time_stamp;
+  pfcp_cp_function_features_t cp_function_features;
+  pfcp_up_function_features_t up_function_features;
+    pfcp_user_plane_ip_resource_information_t
+    * user_plane_ip_resource_information;
+  pfcp_tp_build_id_t tp_build_id;
+  pfcp_ue_ip_address_pool_identity_t *ue_ip_address_pool_identity;
+} pfcp_association_procedure_response_t;
 
 enum
 {

--- a/upf/pfcp.h
+++ b/upf/pfcp.h
@@ -1162,6 +1162,17 @@ typedef f64 pfcp_tp_start_time_t;
 #define PFCP_IE_TP_END_TIME				5
 typedef f64 pfcp_tp_end_time_t;
 
+#define PFCP_IE_TP_ERROR_REPORT				6
+
+#define PFCP_IE_TP_ERROR_MESSAGE			7
+typedef u8 *pfcp_tp_error_message_t;
+
+#define PFCP_IE_TP_FILE_NAME				8
+typedef u8 *pfcp_tp_file_name_t;
+
+#define PFCP_IE_TP_LINE_NUMBER				9
+typedef u32 pfcp_tp_line_number_t;
+
 /* Grouped PFCP Information Elements */
 
 enum
@@ -2188,6 +2199,23 @@ typedef struct
   pfcp_tp_end_time_t tp_end_time;
 } pfcp_usage_report_t;
 
+enum
+{
+  TP_ERROR_REPORT_TP_ERROR_MESSAGE,
+  TP_ERROR_REPORT_TP_FILE_NAME,
+  TP_ERROR_REPORT_TP_LINE_NUMBER,
+  TP_ERROR_REPORT_LAST = TP_ERROR_REPORT_TP_LINE_NUMBER
+};
+
+typedef struct
+{
+  struct pfcp_group grp;
+
+  pfcp_tp_error_message_t error_message;
+  pfcp_tp_file_name_t file_name;
+  pfcp_tp_line_number_t line_number;
+} pfcp_tp_error_report_t;
+
 
 /* PFCP Methods */
 
@@ -2221,6 +2249,7 @@ enum
   PFCP_RESPONSE_CAUSE,
   PFCP_RESPONSE_OFFENDING_IE,
   PFCP_RESPONSE_RECOVERY_TIME_STAMP,
+  PFCP_RESPONSE_TP_ERROR_REPORT,
 };
 
 struct pfcp_response
@@ -2229,6 +2258,7 @@ struct pfcp_response
   pfcp_cause_t cause;
   pfcp_offending_ie_t offending_ie;
   pfcp_recovery_time_stamp_t recovery_time_stamp;
+  pfcp_tp_error_report_t tp_error_report;
 };
 
 enum
@@ -2351,6 +2381,7 @@ enum
 {
   ASSOCIATION_PROCEDURE_RESPONSE_NODE_ID,
   ASSOCIATION_PROCEDURE_RESPONSE_CAUSE,
+  ASSOCIATION_PROCEDURE_RESPONSE_TP_ERROR_REPORT,
   ASSOCIATION_PROCEDURE_RESPONSE_RECOVERY_TIME_STAMP,
   ASSOCIATION_PROCEDURE_RESPONSE_UP_FUNCTION_FEATURES,
   ASSOCIATION_PROCEDURE_RESPONSE_CP_FUNCTION_FEATURES,
@@ -2367,6 +2398,7 @@ typedef struct
 
   pfcp_node_id_t node_id;
   pfcp_cause_t cause;
+  pfcp_tp_error_report_t tp_error_report;
   pfcp_recovery_time_stamp_t recovery_time_stamp;
   pfcp_cp_function_features_t cp_function_features;
   pfcp_up_function_features_t up_function_features;
@@ -2528,6 +2560,7 @@ enum
   SESSION_PROCEDURE_RESPONSE_NODE_ID,
   SESSION_PROCEDURE_RESPONSE_CAUSE,
   SESSION_PROCEDURE_RESPONSE_OFFENDING_IE,
+  SESSION_PROCEDURE_RESPONSE_TP_ERROR_REPORT,
   SESSION_PROCEDURE_RESPONSE_UP_F_SEID,
   SESSION_PROCEDURE_RESPONSE_CREATED_PDR,
   SESSION_PROCEDURE_RESPONSE_LOAD_CONTROL_INFORMATION,
@@ -2548,6 +2581,7 @@ typedef struct
   pfcp_node_id_t node_id;
   pfcp_cause_t cause;
   pfcp_offending_ie_t offending_ie;
+  pfcp_tp_error_report_t tp_error_report;
   pfcp_f_seid_t up_f_seid;
   pfcp_created_pdr_t *created_pdr;
   pfcp_load_control_information_t load_control_information;
@@ -2592,6 +2626,7 @@ enum
 {
   SESSION_REPORT_RESPONSE_CAUSE = PFCP_RESPONSE_CAUSE,
   SESSION_REPORT_RESPONSE_OFFENDING_IE = PFCP_RESPONSE_OFFENDING_IE,
+  SESSION_REPORT_RESPONSE_TP_ERROR_REPORT = PFCP_RESPONSE_TP_ERROR_REPORT,
   SESSION_REPORT_RESPONSE_UPDATE_BAR,
   SESSION_REPORT_RESPONSE_PFCPSRRSP_FLAGS,
   SESSION_REPORT_RESPONSE_CP_F_SEID,

--- a/upf/pfcp.h
+++ b/upf/pfcp.h
@@ -2471,36 +2471,6 @@ typedef struct
 
 enum
 {
-  SESSION_ESTABLISHMENT_RESPONSE_NODE_ID = PFCP_RESPONSE_NODE_ID,
-  SESSION_ESTABLISHMENT_RESPONSE_CAUSE = PFCP_RESPONSE_CAUSE,
-  SESSION_ESTABLISHMENT_RESPONSE_OFFENDING_IE = PFCP_RESPONSE_OFFENDING_IE,
-  SESSION_ESTABLISHMENT_RESPONSE_UP_F_SEID,
-  SESSION_ESTABLISHMENT_RESPONSE_CREATED_PDR,
-  SESSION_ESTABLISHMENT_RESPONSE_LOAD_CONTROL_INFORMATION,
-  SESSION_ESTABLISHMENT_RESPONSE_OVERLOAD_CONTROL_INFORMATION,
-  SESSION_ESTABLISHMENT_RESPONSE_FQ_CSID,
-  SESSION_ESTABLISHMENT_RESPONSE_FAILED_RULE_ID,
-  SESSION_ESTABLISHMENT_RESPONSE_CREATED_TRAFFIC_ENDPOINT,
-  SESSION_ESTABLISHMENT_RESPONSE_LAST =
-    SESSION_ESTABLISHMENT_RESPONSE_CREATED_TRAFFIC_ENDPOINT
-};
-
-typedef struct
-{
-  struct pfcp_group grp;
-  struct pfcp_response response;
-
-  pfcp_f_seid_t up_f_seid;
-  pfcp_created_pdr_t *created_pdr;
-  pfcp_load_control_information_t load_control_information;
-  pfcp_overload_control_information_t overload_control_information;
-  pfcp_fq_csid_t *fq_csid;
-  pfcp_failed_rule_id_t failed_rule_id;
-  pfcp_created_traffic_endpoint_t *created_traffic_endpoint;
-} pfcp_session_establishment_response_t;
-
-enum
-{
   SESSION_MODIFICATION_REQUEST_F_SEID,
   SESSION_MODIFICATION_REQUEST_REMOVE_PDR,
   SESSION_MODIFICATION_REQUEST_REMOVE_FAR,
@@ -2566,36 +2536,6 @@ typedef struct
   pfcp_create_mar_t *create_mar;
 } pfcp_session_modification_request_t;
 
-enum
-{
-  SESSION_MODIFICATION_RESPONSE_CAUSE = PFCP_RESPONSE_CAUSE,
-  SESSION_MODIFICATION_RESPONSE_OFFENDING_IE = PFCP_RESPONSE_OFFENDING_IE,
-  SESSION_MODIFICATION_RESPONSE_CREATED_PDR,
-  SESSION_MODIFICATION_RESPONSE_LOAD_CONTROL_INFORMATION,
-  SESSION_MODIFICATION_RESPONSE_OVERLOAD_CONTROL_INFORMATION,
-  SESSION_MODIFICATION_RESPONSE_USAGE_REPORT,
-  SESSION_MODIFICATION_RESPONSE_FAILED_RULE_ID,
-  SESSION_MODIFICATION_RESPONSE_ADDITIONAL_USAGE_REPORTS_INFORMATION,
-  SESSION_MODIFICATION_RESPONSE_CREATED_TRAFFIC_ENDPOINT,
-  SESSION_MODIFICATION_RESPONSE_LAST =
-    SESSION_MODIFICATION_RESPONSE_FAILED_RULE_ID
-};
-
-typedef struct
-{
-  struct pfcp_group grp;
-  struct pfcp_response response;
-
-  pfcp_created_pdr_t *created_pdr;
-  pfcp_load_control_information_t load_control_information;
-  pfcp_overload_control_information_t overload_control_information;
-  pfcp_usage_report_t *usage_report;
-  pfcp_failed_rule_id_t failed_rule_id;
-    pfcp_additional_usage_reports_information_t
-    additional_usage_reports_information;
-  pfcp_created_traffic_endpoint_t *created_traffic_endpoint;
-} pfcp_session_modification_response_t;
-
 typedef struct
 {
   struct pfcp_group grp;
@@ -2603,23 +2543,40 @@ typedef struct
 
 enum
 {
-  SESSION_DELETION_RESPONSE_CAUSE = PFCP_RESPONSE_CAUSE,
-  SESSION_DELETION_RESPONSE_OFFENDING_IE = PFCP_RESPONSE_OFFENDING_IE,
-  SESSION_DELETION_RESPONSE_LOAD_CONTROL_INFORMATION,
-  SESSION_DELETION_RESPONSE_OVERLOAD_CONTROL_INFORMATION,
-  SESSION_DELETION_RESPONSE_USAGE_REPORT,
-  SESSION_DELETION_RESPONSE_LAST = SESSION_DELETION_RESPONSE_USAGE_REPORT
+  SESSION_PROCEDURE_RESPONSE_NODE_ID,
+  SESSION_PROCEDURE_RESPONSE_CAUSE,
+  SESSION_PROCEDURE_RESPONSE_OFFENDING_IE,
+  SESSION_PROCEDURE_RESPONSE_UP_F_SEID,
+  SESSION_PROCEDURE_RESPONSE_CREATED_PDR,
+  SESSION_PROCEDURE_RESPONSE_LOAD_CONTROL_INFORMATION,
+  SESSION_PROCEDURE_RESPONSE_OVERLOAD_CONTROL_INFORMATION,
+  SESSION_PROCEDURE_RESPONSE_USAGE_REPORT,
+  SESSION_PROCEDURE_RESPONSE_FQ_CSID,
+  SESSION_PROCEDURE_RESPONSE_FAILED_RULE_ID,
+  SESSION_PROCEDURE_RESPONSE_ADDITIONAL_USAGE_REPORTS_INFORMATION,
+  SESSION_PROCEDURE_RESPONSE_CREATED_TRAFFIC_ENDPOINT,
+  SESSION_PROCEDURE_RESPONSE_LAST =
+    SESSION_PROCEDURE_RESPONSE_CREATED_TRAFFIC_ENDPOINT
 };
 
 typedef struct
 {
   struct pfcp_group grp;
-  struct pfcp_response response;
 
+  pfcp_node_id_t node_id;
+  pfcp_cause_t cause;
+  pfcp_offending_ie_t offending_ie;
+  pfcp_f_seid_t up_f_seid;
+  pfcp_created_pdr_t *created_pdr;
   pfcp_load_control_information_t load_control_information;
   pfcp_overload_control_information_t overload_control_information;
   pfcp_usage_report_t *usage_report;
-} pfcp_session_deletion_response_t;
+  pfcp_fq_csid_t *fq_csid;
+  pfcp_failed_rule_id_t failed_rule_id;
+    pfcp_additional_usage_reports_information_t
+    additional_usage_reports_information;
+  pfcp_created_traffic_endpoint_t *created_traffic_endpoint;
+} pfcp_session_procedure_response_t;
 
 enum
 {


### PR DESCRIPTION
Add a TP vendor specific IEs to give a verbose error report on PDR, FAE, URR and QER errors.

As a prerequisite, the handling of some PFCP response message is changed.

Fixes #47 