### PR TITLE
Add shared IP application rules

### DIFF
--- a/test/e2e/framework/sessionconfig.go
+++ b/test/e2e/framework/sessionconfig.go
@@ -13,7 +13,7 @@ type SessionConfig struct {
 	UEIP            net.IP
 	PGWIP           net.IP
 	SGWIP           net.IP
-	AppPDR          bool
+	AppName         string
 	Redirect        bool
 	Mode            UPGMode
 	TEIDPGWs5u      uint32
@@ -23,6 +23,11 @@ type SessionConfig struct {
 	ProxyAccessTEID uint32
 	ProxyCoreTEID   uint32
 }
+
+const (
+	HTTPAppName = "TST"
+	IPAppName   = "IPAPP"
+)
 
 func (cfg SessionConfig) sgwOuterHeaderCreation() *ie.IE {
 	ip4 := cfg.SGWIP.To4()
@@ -223,10 +228,10 @@ func (cfg SessionConfig) CreatePDRs() []*ie.IE {
 		cfg.forwardPDR(cfg.IdBase, 1, 1, 200, ""),
 		cfg.reversePDR(cfg.IdBase+1, 2, 1, 200, ""),
 	}
-	if cfg.AppPDR {
+	if cfg.AppName != "" {
 		ies = append(ies,
-			cfg.forwardPDR(cfg.IdBase+2, 1, 2, 100, "TST"),
-			cfg.reversePDR(cfg.IdBase+3, 2, 2, 100, "TST"))
+			cfg.forwardPDR(cfg.IdBase+2, 1, 2, 100, cfg.AppName),
+			cfg.reversePDR(cfg.IdBase+3, 2, 2, 100, cfg.AppName))
 	}
 	return ies
 }
@@ -236,7 +241,7 @@ func (cfg SessionConfig) DeletePDRs() []*ie.IE {
 		ie.NewRemovePDR(ie.NewPDRID(cfg.IdBase)),
 		ie.NewRemovePDR(ie.NewPDRID(cfg.IdBase + 1)),
 	}
-	if cfg.AppPDR {
+	if cfg.AppName != "" {
 		ies = append(ies,
 			ie.NewRemovePDR(ie.NewPDRID(cfg.IdBase+2)),
 			ie.NewRemovePDR(ie.NewPDRID(cfg.IdBase+3)))

--- a/test/e2e/framework/upgmode.go
+++ b/test/e2e/framework/upgmode.go
@@ -107,6 +107,7 @@ func pgwVPPConfigIPv4() vpp.VPPConfig {
 			// NOTE: both IP and subnet (ip4 or ipv6) should be variable below
 			// For IPv6, ::/0 should be used as the subnet
 			"ip route add 0.0.0.0/0 table 200 via 10.0.2.3 host-sgi0",
+			"create upf application name IPAPP",
 			"create upf application proxy name TST",
 			"upf application TST rule 3000 add l7 regex ^https?://theserver[46]-.*",
 			// TODO: make stitching optional and verify it
@@ -175,6 +176,7 @@ func pgwVPPConfigIPv6() vpp.VPPConfig {
 			// "upf gtpu endpoint ip6 2001:db8:10::2 nwi cp teid 0x80000000/2",
 			"upf gtpu endpoint ip6 2001:db8:13::2 nwi epc teid 0x80000000/2",
 			"ip route add ::/0 table 200 via 2001:db8:12::3 host-sgi0",
+			"create upf application name IPAPP",
 			"create upf application proxy name TST",
 			"upf application TST rule 3000 add l7 regex ^https?://theserver[46]-.*",
 			// TODO: make stitching optional and verify it
@@ -238,6 +240,7 @@ func tdfVPPConfigIPv4() vpp.VPPConfig {
 			// NOTE: both IP and subnet (ip4 or ipv6) should be variable below
 			// For IPv6, ::/0 should be used as the subnet
 			"ip route add 0.0.0.0/0 table 200 via 10.0.2.3 host-sgi0",
+			"create upf application name IPAPP",
 			"create upf application proxy name TST",
 			"upf application TST rule 3000 add l7 regex ^https?://theserver[46]-.*",
 			// TODO: make stitching optional and verify it
@@ -299,6 +302,7 @@ func tdfVPPConfigIPv6() vpp.VPPConfig {
 			"upf tdf ul table vrf 100 ip6 table-id 1001",
 			"upf tdf ul enable ip6 host-access0",
 			"ip route add ::/0 table 200 via 2001:db8:12::3 host-sgi0",
+			"create upf application name IPAPP",
 			"create upf application proxy name TST",
 			"upf application TST rule 3000 add l7 regex ^https?://theserver[46]-.*",
 			// TODO: make stitching optional and verify it
@@ -369,6 +373,7 @@ func gtpProxyVPPConfigIPv4() vpp.VPPConfig {
 			"upf gtpu endpoint ip 10.0.0.2 nwi cp teid 0x80000000/2",
 			"upf gtpu endpoint ip 10.0.2.2 nwi access teid 0x80000000/2",
 			"upf gtpu endpoint ip 10.0.3.2 nwi core teid 0x80000000/2",
+			"create upf application name IPAPP",
 			"create upf application proxy name TST",
 			"upf application TST rule 3000 add l7 regex ^https?://theserver[46]-.*",
 			// TODO: make stitching optional and verify it
@@ -440,6 +445,7 @@ func gtpProxyVPPConfigIPv6() vpp.VPPConfig {
 			"upf gtpu endpoint ip 10.0.0.2 nwi cp teid 0x80000000/2",
 			"upf gtpu endpoint ip6 2001:db8:13::2 nwi access teid 0x80000000/2",
 			"upf gtpu endpoint ip6 2001:db8:14::2 nwi core teid 0x80000000/2",
+			"create upf application name IPAPP",
 			"create upf application proxy name TST",
 			"upf application TST rule 3000 add l7 regex ^https?://theserver[46]-.*",
 			// TODO: make stitching optional and verify it

--- a/test/e2e/traffic/http.go
+++ b/test/e2e/traffic/http.go
@@ -45,6 +45,10 @@ func (cfg *HTTPConfig) AddServerIP(ip net.IP) {
 	cfg.ServerIPs = append(cfg.ServerIPs, ip)
 }
 
+func (cfg *HTTPConfig) HasServerIP() bool {
+	return len(cfg.ServerIPs) != 0
+}
+
 func (cfg *HTTPConfig) SetNoLinger(noLinger bool) { cfg.NoLinger = noLinger }
 
 func (cfg *HTTPConfig) SetDefaults() {

--- a/test/e2e/traffic/icmp.go
+++ b/test/e2e/traffic/icmp.go
@@ -29,6 +29,10 @@ func (cfg *ICMPPingConfig) AddServerIP(ip net.IP) {
 	cfg.ServerIP = ip
 }
 
+func (cfg *ICMPPingConfig) HasServerIP() bool {
+	return cfg.ServerIP != nil
+}
+
 func (cfg *ICMPPingConfig) SetNoLinger(noLinger bool) {}
 
 func (cfg *ICMPPingConfig) SetDefaults() {

--- a/test/e2e/traffic/redirect.go
+++ b/test/e2e/traffic/redirect.go
@@ -40,6 +40,10 @@ func (cfg *RedirectConfig) AddServerIP(ip net.IP) {
 	cfg.ServerIP = ip
 }
 
+func (cfg *RedirectConfig) HasServerIP() bool {
+	return cfg.ServerIP != nil
+}
+
 func (cfg *RedirectConfig) SetNoLinger(noLinger bool) { cfg.NoLinger = noLinger }
 
 func (cfg *RedirectConfig) SetDefaults() {

--- a/test/e2e/traffic/trafficgen.go
+++ b/test/e2e/traffic/trafficgen.go
@@ -41,6 +41,7 @@ type TrafficClient interface {
 type TrafficConfig interface {
 	SetDefaults()
 	AddServerIP(ip net.IP)
+	HasServerIP() bool
 	SetNoLinger(noLinger bool)
 	Server(rec TrafficRec) TrafficServer
 	Client(rec TrafficRec) TrafficClient

--- a/test/e2e/traffic/udp.go
+++ b/test/e2e/traffic/udp.go
@@ -35,6 +35,10 @@ func (cfg *UDPPingConfig) AddServerIP(ip net.IP) {
 	cfg.ServerIP = ip
 }
 
+func (cfg *UDPPingConfig) HasServerIP() bool {
+	return cfg.ServerIP != nil
+}
+
 func (cfg *UDPPingConfig) SetNoLinger(noLinger bool) {}
 
 func (cfg *UDPPingConfig) SetDefaults() {
@@ -87,7 +91,7 @@ func (us *UDPServer) Start(ctx context.Context, ns *network.NetNS) error {
 	}
 
 	uc, err := ns.ListenUDP(ctx, &net.UDPAddr{
-		IP:   nil,
+		IP:   us.cfg.ServerIP,
 		Port: us.cfg.Port,
 	})
 	if err != nil {

--- a/test/e2e/vpp/vppstartup.go
+++ b/test/e2e/vpp/vppstartup.go
@@ -13,7 +13,6 @@ unix {
   nodaemon
   coredump-size unlimited
   full-coredump
-  interactive
   cli-listen {{.CLISock}}
   log {{.VPPLog}}
 }

--- a/upf/CMakeLists.txt
+++ b/upf/CMakeLists.txt
@@ -49,8 +49,10 @@ if(HS_FOUND)
     upf_proxy.c
     upf_app_db.c
     upf_ipfilter.c
+    upf_app_dpo.c
     flowtable_init.c
     flowtable.c
+    unittest.c
 
     MULTIARCH_SOURCES
     upf_gtpu_encap.c

--- a/upf/test/test_upf.py
+++ b/upf/test/test_upf.py
@@ -1368,6 +1368,13 @@ class TestPGWFTUPIP6(IPv6Mixin, TestPGWBase, framework.VppTestCase):
             self.teid = resp[IE_CreatedPDR][IE_FTEID].TEID
             self.logger.info(self.teid)
 
+class TestUPFUnit(framework.VppTestCase):
+    """ UPF Unit Test Cases """
+
+    def test_unit(self):
+        r = self.vapi.cli_return_response("test upf debug")
+        self.assertEqual(r.retval, 0)
+
 # TODO: send session report response
 # TODO: check for heartbeat requests from UPF
 # TODO: check redirects (perhaps IPv4 type redirect) -- currently broken

--- a/upf/unittest.c
+++ b/upf/unittest.c
@@ -1,0 +1,299 @@
+#include <vlib/vlib.h>
+
+#include "upf.h"
+#include "upf_ipfilter.h"
+#include "upf_app_db.h"
+
+static int upf_test_do_debug = 0;
+
+/* based on fib_test.c */
+#define UPF_TEST_I(_cond, _comment, _args...)		\
+  ({							\
+    int _evald = (_cond);				\
+    if (!(_evald)) {					\
+      fformat(stderr, "FAIL:%d: " _comment "\n",	\
+	      __LINE__, ##_args);			\
+      res = 1;						\
+    } else {						\
+      if (upf_test_do_debug)				\
+	fformat(stderr, "PASS:%d: " _comment "\n",	\
+		__LINE__, ##_args);			\
+    }							\
+    res;						\
+  })
+#define UPF_TEST(_cond, _comment, _args...)	\
+  {						\
+    if (UPF_TEST_I(_cond, _comment, ##_args))	\
+      ASSERT(!("FAIL: " _comment));		\
+  }
+
+static int
+test_add_ip_rule (u8 *app_name, u32 id, char *ipfilter)
+{
+  int res = 0;
+  upf_main_t * gtm = &upf_main;
+  unformat_input_t input;
+  acl_rule_t rule;
+  unformat_init_string (&input, ipfilter, strlen(ipfilter));
+  UPF_TEST (unformat (&input, "%U", unformat_ipfilter, &rule),
+            "unformat ipfilter");
+  unformat_free (&input);
+  UPF_TEST (upf_rule_add_del (gtm, app_name, id, 1, 0, &rule) == 0,
+            "upf_rule_add_del");
+  return res;
+}
+
+static int
+setup_apps (u32 *app_id, u32 *app_id_any)
+{
+  int res = 0;
+  upf_main_t * gtm = &upf_main;
+  u8 * app_name = format (0, "IPAPP"), * app_name_any = format (0, "IPANY");
+  uword *p;
+
+  UPF_TEST (upf_app_add_del (gtm, app_name, 0, 1) == 0, "add app");
+  UPF_TEST (test_add_ip_rule (app_name, 2000,
+                              "permit out ip from 10.10.10.10 to assigned") == 0,
+            "add ip rule 2000");
+  UPF_TEST (test_add_ip_rule (app_name, 2001,
+                              "permit out ip from 192.168.0.0/24 70-100 to assigned") == 0,
+            "add ip rule 2001");
+  UPF_TEST (test_add_ip_rule (app_name, 2002,
+                              "permit out ip from 2001:db8:12::2 to assigned") == 0,
+            "add ip rule 2002");
+  UPF_TEST (test_add_ip_rule (app_name, 2003,
+                              "permit out ip from 2001:db8:13::/64 70-100 to assigned") == 0,
+            "add ip rule 2003");
+  UPF_TEST (upf_app_add_del (gtm, app_name_any, 0, 1) == 0, "add app");
+  UPF_TEST (test_add_ip_rule (app_name_any, 12345,
+                              "permit out ip from any to assigned") == 0,
+            "add ip rule 12345");
+
+  p = hash_get_mem (gtm->upf_app_by_name, app_name);
+  UPF_TEST (!!p, "get app by name");
+  UPF_TEST (!pool_is_free_index (gtm->upf_apps, p[0]), "app entry not free");
+  *app_id = upf_adf_get_adr_db (p[0]);
+  /* UPF_TEST (fib_table_find (FIB_PROTOCOL_IP4, 10000000 + (*app - gtm->upf_apps)) != ~0, */
+  /*           "FIB table created (IP4)"); */
+  /* UPF_TEST (fib_table_find (FIB_PROTOCOL_IP6, 20000000 + (*app - gtm->upf_apps)) != ~0, */
+  /*           "FIB table created (IP6)"); */
+
+  p = hash_get_mem (gtm->upf_app_by_name, app_name_any);
+  UPF_TEST (!!p, "get app by name");
+  UPF_TEST (!pool_is_free_index (gtm->upf_apps, p[0]), "app entry not free");
+  *app_id_any = upf_adf_get_adr_db (p[0]);
+  /* UPF_TEST (fib_table_find (FIB_PROTOCOL_IP4, 10000000 + (*app_any - gtm->upf_apps)) != ~0, */
+  /*           "FIB table created (IP4)"); */
+  /* UPF_TEST (fib_table_find (FIB_PROTOCOL_IP6, 20000000 + (*app_any - gtm->upf_apps)) != ~0, */
+  /*           "FIB table created (IP6)"); */
+
+  vec_free (app_name);
+  vec_free (app_name_any);
+
+  return res;
+}
+
+static int
+cleanup_apps (u32 app_id, u32 app_id_any)
+{
+  int res = 0;
+  upf_main_t * gtm = &upf_main;
+  u8 * app_name = format (0, "IPAPP"), * app_name_any = format (0, "IPANY");
+  /* u32 app_table_id = 10000000 + (app - gtm->upf_apps), */
+  /*   app_any_table_id = 20000000 + (app_any - gtm->upf_apps); */
+
+  upf_adf_put_adr_db (app_id);
+  upf_adf_put_adr_db (app_id_any);
+
+  UPF_TEST (upf_app_add_del (gtm, app_name, 0, 0) == 0, "del IPAPP");
+
+  /* FIXME: trying to remove FIB table causes crash
+  UPF_TEST (fib_table_find (FIB_PROTOCOL_IP4, app_table_id) == ~0,
+            "IPAPP FIB table removed (IP4)");
+  UPF_TEST (fib_table_find (FIB_PROTOCOL_IP6, app_table_id) == ~0,
+            "IPAPP FIB table removed (IP6)");
+  */
+
+  UPF_TEST (upf_app_add_del (gtm, app_name_any, 0, 0) == 0, "del IPANY");
+  /* FIXME: trying to remove FIB table causes crash
+  UPF_TEST (fib_table_find (FIB_PROTOCOL_IP4, app_any_table_id) == ~0,
+            "IPANY FIB table removed (IP4)");
+  UPF_TEST (fib_table_find (FIB_PROTOCOL_IP6, app_any_table_id) == ~0,
+            "IPANY FIB table removed (IP6)");
+  */
+
+  vec_free (app_name);
+  vec_free (app_name_any);
+
+  return res;
+}
+
+static int
+ip_app_test_v4 (void)
+{
+  int res = 0;
+  u32 app_id, app_id_any;
+
+  setup_apps (&app_id, &app_id_any);
+
+  ip46_address_t ip_ue_172_17_0_5 = {
+    .ip4.as_u32 = clib_host_to_net_u32(0xac110005),
+  };
+  ip46_address_t ip_192_168_0_5 = {
+    .ip4.as_u32 = clib_host_to_net_u32(0xc0a80005),
+  };
+  ip46_address_t ip_10_10_10_10 = {
+    .ip4.as_u32 = clib_host_to_net_u32(0x0a0a0a0a),
+  };
+  ip46_address_t ip_10_20_20_20 = {
+    .ip4.as_u32 = clib_host_to_net_u32(0x0a141414),
+  };
+
+  flow_entry_t flow;
+  memset (&flow, 0, sizeof(flow));
+  flow.key.ip[FT_ORIGIN].ip4.as_u32 = ip_ue_172_17_0_5.ip4.as_u32;
+  flow.key.port[FT_ORIGIN] = clib_host_to_net_u16(12345);
+  flow.key.ip[FT_REVERSE].ip4.as_u32 = ip_10_20_20_20.ip4.as_u32;
+  flow.key.port[FT_REVERSE] = clib_host_to_net_u16(80);
+
+  UPF_TEST (!upf_app_ip_rule_match (app_id, &flow, &ip_ue_172_17_0_5),
+            "rule mismatch (IPAPP): 172.17.0.5:12345 -> 10.20.20.20:80");
+  UPF_TEST (upf_app_ip_rule_match (app_id_any, &flow, &ip_ue_172_17_0_5),
+            "rule match (IPANY): 172.17.0.5:12345 -> 10.20.20.20:80");
+
+  flow.key.ip[FT_REVERSE].ip4.as_u32 = ip_10_10_10_10.ip4.as_u32;
+  UPF_TEST (upf_app_ip_rule_match (app_id, &flow, &ip_ue_172_17_0_5),
+            "rule match (IPAPP): 172.17.0.5:12345 -> 10.10.10.10:80");
+  UPF_TEST (upf_app_ip_rule_match (app_id_any, &flow, &ip_ue_172_17_0_5),
+            "rule match (IPANY): 172.17.0.5:12345 -> 10.10.10.10:80");
+
+  flow.key.ip[FT_REVERSE].ip4.as_u32 = ip_192_168_0_5.ip4.as_u32;
+  UPF_TEST (upf_app_ip_rule_match (app_id, &flow, &ip_ue_172_17_0_5),
+            "rule match (IPAPP): 172.17.0.5:12345 -> 192.168.0.5:80");
+  UPF_TEST (upf_app_ip_rule_match (app_id_any, &flow, &ip_ue_172_17_0_5),
+            "rule match (IPANY): 172.17.0.5:12345 -> 192.168.0.5:80");
+
+  flow.key.port[FT_REVERSE] = clib_host_to_net_u16(9999);
+  UPF_TEST (!upf_app_ip_rule_match (app_id, &flow, &ip_ue_172_17_0_5),
+            "rule mismatch (IPAPP): 172.17.0.5:12345 -> 192.168.0.5:9999");
+  UPF_TEST (upf_app_ip_rule_match (app_id_any, &flow, &ip_ue_172_17_0_5),
+            "rule match (IPANY): 172.17.0.5:12345 -> 192.168.0.5:9999");
+
+  flow.key.ip[FT_ORIGIN].ip4.as_u32 = ip_10_20_20_20.ip4.as_u32;
+  flow.key.port[FT_REVERSE] = clib_host_to_net_u16(80);
+  UPF_TEST (!upf_app_ip_rule_match (app_id, &flow, &ip_ue_172_17_0_5),
+            "rule mismatch (IPAPP): 10.20.20.20:12345 -> 192.168.0.5:80");
+  UPF_TEST (!upf_app_ip_rule_match (app_id_any, &flow, &ip_ue_172_17_0_5),
+            "rule mismatch (IPANY): 10.20.20.20:12345 -> 192.168.0.5:80");
+
+  cleanup_apps(app_id, app_id_any);
+
+  return res;
+}
+
+static int
+ip_app_test_v6 (void)
+{
+  int res = 0;
+  u32 app_id, app_id_any;
+
+  setup_apps (&app_id, &app_id_any);
+
+  ip46_address_t ip_ue_2001_db8_11__3 = {
+    .ip6.as_u64 = {
+      clib_host_to_net_u64(0x20010db800110000),
+      clib_host_to_net_u64(0x0000000000000003),
+    }
+  };
+  ip46_address_t ip_2001_db8_13__5 = {
+    .ip6.as_u64 = {
+      clib_host_to_net_u64(0x20010db800130000),
+      clib_host_to_net_u64(0x0000000000000005),
+    }
+  };
+  ip46_address_t ip_2001_db8_12__2 = {
+    .ip6.as_u64 = {
+      clib_host_to_net_u64(0x20010db800120000),
+      clib_host_to_net_u64(0x0000000000000002),
+    }
+  };
+  ip46_address_t ip_2001_db8_12__3 = {
+    .ip6.as_u64 = {
+      clib_host_to_net_u64(0x20010db800120000),
+      clib_host_to_net_u64(0x0000000000000003),
+    }
+  };
+
+  flow_entry_t flow;
+  memset (&flow, 0, sizeof(flow));
+  flow.key.ip[FT_ORIGIN].ip6.as_u64[0] = ip_ue_2001_db8_11__3.ip6.as_u64[0];
+  flow.key.ip[FT_ORIGIN].ip6.as_u64[1] = ip_ue_2001_db8_11__3.ip6.as_u64[1];
+  flow.key.port[FT_ORIGIN] = clib_host_to_net_u16(12345);
+  flow.key.ip[FT_REVERSE].ip6.as_u64[0] = ip_2001_db8_12__3.ip6.as_u64[0];
+  flow.key.ip[FT_REVERSE].ip6.as_u64[1] = ip_2001_db8_12__3.ip6.as_u64[1];
+  flow.key.port[FT_REVERSE] = clib_host_to_net_u16(80);
+
+  UPF_TEST (!upf_app_ip_rule_match (app_id, &flow, &ip_ue_2001_db8_11__3),
+            "rule mismatch (IPAPP): [2001:db8:11::3]:12345 -> [2001:db8:12::3]:80");
+  UPF_TEST (upf_app_ip_rule_match (app_id_any, &flow, &ip_ue_2001_db8_11__3),
+            "rule match (IPANY): [2001:db8:11::3]:12345 -> [2001:db8:12::3]:80");
+
+  flow.key.ip[FT_REVERSE].ip6.as_u64[0] = ip_2001_db8_12__2.ip6.as_u64[0];
+  flow.key.ip[FT_REVERSE].ip6.as_u64[1] = ip_2001_db8_12__2.ip6.as_u64[1];
+  UPF_TEST (upf_app_ip_rule_match (app_id, &flow, &ip_ue_2001_db8_11__3),
+            "rule match (IPAPP): [2001:db8:11::3]:12345 -> [2001:db8:12::2]:80");
+  UPF_TEST (upf_app_ip_rule_match (app_id_any, &flow, &ip_ue_2001_db8_11__3),
+            "rule match (IPANY): [2001:db8:11::3]:12345 -> [2001:db8:12::2]:80");
+
+  flow.key.ip[FT_REVERSE].ip6.as_u64[0] = ip_2001_db8_13__5.ip6.as_u64[0];
+  flow.key.ip[FT_REVERSE].ip6.as_u64[1] = ip_2001_db8_13__5.ip6.as_u64[1];
+  UPF_TEST (upf_app_ip_rule_match (app_id, &flow, &ip_ue_2001_db8_11__3),
+            "rule match (IPAPP): [2001:db8:11::3]:12345 -> [2001:db8:13::5]:80");
+  UPF_TEST (upf_app_ip_rule_match (app_id_any, &flow, &ip_ue_2001_db8_11__3),
+            "rule match (IPANY): [2001:db8:11::3]:12345 -> [2001:db8:13::5]:80");
+
+  flow.key.port[FT_REVERSE] = clib_host_to_net_u16(9999);
+  UPF_TEST (!upf_app_ip_rule_match (app_id, &flow, &ip_ue_2001_db8_11__3),
+            "rule mismatch (IPAPP): [2001:db8:11::3]:12345 -> [2001:db8:13::5]:9999");
+  UPF_TEST (upf_app_ip_rule_match (app_id_any, &flow, &ip_ue_2001_db8_11__3),
+            "rule match (IPANY): [2001:db8:11::3]:12345 -> [2001:db8:13::5]:9999");
+
+  flow.key.ip[FT_ORIGIN].ip6.as_u64[0] = ip_2001_db8_12__3.ip6.as_u64[0];
+  flow.key.ip[FT_ORIGIN].ip6.as_u64[1] = ip_2001_db8_12__3.ip6.as_u64[1];
+  flow.key.port[FT_REVERSE] = clib_host_to_net_u16(80);
+  UPF_TEST (!upf_app_ip_rule_match (app_id, &flow, &ip_ue_2001_db8_11__3),
+            "rule mismatch (IPAPP): [2001:db8:12::3]:12345 -> [2001:db8:13::5]:80");
+  UPF_TEST (!upf_app_ip_rule_match (app_id_any, &flow, &ip_ue_2001_db8_11__3),
+            "rule mismatch (IPANY): [2001:db8:12::3]:12345 -> [2001:db8:13::5]:80");
+
+  cleanup_apps(app_id, app_id_any);
+
+  return res;
+}
+
+static clib_error_t *
+test_upf_command_fn (vlib_main_t * vm,
+		     unformat_input_t * input, vlib_cli_command_t * cmd)
+{
+  if (unformat (input, "debug"))
+    upf_test_do_debug = 1;
+
+  if (ip_app_test_v4() == 0 && ip_app_test_v6() == 0)
+    return 0;
+  else
+    return clib_error_return (0, "test failed");
+}
+
+/* *INDENT-OFF* */
+VLIB_CLI_COMMAND (test_upf_command, static) =
+  {
+    .path = "test upf",
+    .short_help = "upf unit test",
+    .function = test_upf_command_fn,
+  };
+/* *INDENT-ON* */
+
+/*
+  TODO: test intersecting rules
+  TODO: test reverse flows
+ */

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -1,5 +1,5 @@
 /*
- * upf.c - 3GPP TS 29.244 GTP-U UP plug-in header file
+ * upf.h - 3GPP TS 29.244 GTP-U UP plug-in header file
  *
  * Copyright (c) 2017-2019 Travelping GmbH
  *
@@ -369,6 +369,7 @@ typedef struct
   int match_teid:1;
   int match_ue_ip:3;
   int match_sdf:1;
+  int match_ip_app:1;
 
   u32 fib_index;
   u32 teid;			// TEID
@@ -767,12 +768,14 @@ typedef struct
 {
   u8 *name;
   u32 flags;
-  uword *rules_by_id;		/* hash over rules id */
-  upf_adr_t *rules;		/* vector of rules definition */
+  u32 num_ip_rules;
+  uword *rules_by_id;		/* hash over rule ids */
+  upf_adr_t *rules;		/* vector of rule definitions */
   u32 db_index;			/* index in ADR pool */
 } upf_adf_app_t;
 
-#define UPF_ADR_PROXY   BIT(0)
+#define UPF_ADR_PROXY    BIT(0)
+#define UPF_ADR_IP_RULES BIT(1)
 
 #define UPF_ADR_PROTO_HTTP  1
 #define UPF_ADR_PROTO_HTTPS 2

--- a/upf/upf_app_dpo.c
+++ b/upf/upf_app_dpo.c
@@ -1,0 +1,461 @@
+/*
+ * Copyright (c) 2017-2019 Travelping GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <vnet/fib/ip4_fib.h>
+#include <vnet/fib/ip6_fib.h>
+#include <vnet/dpo/load_balance.h>
+
+#include "upf.h"
+#include "upf_app_dpo.h"
+
+#define FIB_TABLE_ID_START 10000000
+
+#if CLIB_DEBUG > 1
+#define upf_debug clib_warning
+#else
+#define upf_debug(...)				\
+  do { } while (0)
+#endif
+
+/**
+ * DPO type registered for app
+ */
+dpo_type_t upf_app_dpo_type;
+static fib_source_t app_fib_source;
+
+static index_t
+upf_app_dpo_lookup (upf_adf_entry_t *appentry, ip46_address_t *addr)
+{
+  const load_balance_t * lb;
+  const dpo_id_t *dpo;
+  index_t lb_index = ip46_address_is_ip4(addr) ?
+    ip4_fib_table_lookup_lb (ip4_fib_get(appentry->fib_index_ip4), &addr->ip4) :
+    ip6_fib_table_fwding_lookup (appentry->fib_index_ip6, &addr->ip6);
+  ASSERT (lb_index != INDEX_INVALID);
+  lb = load_balance_get (lb_index);
+  dpo = load_balance_get_bucket_i (lb, 0);
+  if (dpo->dpoi_type != upf_app_dpo_type)
+    return INDEX_INVALID;
+
+  upf_debug ("FIB %d MATCH: %U dpo index %d",
+             ip46_address_is_ip4(addr) ?
+             appentry->fib_index_ip4 :
+             appentry->fib_index_ip6,
+             format_ip46_address, addr, IP46_TYPE_ANY,
+             dpo->dpoi_index);
+  return dpo->dpoi_index;
+}
+
+static int
+ip4_equal_with_prefix_len(ip4_address_t *a1, ip4_address_t *a2, int len)
+{
+  int shift = 32 - len;
+  return a1->as_u32 >> shift == a2->as_u32 >> shift;
+}
+
+static int
+ip6_equal_with_prefix_len(ip6_address_t *a1, ip6_address_t *a2, int len)
+{
+  int shift;
+  if (len > 64)
+    {
+      if (a1->as_u64[0] != a2->as_u64[0])
+        return 0;
+      shift = 128 - len;
+      return a1->as_u64[1] >> shift == a2->as_u64[1] >> shift;
+    }
+  shift = 64 - len;
+  return a1->as_u64[0] >> shift == a2->as_u64[0] >> shift;
+}
+
+static int
+ip_equal_with_prefix_len(ip46_address_t *a1, ip46_address_t *a2, int len)
+{
+  return ip46_address_is_ip4(a1) ?
+    ip4_equal_with_prefix_len(&a1->ip4, &a2->ip4, len) :
+    ip6_equal_with_prefix_len(&a1->ip6, &a2->ip6, len);
+}
+
+static int
+acl_rule_port_in_range(u16 port, acl_rule_t * rule, u8 field)
+{
+  ipfilter_port_t * match = &rule->port[field];
+  return port >= match->min && port <= match->max;
+}
+
+static int
+upf_do_ip_rule_match (upf_adf_entry_t *appentry, ip46_address_t *src, u16 sport, ip46_address_t *dst, u16 dport, ip46_address_t *assigned)
+{
+  /*
+   * IP app rules for server XX are written like this:
+   *   from XX to assigned
+   * Here XX is src, 'assigned' is dst
+   * src is matched using FIB, then sport is matched against the
+   * port ranges of the entries found
+   * dst and dport are matched by plain comparison
+   */
+  index_t dpo_index = upf_app_dpo_lookup (appentry, src);
+  while (dpo_index != INDEX_INVALID)
+    {
+      upf_app_dpo_t * app_dpo = appentry->app_dpos + dpo_index;
+      acl_rule_t * rule = appentry->acl + app_dpo->rule_index;
+      ipfilter_address_t * dst_rule_addr = &rule->address[IPFILTER_RULE_FIELD_DST];
+      ip46_address_t * dst_match = &dst_rule_addr->address;
+      u8 dst_prefix_len = dst_rule_addr->mask;
+      if (!acl_addr_is_any(dst_rule_addr))
+        {
+          if (acl_addr_is_assigned (dst_rule_addr))
+            {
+              dst_match = assigned;
+              dst_prefix_len = ip46_address_is_ip4(dst) ? 32 : 128;
+            }
+          if (!ip_equal_with_prefix_len (dst, dst_match, dst_prefix_len))
+            {
+              dpo_index = app_dpo->next;
+              continue;
+            }
+        }
+      if (acl_rule_port_in_range(sport, rule, IPFILTER_RULE_FIELD_SRC) &&
+	  acl_rule_port_in_range(dport, rule, IPFILTER_RULE_FIELD_DST))
+        {
+          upf_debug("MATCH: src %U sport %d dst %U dport %d assigned %U",
+                    format_ip46_address, src, IP46_TYPE_ANY, sport,
+                    format_ip46_address, dst, IP46_TYPE_ANY, dport,
+                    format_ip46_address, assigned, IP46_TYPE_ANY);
+          return 1;
+        }
+      dpo_index = app_dpo->next;
+    }
+
+  upf_debug("MISMATCH: src %U sport %d dst %U dport %d assigned %U",
+            format_ip46_address, src, IP46_TYPE_ANY, sport,
+            format_ip46_address, dst, IP46_TYPE_ANY, dport,
+            format_ip46_address, assigned, IP46_TYPE_ANY);
+  return 0;
+}
+
+static int src_mask_cmp (void *a1, void *a2)
+{
+  upf_app_dpo_t * ad1 = (upf_app_dpo_t *)a1, * ad2 = (upf_app_dpo_t *)a2;
+  if (ad1->src_preflen < ad2->src_preflen)
+    return -1;
+  else if (ad1->src_preflen == ad2->src_preflen)
+    return 0;
+  else
+    return 1;
+}
+
+static void
+add_app_dpo(upf_adf_entry_t * appentry, acl_rule_t * rule, u8 is_ip4)
+{
+  upf_app_dpo_t * app_dpo;
+  vec_add2 (appentry->app_dpos, app_dpo, 1);
+  app_dpo->rule_index = rule - appentry->acl;
+  app_dpo->next = INDEX_INVALID;
+  app_dpo->dpoi_index = INDEX_INVALID;
+  app_dpo->src_preflen = rule->address[IPFILTER_RULE_FIELD_SRC].mask;
+  app_dpo->is_ip4 = is_ip4;
+}
+
+void
+upf_ensure_app_fib_if_needed (upf_adf_entry_t *appentry)
+{
+  acl_rule_t * rule;
+  upf_app_dpo_t * app_dpo;
+  /* upf_main_t * gtm = &upf_main; */
+  static int next_table_id = FIB_TABLE_ID_START; /* FIXME */
+  /* u32 table_id; */
+
+  if (!appentry->acl || appentry->app_dpos)
+    return;
+
+  /* table_id = FIB_TABLE_ID_START + (app - gtm->upf_apps); */
+  if (appentry->fib_index_ip4 == ~0)
+    {
+      appentry->fib_index_ip4 =
+        fib_table_find_or_create_and_lock (FIB_PROTOCOL_IP4,
+                                           next_table_id++,
+                                           app_fib_source);
+      appentry->fib_index_ip6 =
+        fib_table_find_or_create_and_lock (FIB_PROTOCOL_IP6,
+                                           next_table_id++,
+                                           app_fib_source);
+    }
+
+  vec_foreach (rule, appentry->acl)
+  {
+    int has_ip4 = 0, has_ip6 = 0;
+    ipfilter_address_t * src, * dst;
+
+    src = &rule->address[IPFILTER_RULE_FIELD_SRC];
+    dst = &rule->address[IPFILTER_RULE_FIELD_DST];
+
+    /* TODO: fail to create 'from assigned' rules */
+    if (acl_addr_is_assigned (src))
+      continue;
+
+    if (acl_addr_is_any (src))
+      {
+        if (acl_addr_is_assigned (dst) || acl_addr_is_any (dst))
+          {
+            has_ip4 = 1;
+            has_ip6 = 1;
+          }
+        else if (ip46_address_is_ip4 (&dst->address))
+          has_ip4 = 1;
+        else
+          has_ip6 = 1;
+      }
+    else if (ip46_address_is_ip4 (&src->address))
+      has_ip4 = 1;
+    else
+      has_ip6 = 1;
+    if (has_ip4)
+      add_app_dpo(appentry, rule, 1);
+    if (has_ip6)
+      add_app_dpo(appentry, rule, 0);
+  }
+
+  /* shorter prefixes should go first */
+  vec_sort_with_function (appentry->app_dpos, src_mask_cmp);
+  vec_foreach (app_dpo, appentry->app_dpos)
+  {
+    dpo_id_t dpo = DPO_INVALID;
+    fib_prefix_t pfx;
+    /*
+     * At this point, all of the app_dpos that have been already added
+     * to the FIB table have either shorter or same IP prefix length
+     * as this app_dpo. So, if we find another entry that intersects
+     * with the this app_dpo, we link it from this one, as the FIB
+     * table can yield just one match per address
+     */
+    rule = appentry->acl + app_dpo->rule_index;
+    app_dpo->next = upf_app_dpo_lookup (appentry, &rule->address[IPFILTER_RULE_FIELD_SRC].address);
+    if (acl_addr_is_any(&rule->address[IPFILTER_RULE_FIELD_SRC]))
+      {
+        pfx.fp_addr.as_u64[0] = 0;
+        pfx.fp_addr.as_u64[1] = 0;
+      }
+    else
+      {
+        pfx.fp_addr.as_u64[0] = rule->address[IPFILTER_RULE_FIELD_SRC].address.as_u64[0];
+        pfx.fp_addr.as_u64[1] = rule->address[IPFILTER_RULE_FIELD_SRC].address.as_u64[1];
+      }
+    pfx.fp_proto = app_dpo->is_ip4 ? FIB_PROTOCOL_IP4 : FIB_PROTOCOL_IP6;
+    pfx.fp_len = app_dpo->src_preflen;
+    upf_debug ("add pfx: FIB %d is_ip4 %d fp_len %d IP %U dpo_index %d",
+               app_dpo->is_ip4 ?
+               appentry->fib_index_ip4 : appentry->fib_index_ip6,
+               app_dpo->is_ip4, pfx.fp_len,
+               format_ip46_address, &pfx.fp_addr, IP46_TYPE_ANY,
+               app_dpo - appentry->app_dpos);
+    dpo_set (&dpo,
+             upf_app_dpo_type,
+             fib_proto_to_dpo(pfx.fp_proto),
+             app_dpo - appentry->app_dpos);
+    app_dpo->dpoi_index = dpo.dpoi_index;
+    fib_table_entry_special_dpo_add (app_dpo->is_ip4 ?
+                                     appentry->fib_index_ip4 :
+                                     appentry->fib_index_ip6,
+                                     &pfx,
+                                     FIB_SOURCE_SPECIAL,
+                                     FIB_ENTRY_FLAG_EXCLUSIVE |
+                                     FIB_ENTRY_FLAG_LOOSE_URPF_EXEMPT,
+                                     &dpo);
+  }
+}
+
+void
+upf_app_fib_cleanup (upf_adf_entry_t *appentry)
+{
+  upf_app_dpo_t * app_dpo;
+
+  if (!appentry->app_dpos)
+    return;
+
+  vec_foreach (app_dpo, appentry->app_dpos)
+  {
+    acl_rule_t * rule = appentry->acl + app_dpo->rule_index;
+    fib_prefix_t pfx;
+    if (acl_addr_is_any(&rule->address[IPFILTER_RULE_FIELD_SRC]))
+      {
+        pfx.fp_addr.as_u64[0] = 0;
+        pfx.fp_addr.as_u64[1] = 0;
+      }
+    else
+      {
+        pfx.fp_addr.as_u64[0] = rule->address[IPFILTER_RULE_FIELD_SRC].address.as_u64[0];
+        pfx.fp_addr.as_u64[1] = rule->address[IPFILTER_RULE_FIELD_SRC].address.as_u64[1];
+      }
+    pfx.fp_proto = app_dpo->is_ip4 ? FIB_PROTOCOL_IP4 : FIB_PROTOCOL_IP6;
+    pfx.fp_len = app_dpo->src_preflen;
+    upf_debug ("del pfx: is_ip4 %d fp_len %d IP %U",
+               app_dpo->is_ip4, pfx.fp_len,
+               format_ip46_address, &pfx.fp_addr, IP46_TYPE_ANY);
+    fib_table_entry_special_remove (app_dpo->is_ip4 ?
+                                    appentry->fib_index_ip4 :
+                                    appentry->fib_index_ip6,
+                                    &pfx,
+                                    FIB_SOURCE_SPECIAL);
+  }
+
+  /*
+    FIXME: this crashes due to extra entries in the DPOs:
+    fib_table_unlock (appentry->fib_index_ip4, FIB_PROTOCOL_IP4, app_fib_source);
+    fib_table_unlock (appentry->fib_index_ip6, FIB_PROTOCOL_IP6, app_fib_source);
+    appentry->fib_index_ip4 = ~0;
+    appentry->fib_index_ip6 = ~0;
+  */
+  vec_free (appentry->app_dpos);
+
+  appentry->app_dpos = 0;
+}
+
+u8 upf_app_dpo_match(upf_adf_entry_t *appentry,
+                     flow_entry_t *flow,
+                     ip46_address_t *assigned)
+{
+  if (appentry->fib_index_ip4 == ~0)
+    return 0;
+  return upf_do_ip_rule_match (appentry,
+                               &flow->key.ip[FT_REVERSE ^ flow->is_reverse],
+                               clib_net_to_host_u16(flow->key.port[FT_REVERSE ^ flow->is_reverse]),
+                               &flow->key.ip[FT_ORIGIN ^ flow->is_reverse],
+                               clib_net_to_host_u16(flow->key.port[FT_ORIGIN ^ flow->is_reverse]),
+                               assigned);
+}
+
+const static char *const upf_app_dpo_ip4_nodes[] = {
+  "error-drop",
+  NULL,
+};
+
+const static char *const upf_app_dpo_ip6_nodes[] = {
+  "error-drop",
+  NULL,
+};
+
+const static char *const *const upf_app_dpo_nodes[DPO_PROTO_NUM] = {
+  [DPO_PROTO_IP4] = upf_app_dpo_ip4_nodes,
+  [DPO_PROTO_IP6] = upf_app_dpo_ip6_nodes,
+};
+
+dpo_type_t
+upf_app_dpo_get_type (void)
+{
+  return (upf_app_dpo_type);
+}
+
+static void
+upf_app_dpo_lock (dpo_id_t * dpo)
+{
+  /* NOOP */
+}
+
+static void
+upf_app_dpo_unlock (dpo_id_t * dpo)
+{
+  /* NOOP */
+}
+
+static void
+upf_app_dpo_interpose (const dpo_id_t * original,
+                       const dpo_id_t * parent, dpo_id_t * clone)
+{
+  /* NOOP */
+}
+
+u8 *
+format_upf_app_dpo (u8 * s, va_list * ap)
+{
+  /* index_t index = va_arg (*ap, index_t); */
+  /* upf_session_t *sx = upf_session_dpo_get (index); */
+
+  /* s = */
+  /*   format (s, "UPF session: UP SEID: 0x%016" PRIx64 " (@%p)", sx->cp_seid, */
+  /*           sx); */
+  /* return (s); */
+  return format(s, "<UPF APP DPO>");
+}
+
+const static dpo_vft_t upf_app_dpo_vft = {
+  .dv_lock = upf_app_dpo_lock,
+  .dv_unlock = upf_app_dpo_unlock,
+  .dv_format = format_upf_app_dpo,
+  //.dv_get_urpf = upf_app_dpo_get_urpf,
+  .dv_mk_interpose = upf_app_dpo_interpose,
+};
+
+static clib_error_t *
+upf_app_dpo_module_init (vlib_main_t * vm)
+{
+  app_fib_source = fib_source_allocate ("upf-app",
+					FIB_SOURCE_PRIORITY_HI,
+					FIB_SOURCE_BH_SIMPLE);
+
+  upf_app_dpo_type = dpo_register_new_type (&upf_app_dpo_vft,
+					    upf_app_dpo_nodes);
+
+  return (NULL);
+}
+
+VLIB_INIT_FUNCTION (upf_app_dpo_module_init);
+
+/*
+  TODO:
+  define "dummy" DPO type
+
+  setting dpo:
+
+  dpo_set (dpo, upf_app_dpo_type, dproto, app_dpo_index);
+
+  app_index = index to upf_main's upf_apps
+
+  non-exact match
+
+  dpo's node with ip4-drop
+
+  check if we need FIB_ENTRY_FLAG_LOOSE_URPF_EXEMPT
+
+  fib_table_entry_special_dpo_add (appentry->fib_index, &pfx,
+  FIB_SOURCE_SPECIAL,
+  FIB_ENTRY_FLAG_EXCLUSIVE |
+  FIB_ENTRY_FLAG_LOOSE_URPF_EXEMPT,
+  &dpo_id);
+
+  conflicts:
+  adding more specific route:
+  add link to parent.
+
+  adding less specific route:
+  should not happen:
+  SORT ACLs BY INCREASING PREFIX SIZE! 
+
+  When app rules change:
+  invalidate the fib table
+
+  Build fib table when a session is created
+
+  Later: rebuild db upon 'commit' if there are active sessions
+
+  hashtables with multiple prefix lengths as part of the key:
+  that's how IPv6 FIB works
+  mtrie may be faster
+
+  tuple space search classifier
+  https://pchaigno.github.io/ebpf/2020/09/29/bpf-isnt-just-about-speed.html
+  http://cseweb.ucsd.edu/~varghese/PAPERS/Sigcomm99.pdf
+*/

--- a/upf/upf_app_dpo.h
+++ b/upf/upf_app_dpo.h
@@ -1,0 +1,42 @@
+/*
+ * upf_ip_rules.h - 3GPP TS 29.244 GTP-U UP plug-in header file
+ *
+ * Copyright (c) 2017-2019 Travelping GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __included_upf_ip_rules_h__
+#define __included_upf_ip_rules_h__
+
+#include "upf_app_db.h"
+
+void
+upf_ensure_app_fib_if_needed (upf_adf_entry_t *appentry);
+
+void
+upf_app_fib_cleanup (upf_adf_entry_t *appentry);
+
+u8
+upf_app_dpo_match (upf_adf_entry_t *appentry,
+                   flow_entry_t *flow,
+                   ip46_address_t *assigned);
+
+#endif /* __included_upf_ip_rules_h__ */
+
+/*
+ * fd.io coding-style-patch-verification: ON
+ *
+ * Local Variables:
+ * eval: (c-set-style "gnu")
+ * End:
+ */

--- a/vpp-patches/0010-ping-fix-aborting-on-keypress.patch
+++ b/vpp-patches/0010-ping-fix-aborting-on-keypress.patch
@@ -1,0 +1,86 @@
+From f1a0e9a75bf2af49659a25bf2c729af20d1cb24d Mon Sep 17 00:00:00 2001
+From: Ivan Shvedunov <ivan.shvedunov@travelping.com>
+Date: Thu, 4 Feb 2021 21:21:30 +0300
+Subject: [PATCH] ping: fix aborting on keypress
+
+Type: fix
+
+Currently ping stops on events like SOCKET_READ_EVENT,
+which makes it hard to use over e.g. govpp as it aborts
+immediately most of the time. With this patch, ping only
+stops upon real CLI read / quit events.
+
+Signed-off-by: Ivan Shvedunov <ivan4th@gmail.com>
+Change-Id: Id7a8d0b0fdeb7bbc7b85240e398d27bd5199345b
+---
+ src/plugins/ping/ping.c | 5 +++--
+ src/vlib/unix/cli.c     | 7 -------
+ src/vlib/unix/unix.h    | 8 ++++++++
+ 3 files changed, 11 insertions(+), 9 deletions(-)
+
+diff --git a/src/plugins/ping/ping.c b/src/plugins/ping/ping.c
+index f56f44ffb..a9136cc11 100644
+--- a/src/plugins/ping/ping.c
++++ b/src/plugins/ping/ping.c
+@@ -16,6 +16,7 @@
+ #include <stddef.h>
+ 
+ #include <vlib/vlib.h>
++#include <vlib/unix/unix.h>
+ #include <vnet/fib/ip6_fib.h>
+ #include <vnet/fib/ip4_fib.h>
+ #include <vnet/fib/fib_entry.h>
+@@ -1175,11 +1176,11 @@ run_ping_ip46_address (vlib_main_t * vm, u32 table_id, ip4_address_t * pa4,
+ 		  }
+ 	      }
+ 	      break;
+-	    default:
++	    case UNIX_CLI_PROCESS_EVENT_READ_READY:
++	    case UNIX_CLI_PROCESS_EVENT_QUIT:
+ 	      /* someone pressed a key, abort */
+ 	      vlib_cli_output (vm, "Aborted due to a keypress.");
+ 	      goto double_break;
+-	      break;
+ 	    }
+ 	  vec_free (event_data);
+ 	}
+diff --git a/src/vlib/unix/cli.c b/src/vlib/unix/cli.c
+index 5979dbdbd..470744fb8 100644
+--- a/src/vlib/unix/cli.c
++++ b/src/vlib/unix/cli.c
+@@ -449,13 +449,6 @@ static unix_cli_parse_actions_t unix_cli_parse_pager[] = {
+ 
+ #undef _
+ 
+-/** CLI session events. */
+-typedef enum
+-{
+-  UNIX_CLI_PROCESS_EVENT_READ_READY,  /**< A file descriptor has data to be read. */
+-  UNIX_CLI_PROCESS_EVENT_QUIT,	      /**< A CLI session wants to close. */
+-} unix_cli_process_event_type_t;
+-
+ /** CLI session telnet negotiation timer events. */
+ typedef enum
+ {
+diff --git a/src/vlib/unix/unix.h b/src/vlib/unix/unix.h
+index 9fa95a0c1..86ef88b61 100644
+--- a/src/vlib/unix/unix.h
++++ b/src/vlib/unix/unix.h
+@@ -109,6 +109,14 @@ typedef struct
+ 
+ } unix_main_t;
+ 
++/** CLI session events. */
++typedef enum
++{
++  UNIX_CLI_PROCESS_EVENT_READ_READY, /**< A file descriptor has data to be
++					read. */
++  UNIX_CLI_PROCESS_EVENT_QUIT,	     /**< A CLI session wants to close. */
++} unix_cli_process_event_type_t;
++
+ /* Global main structure. */
+ extern unix_main_t unix_main;
+ extern clib_file_main_t file_main;
+-- 
+2.28.0
+


### PR DESCRIPTION
This PR makes IP application rules shared across session by using separate per-app FIB tables with fake DPOs. Inspired by [adl](https://github.com/FDio/vpp/tree/master/src/plugins/adl) and [gbp](https://github.com/FDio/vpp/tree/master/src/plugins/gbp) VPP plugins.

The optimization is only done for `from ...` part of the IP filter expression which is used to specify the target subnets/IPs in the application rule definition commands.

This PR also adds a unit test for IP rule matching (separate FIB tables).

- [X] make IP rules shared
- [X] unit test
- [X] e2e tests for IP rules
- [X] make sure IP rules work for non-proxy apps
- [x] add downstream VPP patch that fixes `ping` (needed for IP rule e2e tests)
- [x] check if `build_pfcp_rules()` can be simplified (some parts of it are probably redundant)

Possibly for a followup:

- [ ] verify that IP rules specified for proxy apps work for non-TCP (non-proxied) traffic
- [ ] verify that IP rules specified for proxy apps work for TCP traffic
- [ ] verify IP rules with intersecting IPs/subnets but different port ranges
- [ ] free empty unused FIB tables
- [ ] don't rebuild app db upon each rule creation
