### PR TITLE
Fix flow expiration

### DIFF
--- a/test/e2e/traffic/icmp.go
+++ b/test/e2e/traffic/icmp.go
@@ -22,7 +22,13 @@ type ICMPPingConfig struct {
 
 var _ TrafficConfig = &ICMPPingConfig{}
 
-func (cfg *ICMPPingConfig) SetServerIP(ip net.IP)     { cfg.ServerIP = ip }
+func (cfg *ICMPPingConfig) AddServerIP(ip net.IP) {
+	if cfg.ServerIP != nil {
+		panic("only single ServerIP is supported")
+	}
+	cfg.ServerIP = ip
+}
+
 func (cfg *ICMPPingConfig) SetNoLinger(noLinger bool) {}
 
 func (cfg *ICMPPingConfig) SetDefaults() {

--- a/test/e2e/traffic/redirect.go
+++ b/test/e2e/traffic/redirect.go
@@ -16,6 +16,10 @@ import (
 	"github.com/travelping/upg-vpp/test/e2e/network"
 )
 
+const (
+	REDIRECT_READ_TIMEOUT = 5 * time.Second
+)
+
 type RedirectConfig struct {
 	Count                  int
 	ServerIP               net.IP
@@ -85,7 +89,7 @@ func (rc *RedirectClient) checkRedirectOnce(ctx context.Context, ns *network.Net
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
-	timer := time.AfterFunc(READ_TIMEOUT, func() { cancel() })
+	timer := time.AfterFunc(REDIRECT_READ_TIMEOUT, func() { cancel() })
 	defer timer.Stop()
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	resp, err := c.Do(req)

--- a/test/e2e/traffic/redirect.go
+++ b/test/e2e/traffic/redirect.go
@@ -33,7 +33,13 @@ type RedirectConfig struct {
 
 var _ TrafficConfig = &RedirectConfig{}
 
-func (cfg *RedirectConfig) SetServerIP(ip net.IP)     { cfg.ServerIP = ip }
+func (cfg *RedirectConfig) AddServerIP(ip net.IP) {
+	if cfg.ServerIP != nil {
+		panic("only single ServerIP is supported")
+	}
+	cfg.ServerIP = ip
+}
+
 func (cfg *RedirectConfig) SetNoLinger(noLinger bool) { cfg.NoLinger = noLinger }
 
 func (cfg *RedirectConfig) SetDefaults() {

--- a/test/e2e/traffic/trafficgen.go
+++ b/test/e2e/traffic/trafficgen.go
@@ -40,7 +40,7 @@ type TrafficClient interface {
 
 type TrafficConfig interface {
 	SetDefaults()
-	SetServerIP(ip net.IP)
+	AddServerIP(ip net.IP)
 	SetNoLinger(noLinger bool)
 	Server(rec TrafficRec) TrafficServer
 	Client(rec TrafficRec) TrafficClient

--- a/test/e2e/traffic/udp.go
+++ b/test/e2e/traffic/udp.go
@@ -28,7 +28,13 @@ type UDPPingConfig struct {
 
 var _ TrafficConfig = &UDPPingConfig{}
 
-func (cfg *UDPPingConfig) SetServerIP(ip net.IP)     { cfg.ServerIP = ip }
+func (cfg *UDPPingConfig) AddServerIP(ip net.IP) {
+	if cfg.ServerIP != nil {
+		panic("only single ServerIP is supported")
+	}
+	cfg.ServerIP = ip
+}
+
 func (cfg *UDPPingConfig) SetNoLinger(noLinger bool) {}
 
 func (cfg *UDPPingConfig) SetDefaults() {

--- a/test/e2e/vpp_e2e.go
+++ b/test/e2e/vpp_e2e.go
@@ -2,6 +2,7 @@ package exttest
 
 import (
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 
@@ -60,7 +61,9 @@ var _ = ginkgo.Describe("VPP", func() {
 		f.VPP.Ctl("http static server www-root %s uri tcp://0.0.0.0/80 cache-size 2m fifo-size %d debug 2",
 			wsDir, VPP_WS_FIFO_SIZE_KiB)
 		tg := traffic.NewTrafficGen(&traffic.HTTPConfig{
-			ServerIP: framework.MustParseIP("10.0.0.2"),
+			ServerIPs: []net.IP{
+				framework.MustParseIP("10.0.0.2"),
+			},
 		}, &traffic.SimpleTrafficRec{})
 		clientNS := f.VPP.GetNS("client")
 		serverNS := f.VPP.GetNS("server")
@@ -70,7 +73,9 @@ var _ = ginkgo.Describe("VPP", func() {
 	ginkgo.It("should be able to proxy TCP with its proxy plugin", func() {
 		f.VPP.Ctl("test proxy server server-uri tcp://10.0.0.2/555 client-uri tcp://10.0.1.3/777 fifo-size 41943040 max-fifo-size 41943040 rcv-buf-size 41943040")
 		tg := traffic.NewTrafficGen(&traffic.HTTPConfig{
-			ServerIP:   framework.MustParseIP("10.0.0.2"),
+			ServerIPs: []net.IP{
+				framework.MustParseIP("10.0.0.2"),
+			},
 			ClientPort: 555,
 			ServerPort: 777,
 		}, &traffic.PreciseTrafficRec{})

--- a/upf/flowtable.c
+++ b/upf/flowtable.c
@@ -146,6 +146,7 @@ expire_single_flow (flowtable_main_t * fm, flowtable_main_per_cpu_t * fmt,
 		    flow_entry_t * f, dlist_elt_t * e, u32 now)
 {
   ASSERT (f->timer_index == (e - fmt->timers));
+  ASSERT (f->active <= now);
 
   /* timers unlink */
   clib_dlist_remove (fmt->timers, e - fmt->timers);

--- a/upf/flowtable.h
+++ b/upf/flowtable.h
@@ -123,6 +123,7 @@ typedef struct flow_entry
   u8 dont_splice:1;
   u8 app_detection_done:1;
   u16 tcp_state;
+  u32 ps_index;
 
   /* stats */
   flow_stats_t stats[FT_ORDER_MAX];
@@ -216,6 +217,9 @@ typedef struct
 } flowtable_main_t;
 
 extern flowtable_main_t flowtable_main;
+typedef int (*flow_expiration_hook_t) (flow_entry_t * flow);
+
+extern flow_expiration_hook_t flow_expiration_hook;
 
 u8 *format_flow_key (u8 *, va_list *);
 u8 *format_flow (u8 *, va_list *);

--- a/upf/flowtable.h
+++ b/upf/flowtable.h
@@ -369,6 +369,7 @@ flow_update_lifetime (flow_entry_t * f, u8 * iph, u8 is_ip4)
 always_inline void
 flow_update_active (flow_entry_t * f, u32 now)
 {
+  ASSERT (f->active <= now);
   f->active = now;
 }
 
@@ -380,7 +381,6 @@ timer_wheel_insert_flow (flowtable_main_t * fm,
 
   timer_slot_head_index =
     (fmt->time_index + f->lifetime) % fm->timer_max_lifetime;
-  f->active = fmt->time_index;
   clib_dlist_addtail (fmt->timers, timer_slot_head_index, f->timer_index);
 }
 

--- a/upf/flowtable_init.c
+++ b/upf/flowtable_init.c
@@ -77,6 +77,7 @@ flowtable_init_cpu (flowtable_main_t * fm, flowtable_main_per_cpu_t * fmt)
 
   /* init timer wheel */
   fmt->time_index = ~0;
+  fmt->next_check = ~0;
 
   /* alloc TIMER_MAX_LIFETIME heads from the timers pool and fill them with defaults */
   pool_validate_index (fmt->timers, TIMER_MAX_LIFETIME - 1);

--- a/upf/flowtable_init.c
+++ b/upf/flowtable_init.c
@@ -34,7 +34,7 @@
 flowtable_main_t flowtable_main;
 
 clib_error_t *
-flowtable_timelife_update (flowtable_timeout_type_t type, u16 value)
+flowtable_lifetime_update (flowtable_timeout_type_t type, u16 value)
 {
   flowtable_main_t *fm = &flowtable_main;
 
@@ -50,8 +50,12 @@ flowtable_timelife_update (flowtable_timeout_type_t type, u16 value)
 }
 
 clib_error_t *
-flowtable_max_timelife_update (u16 value)
+flowtable_max_lifetime_update (u16 value)
 {
+  /*
+   * TODO: need to do range check on the value (> 0)
+   * and also reschedule the current flows, if any
+   */
   clib_error_t *error = 0;
   flowtable_main_t *fm = &flowtable_main;
 

--- a/upf/upf_flow_node.c
+++ b/upf/upf_flow_node.c
@@ -118,9 +118,7 @@ upf_flow_process (vlib_main_t * vm, vlib_node_runtime_t * node,
   n_left_from = frame->n_vectors;
   next_index = node->cached_next_index;
 
-  u32 current_time =
-    (u32) ((u64) fm->vlib_main->cpu_time_last_node_dispatch /
-	   fm->vlib_main->clib_time.clocks_per_second);
+  u32 current_time = (u32) vlib_time_now (vm);
   timer_wheel_index_update (fm, fmt, current_time);
 
   while (n_left_from > 0)

--- a/upf/upf_flow_node.c
+++ b/upf/upf_flow_node.c
@@ -162,9 +162,9 @@ upf_flow_process (vlib_main_t * vm, vlib_node_runtime_t * node,
 	  bi0 = to_next[0] = from[0];
 	  bi1 = to_next[1] = from[1];
 	  b0 = vlib_get_buffer (vm, bi0);
-          UPF_CHECK_INNER_NODE (b0);
+	  UPF_CHECK_INNER_NODE (b0);
 	  b1 = vlib_get_buffer (vm, bi1);
-          UPF_CHECK_INNER_NODE (b1);
+	  UPF_CHECK_INNER_NODE (b1);
 
 	  created0 = created1 = 0;
 	  is_reverse0 = is_reverse1 = 0;
@@ -327,7 +327,7 @@ upf_flow_process (vlib_main_t * vm, vlib_node_runtime_t * node,
 
 	  bi0 = to_next[0] = from[0];
 	  b0 = vlib_get_buffer (vm, bi0);
-          UPF_CHECK_INNER_NODE (b0);
+	  UPF_CHECK_INNER_NODE (b0);
 
 	  if (PREDICT_FALSE
 	      (pool_is_free_index


### PR DESCRIPTION
* Fix an issue with flow expiration during low traffic (#61)
* Fix flows not expiring due to "time going backwards" (bad current time being used in the code)
* Remove proxy sessions together with flows, after closing them (#58)
* Improve flow diagnostics for debug builds (use flow indices)
* Fix the names of flow lifetime setting functions (there was an unresolved reference in the CLI code)
* Add e2e test for flow expiration

This PR should also clean some possibly remaining proxy session leaks (#51)
