### PR TITLE
Fix E2E tests after XDP changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,7 @@ prepare:
 # build container image
 .build:
   stage: build
-  image: quay.io/travelping/upg-build:6947526467d81757cf74ee880e518042 # XX_DO_NOT_REMOVE_THIS_COMMENT
+  image: quay.io/travelping/upg-build:e89e979bd46043a3d9e7a6d1b11ddc29 # XX_DO_NOT_REMOVE_THIS_COMMENT
   script:
   - |
     export REGISTRY_LOGIN=${QUAY_USER_ID}
@@ -91,7 +91,7 @@ build:debug:
 .test:
   stage: test
   # the following is updated automatically by make update-build-image-tag
-  image: quay.io/travelping/upg-build:6947526467d81757cf74ee880e518042 # XX_DO_NOT_REMOVE_THIS_COMMENT
+  image: quay.io/travelping/upg-build:e89e979bd46043a3d9e7a6d1b11ddc29 # XX_DO_NOT_REMOVE_THIS_COMMENT
   script:
   - make update-vpp
   - tar -C vpp -xvzf ${TEST_ARCHIVE}
@@ -114,7 +114,7 @@ build:debug:
 test:patch-style:
   stage: test
   # the following is updated automatically by make update-build-image-tag
-  image: quay.io/travelping/upg-build:6947526467d81757cf74ee880e518042 # XX_DO_NOT_REMOVE_THIS_COMMENT
+  image: quay.io/travelping/upg-build:e89e979bd46043a3d9e7a6d1b11ddc29 # XX_DO_NOT_REMOVE_THIS_COMMENT
   script:
   - hack/checkstyle.sh
 
@@ -139,7 +139,7 @@ test:release:
   variables:
     SKIP_VPP_SOURCE_CHECK: "y"
   # the following is updated automatically by make update-build-image-tag
-  image: quay.io/travelping/upg-build:6947526467d81757cf74ee880e518042 # XX_DO_NOT_REMOVE_THIS_COMMENT
+  image: quay.io/travelping/upg-build:e89e979bd46043a3d9e7a6d1b11ddc29 # XX_DO_NOT_REMOVE_THIS_COMMENT
   script:
   - tar -C vpp -xvzf ${TEST_ARCHIVE}
   - sysctl vm.nr_hugepages=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:experimental
 # the following is updated automatically by make update-build-image-tag
-FROM quay.io/travelping/upg-build:6947526467d81757cf74ee880e518042 AS build-stage
+FROM quay.io/travelping/upg-build:e89e979bd46043a3d9e7a6d1b11ddc29 AS build-stage
 
 ADD vpp /src/vpp
 ADD upf /src/upf

--- a/Dockerfile.devel
+++ b/Dockerfile.devel
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:experimental
 # the following is updated automatically by make update-build-image-tag
-FROM quay.io/travelping/upg-build:6947526467d81757cf74ee880e518042 AS build-stage
+FROM quay.io/travelping/upg-build:e89e979bd46043a3d9e7a6d1b11ddc29 AS build-stage
 
 ADD vpp /src/vpp
 ADD upf /src/upf

--- a/hack/buildenv.sh
+++ b/hack/buildenv.sh
@@ -42,6 +42,7 @@ else
          -e E2E_DISPATCH_TRACE="${E2E_DISPATCH_TRACE:-}" \
          -e E2E_PAUSE_ON_ERROR="${E2E_PAUSE_ON_ERROR:-}" \
          -e E2E_MULTICORE="${E2E_MULTICORE:-}" \
+         -e E2E_XDP="${E2E_XDP:-}" \
          -w /src/vpp \
          "${build_image}" \
          "$@"

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -34,7 +34,10 @@ export UPG_TEST_QUICK="${E2E_QUICK}"
 export VPP_TRACE="${E2E_TRACE}"
 export VPP_DISPATCH_TRACE="${E2E_DISPATCH_TRACE}"
 export VPP_MULTICORE="${E2E_MULTICORE}"
-export VPP_XDP_SETUP="${E2E_XDP}"
+if [[ ${E2E_XDP} ]]; then
+  ulimit -l 10000000
+  export VPP_XDP=1
+fi
 
 case ${E2E_TARGET} in
   debug)

