### PR TITLE
Fix CI / script / git issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__
 *.pyc
 debug
 release
+# For local E2E artifacts
+artifacts

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,7 +152,6 @@ test:release:
               E2E_JUNIT_DIR=$PWD/junit-output \
               E2E_PARALLEL=y \
               E2E_PARALLEL_NODES=5 \
-              E2E_XDP=y \
               E2E_QUICK=y; then
       mkdir test-out
       tar -cvzf test-out/vpp-test.tar.gz artifacts test/e2e/ginkgo*.log || true

--- a/hack/build-image-name.sh
+++ b/hack/build-image-name.sh
@@ -1,6 +1,6 @@
 function get_build_hash {
   (
-    GIT_DIR=$PWD/vpp/.git git ls-files -s -- Makefile build/external
+    (cd vpp && git ls-files -s -- Makefile build/external)
     md5sum Dockerfile.build
   ) | md5sum | awk '{print $1}'
 }

--- a/hack/hooks/pre-commit
+++ b/hack/hooks/pre-commit
@@ -7,7 +7,6 @@
 
 set -o errexit
 set -o nounset
-set -o pipefail
 
 if git rev-parse --verify HEAD >/dev/null 2>&1
 then


### PR DESCRIPTION
Fix #9 and #8 (pre-commit hook not being usable)
Switch CI back to AF_PACKET jobs to reduce flakiness
Add artifacts/ to .gitignore for convenience when running E2E

Verified that AF_PACKET really improves the CI situation. Stumbled upon #87 but it's a separate issue