### PR TITLE
e2e: set heapsize to 2G

### DIFF
--- a/test/e2e/vpp/vppstartup.go
+++ b/test/e2e/vpp/vppstartup.go
@@ -38,6 +38,8 @@ cpu {
 {{ end }}
 }
 
+heapsize 2G
+
 statseg {
   socket-name {{.StatsSock}}
   size 512M


### PR DESCRIPTION
Fixes #87: "Out of memory" crash in PFCP Association Release E2E test