### PR TITLE
Avoid redefinition for clib_debug > 1

### DIFF
--- a/upf/flowtable.c
+++ b/upf/flowtable.c
@@ -147,9 +147,6 @@ always_inline void
 expire_single_flow (flowtable_main_t * fm, flowtable_main_per_cpu_t * fmt,
 		    flow_entry_t * f, dlist_elt_t * e, u32 now)
 {
-#if CLIB_DEBUG > 1
-  flowtable_main_t *fm = &flowtable_main;
-#endif
   ASSERT (f->timer_index == (e - fmt->timers));
   ASSERT (f->active <= now);
 


### PR DESCRIPTION
flowtable_main_t *fm already present in function signature.
Building with CLIB_DEBUG > 1 causes redefinition. Assuming
flowtable_main_t *fm is a signleton structure removing of
redefinition is safe.