### PR TITLE
[stable backport] Diagnose and fix message queue expiration issues

### DIFF
--- a/upf/upf_pfcp_server.h
+++ b/upf/upf_pfcp_server.h
@@ -66,6 +66,7 @@ typedef struct
   u32 node;
   u32 session_index;
 
+  f64 expires_at;		/* message timestamp */
   u32 timer;
   u32 n1;
   u32 t1;


### PR DESCRIPTION
In pfcp_process(), check whether there are any messages that should
have expired for now and delete them, logging warnings