### PR TITLE
Don't do flow expiration checks too often

### DIFF
--- a/upf/upf.c
+++ b/upf/upf.c
@@ -322,6 +322,7 @@ upf_init (vlib_main_t * vm)
   sm->vlib_main = vm;
   sm->pfcp_spec_version = 15;
   sm->rand_base = random_default_seed ();
+  sm->next_flow_expiration = 0;
 
   if ((error = vlib_call_init_function (vm, upf_proxy_main_init)))
     return error;

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -879,6 +879,9 @@ typedef struct
   u32 rand_base;
 
   pfcp_node_id_t node_id;
+
+  /* when to perform the next flow expiration check */
+  f64 next_flow_expiration;
 } upf_main_t;
 
 extern const fib_node_vft_t upf_vft;


### PR DESCRIPTION
The checks can be rather costly if there are many flows.
Doing them twice per second at most instead of doing the check upon
every frame handled by the flow node should be enough.