--- a/test/e2e/framework/upgmode.go
+++ b/test/e2e/framework/upgmode.go
@@ -57,7 +57,6 @@ func pgwVPPConfigIPv4() vpp.VPPConfig {
 				VPPLinkName:   "cp0",
 				OtherLinkName: "cp1",
 				Table:         0,
-				MTU:           1500,
 				Placement:     -1, // main thread
 			},
 			{
@@ -68,7 +67,6 @@ func pgwVPPConfigIPv4() vpp.VPPConfig {
 				// using L3 capture because of tun
 				// (no Ethernet headers)
 				L3Capture: true,
-				MTU: vpp.ACCESS_MTU,
 				// the default route is added by gtpu (sgw) code here
 			},
 			{
@@ -79,7 +77,6 @@ func pgwVPPConfigIPv4() vpp.VPPConfig {
 				VPPLinkName:   "grx0",
 				OtherLinkName: "grx1",
 				Table:         100,
-				MTU:           1500,
 			},
 			{
 				Name:          "sgi",
@@ -89,7 +86,6 @@ func pgwVPPConfigIPv4() vpp.VPPConfig {
 				VPPLinkName:   "sgi0",
 				OtherLinkName: "sgi1",
 				Table:         200,
-				MTU:           vpp.ACCESS_MTU,
 				NSRoutes: []vpp.RouteConfig{
 					{
 						Dst: MustParseIPNet("10.1.0.0/16"),
@@ -327,7 +323,6 @@ func gtpProxyVPPConfigIPv4() vpp.VPPConfig {
 				VPPLinkName:   "cp0",
 				OtherLinkName: "cp1",
 				Table:         0,
-				MTU:           1500,
 			},
 			{
 				Name:          "ue",
@@ -347,7 +342,6 @@ func gtpProxyVPPConfigIPv4() vpp.VPPConfig {
 				VPPLinkName:   "access0",
 				OtherLinkName: "access1",
 				Table:         100,
-				MTU:           1500,
 			},
 			{
 				Name:          "core",
@@ -357,7 +351,6 @@ func gtpProxyVPPConfigIPv4() vpp.VPPConfig {
 				VPPLinkName:   "core0",
 				OtherLinkName: "core1",
 				Table:         200,
-				MTU:           1500,
 			},
 			{
 				Name:          "srv",
@@ -399,7 +392,6 @@ func gtpProxyVPPConfigIPv6() vpp.VPPConfig {
 				VPPLinkName:   "cp0",
 				OtherLinkName: "cp1",
 				Table:         0,
-				MTU:           1500,
 			},
 			{
 				Name:          "ue",
@@ -419,7 +411,6 @@ func gtpProxyVPPConfigIPv6() vpp.VPPConfig {
 				VPPLinkName:   "access0",
 				OtherLinkName: "access1",
 				Table:         100,
-				MTU:           1500,
 			},
 			{
 				Name:          "core",
@@ -429,7 +420,6 @@ func gtpProxyVPPConfigIPv6() vpp.VPPConfig {
 				VPPLinkName:   "core0",
 				OtherLinkName: "core1",
 				Table:         200,
-				MTU:           1500,
 			},
 			{
 				Name:          "srv",

--- a/test/e2e/network/utils.go
+++ b/test/e2e/network/utils.go
@@ -39,13 +39,13 @@ func makeVethPair(name, peer string, mtu int) (netlink.Link, error) {
 		PeerName: peer,
 	}
 	if err := netlink.LinkAdd(veth); err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "LinkAdd %q", name)
 	}
 	// Re-fetch the link to get its creation-time parameters, e.g. index and mac
 	veth2, err := netlink.LinkByName(name)
 	if err != nil {
 		netlink.LinkDel(veth) // try and clean up the link if possible.
-		return nil, err
+		return nil, errors.Wrapf(err, "LinkByName %q", name)
 	}
 
 	return veth2, nil

--- a/test/e2e/upg_e2e.go
+++ b/test/e2e/upg_e2e.go
@@ -641,17 +641,14 @@ func describeMTU(mode framework.UPGMode, ipMode framework.UPGIPMode) {
 		// TODO: There is a need to check maximum MTU per XDP driver
 		// might be added as a separate test of fixed in this one
 
-		// TODO: Make MTUs config in respect to interface driver
-		// GRX interface should be equal to ACCESS_MTU + GTPU header overhead
-		// so for this we will ignore MTU setting here
+		var startupCfg vpp.VPPStartupConfig
+		startupCfg.SetFromEnv()
+
 		f := framework.NewDefaultFramework(mode, ipMode)
 		for i := range f.VPPCfg.Namespaces {
-			if strings.HasPrefix(f.VPPCfg.Namespaces[i].Name, "grx") {
-				continue
-			}
-			f.VPPCfg.Namespaces[i].MTU = vpp.ACCESS_MTU
+			f.VPPCfg.Namespaces[i].MTU = 1500
 		}
-		f.GTPUMTU = vpp.ACCESS_MTU
+		f.GTPUMTU = 9000
 
 		ginkgo.BeforeEach(func() {
 			seid = startMeasurementSession(f, &framework.SessionConfig{})

--- a/test/e2e/vpp/vppstartup.go
+++ b/test/e2e/vpp/vppstartup.go
@@ -85,6 +85,7 @@ type VPPStartupConfig struct {
 	Trace         bool
 	DispatchTrace bool
 	Multicore     bool
+	XDP           bool
 }
 
 func (cfg *VPPStartupConfig) SetFromEnv() {
@@ -100,6 +101,7 @@ func (cfg *VPPStartupConfig) SetFromEnv() {
 	cfg.Trace = os.Getenv("VPP_TRACE") != ""
 	cfg.DispatchTrace = os.Getenv("VPP_DISPATCH_TRACE") != ""
 	cfg.Multicore = os.Getenv("VPP_MULTICORE") != ""
+	cfg.XDP = os.Getenv("VPP_XDP") != ""
 	cfg.SetDefaults()
 }
 
@@ -133,4 +135,15 @@ func (cfg VPPStartupConfig) Get() string {
 		panic(err)
 	}
 	return b.String()
+}
+
+func (cfg VPPStartupConfig) DefaultMTU() int {
+	if cfg.XDP {
+		// TODO: this is the max MTU value which works for veths.
+		// Find out why & whether it's always the case
+		// (it may perhaps depend on the kernel version, etc.)
+		return 2034
+	} else {
+		return 9000
+	}
 }


### PR DESCRIPTION
This PR fixes some of E2E issues related to #64:
* do actually handle `E2E_XDP=1` in E2E
* add `ulimit -l 10000000` to e2e.sh (tests fail without that setting in XDP mode)
* fix MTU handling, using max possible MTU 2034 in the XDP mode for veths, 9k in the AF_PACKET mode
* update build image tag
* fix Go indent issues