### PR TITLE
[stable backport] Add downstream 'set ip neighbor-config' patch

### DIFF
--- a/vpp-patches/0014-ip-neighbor-add-set-ip-neighbor-config-CLI-command.patch
+++ b/vpp-patches/0014-ip-neighbor-add-set-ip-neighbor-config-CLI-command.patch
@@ -1,0 +1,96 @@
+From 441146ea163f92ea8255f0a5d02bf705f50caeab Mon Sep 17 00:00:00 2001
+From: Ivan Shvedunov <ivan.shvedunov@travelping.com>
+Date: Wed, 17 Feb 2021 20:32:16 +0300
+Subject: [PATCH] ip-neighbor: add set ip neighbor-config CLI command
+
+Type: improvement
+
+Signed-off-by: Ivan Shvedunov <ivan4th@gmail.com>
+---
+ src/vnet/ip-neighbor/ip_neighbor.c | 57 ++++++++++++++++++++++++++++++
+ 1 file changed, 57 insertions(+)
+
+diff --git a/src/vnet/ip-neighbor/ip_neighbor.c b/src/vnet/ip-neighbor/ip_neighbor.c
+index 43d2ccf7f..104285a6f 100644
+--- a/src/vnet/ip-neighbor/ip_neighbor.c
++++ b/src/vnet/ip-neighbor/ip_neighbor.c
+@@ -23,6 +23,7 @@
+ #include <vnet/ip-neighbor/ip_neighbor_watch.h>
+ 
+ #include <vnet/ip/ip6_ll_table.h>
++#include <vnet/ip/ip46_address.h>
+ #include <vnet/fib/fib_table.h>
+ #include <vnet/adj/adj_mcast.h>
+ 
+@@ -1712,12 +1713,68 @@ ip_neighbor_config_show (vlib_main_t * vm,
+   return (NULL);
+ }
+ 
++static clib_error_t *
++ip_neighbor_config_set (vlib_main_t * vm,
++			unformat_input_t * input, vlib_cli_command_t * cmd)
++{
++  unformat_input_t _line_input, *line_input = &_line_input;
++  clib_error_t *error = NULL;
++  ip46_type_t type;
++  u32 limit, age;
++  bool recycle;
++
++  if (!unformat_user (input, unformat_line_input, line_input))
++    return 0;
++
++  if (unformat (line_input, "ip4"))
++    type = IP46_TYPE_IP4;
++  else if (unformat (line_input, "ip6"))
++    type = IP46_TYPE_IP6;
++  else
++    {
++      error = unformat_parse_error (line_input);
++      goto done;
++    }
++
++  limit = ip_neighbor_db[type].ipndb_limit;
++  age = ip_neighbor_db[type].ipndb_age;
++  recycle = ip_neighbor_db[type].ipndb_recycle;
++
++  while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
++    {
++      if (unformat (line_input, "limit %u", &limit))
++	;
++      else if (unformat (line_input, "age %u", &age))
++	;
++      else if (unformat (line_input, "recycle"))
++	recycle = true;
++      else if (unformat (line_input, "norecycle"))
++	recycle = false;
++      else
++	{
++	  error = unformat_parse_error (line_input);
++	  goto done;
++	}
++    }
++
++  ip_neighbor_config (type, limit, age, recycle);
++
++ done:
++  unformat_free (line_input);
++  return error;
++}
++
+ /* *INDENT-OFF* */
+ VLIB_CLI_COMMAND (show_ip_neighbor_cfg_cmd_node, static) = {
+   .path = "show ip neighbor-config",
+   .function = ip_neighbor_config_show,
+   .short_help = "show ip neighbor-config",
+ };
++VLIB_CLI_COMMAND (set_ip_neighbor_cfg_cmd_node, static) = {
++  .path = "set ip neighbor-config",
++  .function = ip_neighbor_config_set,
++  .short_help = "set ip neighbor-config ip4|ip6 [limit <limit>] [age <age>] [recycle|norecycle]",
++};
+ /* *INDENT-ON* */
+ 
+ static clib_error_t *
+-- 
+2.28.0
+


### PR DESCRIPTION
This is a backport of the patch for VPP 21.01 (#85).
Upstream: https://gerrit.fd.io/r/c/vpp/+/31363

It adds `set ip neighbor-config` command:

```
set ip neighbor-config ip4|ip6 [limit <limit>] [age <age>] [recycle|norecycle]
```

Setting `age` (in seconds) makes VPP re-issue ARP requests for the expired entries once that 'age' passes:
```
17:29:43.336204 ARP, Request who-has 10.0.1.3 tell 10.0.1.2, length 28
17:29:43.336225 ARP, Reply 10.0.1.3 is-at 8a:ee:05:35:c7:99, length 28
```