### PR TITLE
set Rx IfIndex to the NWI interface in FAR processing

### DIFF
--- a/upf/upf_forward.c
+++ b/upf/upf_forward.c
@@ -131,7 +131,7 @@ upf_forward (vlib_main_t * vm, vlib_node_runtime_t * node,
 	  n_left_to_next -= 1;
 
 	  b = vlib_get_buffer (vm, bi);
-          UPF_CHECK_INNER_NODE (b);
+	  UPF_CHECK_INNER_NODE (b);
 
 	  /* Get next node index and adj index from tunnel next_dpo */
 	  sidx = upf_buffer_opaque (b)->gtpu.session_index;
@@ -201,17 +201,19 @@ upf_forward (vlib_main_t * vm, vlib_node_runtime_t * node,
 		      b->flags &= ~(VNET_BUFFER_F_OFFLOAD_TCP_CKSUM |
 				    VNET_BUFFER_F_OFFLOAD_UDP_CKSUM |
 				    VNET_BUFFER_F_OFFLOAD_IP_CKSUM);
-		      vnet_buffer (b)->sw_if_index[VLIB_TX] =
-			upf_nwi_fib_index (FIB_PROTOCOL_IP4,
-					   far->forward.nwi_index);
+		      upf_nwi_if_and_fib_index
+			(gtm, FIB_PROTOCOL_IP4, far->forward.nwi_index,
+			 &vnet_buffer (b)->sw_if_index[VLIB_RX],
+			 &vnet_buffer (b)->sw_if_index[VLIB_TX]);
 		    }
 		  else
 		    {
 		      b->flags &= ~(VNET_BUFFER_F_OFFLOAD_TCP_CKSUM |
 				    VNET_BUFFER_F_OFFLOAD_UDP_CKSUM);
-		      vnet_buffer (b)->sw_if_index[VLIB_TX] =
-			upf_nwi_fib_index (FIB_PROTOCOL_IP6,
-					   far->forward.nwi_index);
+		      upf_nwi_if_and_fib_index
+			(gtm, FIB_PROTOCOL_IP6, far->forward.nwi_index,
+			 &vnet_buffer (b)->sw_if_index[VLIB_RX],
+			 &vnet_buffer (b)->sw_if_index[VLIB_TX]);
 		    }
 		  next = UPF_FORWARD_NEXT_IP_INPUT;
 		}

--- a/upf/upf_pfcp.h
+++ b/upf/upf_pfcp.h
@@ -113,6 +113,24 @@ ipfilter_address_cmp_const (const ipfilter_address_t * a,
   return intcmp (a->mask, b.mask);
 };
 
+static inline void
+upf_nwi_if_and_fib_index (upf_main_t * gtm, fib_protocol_t proto,
+			  u32 nwi_index, u32 * sw_if_index, u32 * fib_index)
+{
+  if (!pool_is_free_index (gtm->nwis, nwi_index))
+    {
+      upf_nwi_t *nwi = pool_elt_at_index (gtm->nwis, nwi_index);
+
+      *sw_if_index = nwi->sw_if_index;
+      *fib_index = nwi->fib_index[proto];
+    }
+  else
+    {
+      *sw_if_index = vnet_main.local_interface_sw_if_index;
+      *fib_index = ~0;
+    }
+}
+
 static inline u32
 upf_nwi_fib_index (fib_protocol_t proto, u32 nwi_index)
 {


### PR DESCRIPTION
Set the `[VLIB_RX]` buffer metadata (the ingress sw_if_index) during
forwarding to the interface of the outgoing Network Instance.
Together with the setting of the FIB table index, that ensures that
further processing of the packet (e.g. NAT) is happening in the
current context.