### PR TITLE
Fix flow expiration and rescheduling (take 2)

### DIFF
--- a/upf/upf_flow_node.c
+++ b/upf/upf_flow_node.c
@@ -245,11 +245,15 @@ upf_flow_process (vlib_main_t * vm, vlib_node_runtime_t * node,
 	  FLOW_DEBUG (fm, flow1);
 
 	  /* timer management */
-	  flow_update_lifetime (flow0, p0, is_ip4);
-	  flow_update_lifetime (flow1, p1, is_ip4);
-
 	  flow_update_active (flow0, current_time);
 	  flow_update_active (flow1, current_time);
+
+	  /*
+	   * Should update lifetime after updating flow activity to
+	   * avoid scheduling flows "in the past"
+	   */
+	  flow_update_lifetime (flow0, p0, is_ip4);
+	  flow_update_lifetime (flow1, p1, is_ip4);
 
 	  /* flow statistics */
 	  flow0->stats[is_reverse0].pkts++;
@@ -377,8 +381,13 @@ upf_flow_process (vlib_main_t * vm, vlib_node_runtime_t * node,
 		      flow->is_reverse, created);
 
 	  /* timer management */
-	  flow_update_lifetime (flow, p, is_ip4);
 	  flow_update_active (flow, current_time);
+
+	  /*
+	   * Should update lifetime after updating flow activity to
+	   * avoid scheduling flows "in the past"
+	   */
+	  flow_update_lifetime (flow, p, is_ip4);
 
 	  /* flow statistics */
 	  flow->stats[is_reverse].pkts++;


### PR DESCRIPTION
The previous fix (#67) has a bug in it causing multiple rechecks
for flow expirations around the flowtable timer wheel.
Some redundant reshuffling of the per-wheel-entry flow lists has been
removed.
Besides, there was a problem in the flow node that was causing the
flow expirations to be incorrectly rescheduled: flow_update_lifetime()
was being invoked before flow_update_active() for the same flow.