### PR TITLE
[stable backport] [UPG-NAT] Controlled NAT-Function

### DIFF
--- a/upf/pfcp.c
+++ b/upf/pfcp.c
@@ -6846,7 +6846,7 @@ static struct pfcp_ie_def vendor_tp_specs[] =
    SIMPLE_IE_FREE(PFCP_IE_TP_BUILD_ID, tp_build_id, "TP: Build Identifier"),
    SIMPLE_IE(PFCP_IE_TP_NOW, tp_now, "TP: Now"),
    SIMPLE_IE(PFCP_IE_TP_START_TIME, tp_start_time, "TP: Start Time"),
-   SIMPLE_IE(PFCP_IE_TP_END_TIME, tp_end_time, "TP: Start Time"),
+   SIMPLE_IE(PFCP_IE_TP_END_TIME, tp_end_time, "TP: End Time"),
    [PFCP_IE_TP_ERROR_REPORT] =
    {
      .name = "TP: Error Report",

--- a/upf/pfcp.c
+++ b/upf/pfcp.c
@@ -4744,9 +4744,6 @@ decode_bbf_nat_external_port_range (u8 * data, u16 length, void *p)
   v->start_port = get_u16 (data);
   length -= 2;
 
-  if (length < 2)
-    return PFCP_CAUSE_INVALID_LENGTH;
-
   v->start_port = get_u16 (data);
   return 0;
 }
@@ -4777,7 +4774,7 @@ decode_bbf_up_function_features (u8 * data, u16 length, void *p)
 {
   u64 *v = p;
 
-  if (length % 2 != 0 || length < 2)
+  if (length % 2 != 0 || length < 4)
     return PFCP_CAUSE_INVALID_LENGTH;
 
   *v = get_u16_little (data);
@@ -4796,8 +4793,7 @@ encode_bbf_up_function_features (void *p, u8 ** vec)
 {
   u32 *v = p;
 
-  put_u16_little (*vec, *v);
-  put_u16_little (*vec, *v >> 16);
+  put_u32 (*vec, *v);
 
   return 0;
 }
@@ -6172,20 +6168,48 @@ static struct pfcp_group_ie_def pfcp_ue_ip_address_pool_group[] =
     },
   };
 
-#define encode_ip_version encode_u8_ie
-#define decode_ip_version decode_u8_ie
-
 static u8 *
 format_ip_version (u8 * s, va_list * args)
 {
   pfcp_ip_version_t *v = va_arg (*args, pfcp_ip_version_t *);
 
-  if (ISSET_BIT(*v, IP_VERSION_4))
-    s = format (s, "IPv4");
-  else
-    s = format (s, "IPv6");
+  s = format (s, "IPv4:%u IPv6 %u", !!(*v & IP_VERSION_4),
+              !!(*v & IP_VERSION_6));
 
   return s;
+}
+
+static int
+decode_ip_version (u8 * data, u16 length, void *p)
+{
+  pfcp_ip_version_t *v = p;
+
+  *v = get_u8 (data);
+
+  if (!(*v & IP_VERSION_4) && !(*v & IP_VERSION_6))
+    {
+      pfcp_debug
+        ("PFCP: IP Version should have at least IPv4 or IPv6 bits set");
+      return -1;
+    }
+
+  return 0;
+}
+
+static int
+encode_ip_version (void *p, u8 ** vec)
+{
+  pfcp_ip_version_t *v = p;
+
+  if (!(*v & IP_VERSION_4) && !(*v & IP_VERSION_6))
+    {
+      pfcp_debug
+        ("PFCP: IP Version should have at least IPv4 or IPv6 bits set");
+      return -1;
+    }
+
+  put_u8 (*vec, *v);
+  return 0;
 }
 
 static struct pfcp_group_ie_def pfcp_tp_error_report_group[] =
@@ -6965,10 +6989,10 @@ static struct pfcp_group_ie_def pfcp_association_setup_request_group[] =
       .vendor = VENDOR_TRAVELPING,
       .offset = offsetof(pfcp_association_setup_request_t, tp_build_id)
     },
-    [ASSOCIATION_SETUP_REQUEST_UE_IP_ADDRESS_POOL_IDENTITY] = {
-      .type = PFCP_IE_UE_IP_ADDRESS_POOL_IDENTITY,
+    [ASSOCIATION_SETUP_REQUEST_UE_IP_ADDRESS_POOL_INFORMATION] = {
+      .type = PFCP_IE_UE_IP_ADDRESS_POOL_INFORMATION,
       .is_array = true,
-      .offset = offsetof(pfcp_association_setup_request_t, ue_ip_address_pool_identity)
+      .offset = offsetof(pfcp_association_setup_request_t, ue_ip_address_pool_information)
     },
     [ASSOCIATION_SETUP_REQUEST_ALTERNATIVE_SMF_IP_ADDRESS] = {
       .type = PFCP_IE_ALTERNATIVE_SMF_IP_ADDRESS,
@@ -7019,11 +7043,6 @@ static struct pfcp_group_ie_def pfcp_association_setup_response_group[] =
       .vendor = VENDOR_TRAVELPING,
       .offset = offsetof(pfcp_association_procedure_response_t, tp_build_id)
     },
-    [ASSOCIATION_PROCEDURE_RESPONSE_UE_IP_ADDRESS_POOL_IDENTITY] = {
-      .type = PFCP_IE_UE_IP_ADDRESS_POOL_IDENTITY,
-      .is_array = true,
-      .offset = offsetof(pfcp_association_procedure_response_t, ue_ip_address_pool_identity)
-    },
     [ASSOCIATION_PROCEDURE_RESPONSE_UE_IP_ADDRESS_POOL_INFORMATION] = {
       .type = PFCP_IE_UE_IP_ADDRESS_POOL_INFORMATION,
       .is_array = true,
@@ -7062,10 +7081,10 @@ static struct pfcp_group_ie_def pfcp_association_update_request_group[] =
       .type = PFCP_IE_PFCPAUREQ_FLAGS,
       .offset = offsetof(pfcp_association_update_request_t, pfcpaureq_flags)
     },
-    [ASSOCIATION_UPDATE_REQUEST_UE_IP_ADDRESS_POOL_IDENTITY] = {
-      .type = PFCP_IE_UE_IP_ADDRESS_POOL_IDENTITY,
+    [ASSOCIATION_UPDATE_REQUEST_UE_IP_ADDRESS_POOL_INFORMATION] = {
+      .type = PFCP_IE_UE_IP_ADDRESS_POOL_INFORMATION,
       .is_array = true,
-      .offset = offsetof(pfcp_association_update_request_t, ue_ip_address_pool_identity)
+      .offset = offsetof(pfcp_association_update_request_t, ue_ip_address_pool_information)
     },
     [ASSOCIATION_UPDATE_REQUEST_ALTERNATIVE_SMF_IP_ADDRESS] = {
       .type = PFCP_IE_ALTERNATIVE_SMF_IP_ADDRESS,
@@ -7738,10 +7757,10 @@ static struct pfcp_ie_def msg_specs[] =
 /* *INDENT-ON* */
 
 static const struct pfcp_group_ie_def *
-get_ie_spec (const pfcp_ie_t * ie, const struct pfcp_ie_def *def)
+get_ie_spec (const struct pfcp_ie_def *def, u16 type)
 {
   for (int i = 0; i < def->size; i++)
-    if (def->group[i].type != 0 && def->group[i].type == ntohs (ie->type))
+    if (def->group[i].type != 0 && def->group[i].type == type)
       return &def->group[i];
 
   return NULL;
@@ -7820,22 +7839,13 @@ decode_group (u8 * p, int len, const struct pfcp_ie_def *grp_def,
       const struct pfcp_ie_def *ie_def;
       u16 length = ntohs (ie->length);
       i16 type = ntohs (ie->type);
+      int id = 0;
 
       pfcp_debug ("%U", format_pfcp_ie, ie);
 
       pos += 4;
       if (pos + length > len)
 	return PFCP_CAUSE_INVALID_LENGTH;
-
-      item = get_ie_spec (ie, grp_def);
-
-      if (!item)
-	{
-	  vec_add1 (grp->ies, ie);
-	  goto next;
-	}
-
-      int id = item - grp_def->group;
 
       if (type & 0x8000)
 	{
@@ -7863,6 +7873,16 @@ decode_group (u8 * p, int len, const struct pfcp_ie_def *grp_def,
 	{
 	  ie_def = &tgpp_specs[type];
 	}
+
+      item = get_ie_spec (grp_def, type);
+
+      if (!item)
+	{
+	  vec_add1 (grp->ies, ie);
+	  goto next;
+	}
+
+      id = item - grp_def->group;
 
       u8 *v = ((u8 *) grp) + item->offset;
 

--- a/upf/pfcp.c
+++ b/upf/pfcp.c
@@ -86,11 +86,14 @@ format_enum (u8 * s, va_list * args)
 u8 *
 format_network_instance (u8 * s, va_list * args)
 {
-  u8 *label = va_arg (*args, u8 *);
+  u8 **p = va_arg (*args, u8 **);
   u8 i = 0;
+  u8 *label;
 
-  if (!label)
+  if (!p || !*p)
     return format (s, "invalid");
+
+  label = *p;
 
   if (*label > 64)
     {
@@ -1778,7 +1781,7 @@ format_node_id (u8 * s, va_list * args)
       break;
 
     case NID_FQDN:
-      s = format (s, "%U", format_network_instance, n->fqdn);
+      s = format (s, "%U", format_network_instance, &n->fqdn);
       break;
     }
   return s;
@@ -3107,7 +3110,7 @@ format_remote_gtp_u_peer (u8 * s, va_list * args)
       format (s, ",DI:%U", format_destination_interface,
 	      v->destination_interface);
   if (vec_len (v->network_instance) > 0)
-    s = format (s, ",NI: %U", format_network_instance, v->network_instance);
+    s = format (s, ",NI: %U", format_network_instance, &v->network_instance);
 
   return s;
 }
@@ -3502,7 +3505,7 @@ format_user_plane_ip_resource_information (u8 * s, va_list * args)
 
   if (v->network_instance)
     s = format (s, "Network Instance: %U, ",
-		format_network_instance, v->network_instance);
+		format_network_instance, &v->network_instance);
 
   if (v->flags & USER_PLANE_IP_RESOURCE_INFORMATION_V4)
     s = format (s, "%U, ", format_ip4_address, &v->ip4);

--- a/upf/pfcp.h
+++ b/upf/pfcp.h
@@ -2239,6 +2239,26 @@ typedef struct
 
 enum
 {
+  UE_IP_ADDRESS_POOL_INFORMATION_POOL_IDENTIFY,
+  UE_IP_ADDRESS_POOL_INFORMATION_NETWORK_INSTANCE,
+  UE_IP_ADDRESS_POOL_INFORMATION_IP_VERSION,
+  UE_IP_ADDRESS_POOL_INFORMATION_BBF_NAT_PORT_BLOCK,
+  UE_IP_ADDRESS_POOL_INFORMATION_POOL_LAST =
+    UE_IP_ADDRESS_POOL_INFORMATION_BBF_NAT_PORT_BLOCK
+};
+
+typedef struct
+{
+  struct pfcp_group grp;
+
+  pfcp_ue_ip_address_pool_identity_t ue_ip_address_pool_identity;
+  pfcp_network_instance_t network_instance;
+  pfcp_ip_version_t ip_version;
+  pfcp_bbf_nat_port_block_t *port_blocks;
+} pfcp_ue_ip_address_pool_information_t;
+
+enum
+{
   TP_ERROR_REPORT_TP_ERROR_MESSAGE,
   TP_ERROR_REPORT_TP_FILE_NAME,
   TP_ERROR_REPORT_TP_LINE_NUMBER,
@@ -2367,7 +2387,7 @@ enum
   ASSOCIATION_SETUP_REQUEST_CP_FUNCTION_FEATURES,
   ASSOCIATION_SETUP_REQUEST_USER_PLANE_IP_RESOURCE_INFORMATION,
   ASSOCIATION_SETUP_REQUEST_TP_BUILD_ID,
-  ASSOCIATION_SETUP_REQUEST_UE_IP_ADDRESS_POOL_IDENTITY,
+  ASSOCIATION_SETUP_REQUEST_UE_IP_ADDRESS_POOL_INFORMATION,
   ASSOCIATION_SETUP_REQUEST_ALTERNATIVE_SMF_IP_ADDRESS,
   ASSOCIATION_SETUP_REQUEST_LAST =
     ASSOCIATION_SETUP_REQUEST_ALTERNATIVE_SMF_IP_ADDRESS
@@ -2381,10 +2401,10 @@ typedef struct
   pfcp_recovery_time_stamp_t recovery_time_stamp;
   pfcp_cp_function_features_t cp_function_features;
   pfcp_up_function_features_t up_function_features;
+  pfcp_ue_ip_address_pool_information_t ue_ip_address_pool_information;
     pfcp_user_plane_ip_resource_information_t
     * user_plane_ip_resource_information;
   pfcp_tp_build_id_t tp_build_id;
-  pfcp_ue_ip_address_pool_identity_t ue_ip_address_pool_identity;
   pfcp_alternative_smf_ip_address_t *alternative_smf_ip_address;
 } pfcp_association_setup_request_t;
 
@@ -2397,7 +2417,7 @@ enum
   ASSOCIATION_UPDATE_REQUEST_GRACEFUL_RELEASE_PERIOD,
   ASSOCIATION_UPDATE_REQUEST_USER_PLANE_IP_RESOURCE_INFORMATION,
   ASSOCIATION_UPDATE_REQUEST_PFCPAUREQ_FLAGS,
-  ASSOCIATION_UPDATE_REQUEST_UE_IP_ADDRESS_POOL_IDENTITY,
+  ASSOCIATION_UPDATE_REQUEST_UE_IP_ADDRESS_POOL_INFORMATION,
   ASSOCIATION_UPDATE_REQUEST_ALTERNATIVE_SMF_IP_ADDRESS,
   ASSOCIATION_UPDATE_REQUEST_LAST =
     ASSOCIATION_UPDATE_REQUEST_ALTERNATIVE_SMF_IP_ADDRESS
@@ -2415,7 +2435,7 @@ typedef struct
     pfcp_user_plane_ip_resource_information_t
     * user_plane_ip_resource_information;
   pfcp_pfcpaureq_flags_t pfcpaureq_flags;
-  pfcp_ue_ip_address_pool_identity_t ue_ip_address_pool_identity;
+  pfcp_ue_ip_address_pool_information_t *ue_ip_address_pool_information;
   pfcp_alternative_smf_ip_address_t *alternative_smf_ip_address;
 } pfcp_association_update_request_t;
 
@@ -2432,26 +2452,6 @@ typedef struct
 
 } pfcp_association_release_request_t;
 
-
-enum
-{
-  UE_IP_ADDRESS_POOL_INFORMATION_POOL_IDENTIFY,
-  UE_IP_ADDRESS_POOL_INFORMATION_NETWORK_INSTANCE,
-  UE_IP_ADDRESS_POOL_INFORMATION_IP_VERSION,
-  UE_IP_ADDRESS_POOL_INFORMATION_BBF_NAT_PORT_BLOCK,
-  UE_IP_ADDRESS_POOL_INFORMATION_POOL_LAST =
-    UE_IP_ADDRESS_POOL_INFORMATION_BBF_NAT_PORT_BLOCK
-};
-
-typedef struct
-{
-  struct pfcp_group grp;
-
-  pfcp_ue_ip_address_pool_identity_t ue_ip_address_pool_identity;
-  pfcp_network_instance_t network_instance;
-  pfcp_ip_version_t ip_version;
-  pfcp_bbf_nat_port_block_t *port_blocks;
-} pfcp_ue_ip_address_pool_information_t;
 enum
 {
   ASSOCIATION_PROCEDURE_RESPONSE_NODE_ID,
@@ -2460,13 +2460,12 @@ enum
   ASSOCIATION_PROCEDURE_RESPONSE_RECOVERY_TIME_STAMP,
   ASSOCIATION_PROCEDURE_RESPONSE_UP_FUNCTION_FEATURES,
   ASSOCIATION_PROCEDURE_RESPONSE_CP_FUNCTION_FEATURES,
-  ASSOCIATION_PROCEDURE_RESPONSE_BBF_UP_FUNCTION_FEATURES,
   ASSOCIATION_PROCEDURE_RESPONSE_USER_PLANE_IP_RESOURCE_INFORMATION,
-  ASSOCIATION_PROCEDURE_RESPONSE_TP_BUILD_ID,
-  ASSOCIATION_PROCEDURE_RESPONSE_UE_IP_ADDRESS_POOL_IDENTITY,
   ASSOCIATION_PROCEDURE_RESPONSE_UE_IP_ADDRESS_POOL_INFORMATION,
+  ASSOCIATION_PROCEDURE_RESPONSE_BBF_UP_FUNCTION_FEATURES,
+  ASSOCIATION_PROCEDURE_RESPONSE_TP_BUILD_ID,
   ASSOCIATION_PROCEDURE_RESPONSE_LAST =
-    ASSOCIATION_PROCEDURE_RESPONSE_UE_IP_ADDRESS_POOL_INFORMATION
+    ASSOCIATION_PROCEDURE_RESPONSE_TP_BUILD_ID
 };
 
 typedef struct
@@ -2479,12 +2478,11 @@ typedef struct
   pfcp_recovery_time_stamp_t recovery_time_stamp;
   pfcp_cp_function_features_t cp_function_features;
   pfcp_up_function_features_t up_function_features;
-  pfcp_bbf_up_function_features_t bbf_up_function_features;
+  pfcp_ue_ip_address_pool_information_t *ue_ip_address_pool_information;
     pfcp_user_plane_ip_resource_information_t
     * user_plane_ip_resource_information;
+  pfcp_bbf_up_function_features_t bbf_up_function_features;
   pfcp_tp_build_id_t tp_build_id;
-  pfcp_ue_ip_address_pool_identity_t ue_ip_address_pool_identity;
-  pfcp_ue_ip_address_pool_information_t *ue_ip_address_pool_information;
 } pfcp_association_procedure_response_t;
 
 enum

--- a/upf/pfcp.h
+++ b/upf/pfcp.h
@@ -2728,7 +2728,7 @@ typedef struct
 
 u8 *format_flags (u8 * s, va_list * args);
 u8 *format_enum (u8 * s, va_list * args);
-u8 *format_network_instance (u8 * s, va_list * args);
+u8 *format_dns_labels (u8 * s, va_list * args);
 u8 *format_pfcp_msg_hdr (u8 * s, va_list * args);
 u8 *format_user_plane_ip_resource_information (u8 * s, va_list * args);
 u8 *format_redirect_information (u8 * s, va_list * args);

--- a/upf/pfcp.h
+++ b/upf/pfcp.h
@@ -1145,7 +1145,40 @@ typedef struct
   ip6_address_t ip6;
 } pfcp_alternative_smf_ip_address_t;
 
-#define VENDOR_TRAVELPING   18681
+#define PFCP_IE_UE_IP_ADDRESS_POOL_INFORMATION		233
+
+#define PFCP_IE_IP_VERSION				258
+typedef u8 pfcp_ip_version_t;
+#define IP_VERSION_4					BIT(0)
+#define IP_VERSION_6					BIT(1)
+
+#define VENDOR_BBF					3561
+
+#define PFCP_IE_BBF_UP_FUNCTION_FEATURES		0
+typedef u32 pfcp_bbf_up_function_features_t;
+
+#define BBF_UP_NAT					BIT(6)
+
+#define PFCP_IE_BBF_NAT_OUTSIDE_ADDRESS			14
+typedef ip4_address_t pfcp_bbf_nat_outside_address_t;
+
+#define PFCP_IE_BBF_NAT_EXTERNAL_PORT_RANGE		16
+typedef struct
+{
+  u16 start_port;
+  u16 end_port;
+} pfcp_bbf_nat_external_port_range_t;
+
+#define PFCP_IE_BBF_APPLY_ACTION			15
+
+#define BBF_APPLY_ACTION_NAT				BIT(0)
+
+typedef u8 pfcp_bbf_apply_action_t;
+
+#define PFCP_IE_BBF_NAT_PORT_BLOCK			18
+typedef u8 *pfcp_bbf_nat_port_block_t;
+
+#define VENDOR_TRAVELPING				18681
 
 #define PFCP_IE_TP_PACKET_MEASUREMENT			1
 typedef pfcp_volume_threshold_t pfcp_tp_packet_measurement_t;
@@ -1172,6 +1205,8 @@ typedef u8 *pfcp_tp_file_name_t;
 
 #define PFCP_IE_TP_LINE_NUMBER				9
 typedef u32 pfcp_tp_line_number_t;
+
+#define PFCP_IE_TP_CREATED_NAT_BINDING			10
 
 /* Grouped PFCP Information Elements */
 
@@ -1439,8 +1474,9 @@ enum
   FORWARDING_PARAMETERS_LINKED_TRAFFIC_ENDPOINT_ID,
   FORWARDING_PARAMETERS_PROXYING,
   FORWARDING_PARAMETERS_DESTINATION_INTERFACE_TYPE,
-  FORWARDING_PARAMETERS_LAST =
-    FORWARDING_PARAMETERS_DESTINATION_INTERFACE_TYPE
+  FORWARDING_PARAMETERS_BBF_APPLY_ACTION,
+  FORWARDING_PARAMETERS_BBF_NAT_PORT_BLOCK,
+  FORWARDING_PARAMETERS_LAST = FORWARDING_PARAMETERS_BBF_NAT_PORT_BLOCK
 };
 
 typedef struct
@@ -1457,6 +1493,8 @@ typedef struct
   pfcp_traffic_endpoint_id_t linked_traffic_endpoint_id;
   pfcp_proxying_t proxying;
   pfcp_tgpp_interface_type_t destination_interface_type;
+  pfcp_bbf_apply_action_t bbf_apply_action;
+  pfcp_bbf_nat_port_block_t nat_port_block;
 } pfcp_forwarding_parameters_t;
 
 enum
@@ -2216,6 +2254,23 @@ typedef struct
   pfcp_tp_line_number_t line_number;
 } pfcp_tp_error_report_t;
 
+enum
+{
+  TP_CREATED_BINDING_NAT_PORT_BLOCK,
+  TP_CREATED_BINDING_NAT_OUTSIDE_ADDRESS,
+  TP_CREATED_BINDING_NAT_EXTERNAL_PORT_RANGE,
+  TP_CREATED_BINDING_LAST = TP_CREATED_BINDING_NAT_EXTERNAL_PORT_RANGE
+};
+
+typedef struct
+{
+  struct pfcp_group grp;
+
+  pfcp_bbf_nat_port_block_t block;
+  pfcp_bbf_nat_outside_address_t outside_addr;
+  pfcp_bbf_nat_external_port_range_t port_range;
+} pfcp_tp_created_binding_t;
+
 
 /* PFCP Methods */
 
@@ -2329,7 +2384,7 @@ typedef struct
     pfcp_user_plane_ip_resource_information_t
     * user_plane_ip_resource_information;
   pfcp_tp_build_id_t tp_build_id;
-  pfcp_ue_ip_address_pool_identity_t *ue_ip_address_pool_identity;
+  pfcp_ue_ip_address_pool_identity_t ue_ip_address_pool_identity;
   pfcp_alternative_smf_ip_address_t *alternative_smf_ip_address;
 } pfcp_association_setup_request_t;
 
@@ -2360,7 +2415,7 @@ typedef struct
     pfcp_user_plane_ip_resource_information_t
     * user_plane_ip_resource_information;
   pfcp_pfcpaureq_flags_t pfcpaureq_flags;
-  pfcp_ue_ip_address_pool_identity_t *ue_ip_address_pool_identity;
+  pfcp_ue_ip_address_pool_identity_t ue_ip_address_pool_identity;
   pfcp_alternative_smf_ip_address_t *alternative_smf_ip_address;
 } pfcp_association_update_request_t;
 
@@ -2377,6 +2432,26 @@ typedef struct
 
 } pfcp_association_release_request_t;
 
+
+enum
+{
+  UE_IP_ADDRESS_POOL_INFORMATION_POOL_IDENTIFY,
+  UE_IP_ADDRESS_POOL_INFORMATION_NETWORK_INSTANCE,
+  UE_IP_ADDRESS_POOL_INFORMATION_IP_VERSION,
+  UE_IP_ADDRESS_POOL_INFORMATION_BBF_NAT_PORT_BLOCK,
+  UE_IP_ADDRESS_POOL_INFORMATION_POOL_LAST =
+    UE_IP_ADDRESS_POOL_INFORMATION_BBF_NAT_PORT_BLOCK
+};
+
+typedef struct
+{
+  struct pfcp_group grp;
+
+  pfcp_ue_ip_address_pool_identity_t ue_ip_address_pool_identity;
+  pfcp_network_instance_t network_instance;
+  pfcp_ip_version_t ip_version;
+  pfcp_bbf_nat_port_block_t *port_blocks;
+} pfcp_ue_ip_address_pool_information_t;
 enum
 {
   ASSOCIATION_PROCEDURE_RESPONSE_NODE_ID,
@@ -2385,11 +2460,13 @@ enum
   ASSOCIATION_PROCEDURE_RESPONSE_RECOVERY_TIME_STAMP,
   ASSOCIATION_PROCEDURE_RESPONSE_UP_FUNCTION_FEATURES,
   ASSOCIATION_PROCEDURE_RESPONSE_CP_FUNCTION_FEATURES,
+  ASSOCIATION_PROCEDURE_RESPONSE_BBF_UP_FUNCTION_FEATURES,
   ASSOCIATION_PROCEDURE_RESPONSE_USER_PLANE_IP_RESOURCE_INFORMATION,
   ASSOCIATION_PROCEDURE_RESPONSE_TP_BUILD_ID,
   ASSOCIATION_PROCEDURE_RESPONSE_UE_IP_ADDRESS_POOL_IDENTITY,
+  ASSOCIATION_PROCEDURE_RESPONSE_UE_IP_ADDRESS_POOL_INFORMATION,
   ASSOCIATION_PROCEDURE_RESPONSE_LAST =
-    ASSOCIATION_PROCEDURE_RESPONSE_UE_IP_ADDRESS_POOL_IDENTITY
+    ASSOCIATION_PROCEDURE_RESPONSE_UE_IP_ADDRESS_POOL_INFORMATION
 };
 
 typedef struct
@@ -2402,10 +2479,12 @@ typedef struct
   pfcp_recovery_time_stamp_t recovery_time_stamp;
   pfcp_cp_function_features_t cp_function_features;
   pfcp_up_function_features_t up_function_features;
+  pfcp_bbf_up_function_features_t bbf_up_function_features;
     pfcp_user_plane_ip_resource_information_t
     * user_plane_ip_resource_information;
   pfcp_tp_build_id_t tp_build_id;
-  pfcp_ue_ip_address_pool_identity_t *ue_ip_address_pool_identity;
+  pfcp_ue_ip_address_pool_identity_t ue_ip_address_pool_identity;
+  pfcp_ue_ip_address_pool_information_t *ue_ip_address_pool_information;
 } pfcp_association_procedure_response_t;
 
 enum
@@ -2570,8 +2649,9 @@ enum
   SESSION_PROCEDURE_RESPONSE_FAILED_RULE_ID,
   SESSION_PROCEDURE_RESPONSE_ADDITIONAL_USAGE_REPORTS_INFORMATION,
   SESSION_PROCEDURE_RESPONSE_CREATED_TRAFFIC_ENDPOINT,
+  SESSION_PROCEDURE_RESPONSE_TP_CREATED_BINDING,
   SESSION_PROCEDURE_RESPONSE_LAST =
-    SESSION_PROCEDURE_RESPONSE_CREATED_TRAFFIC_ENDPOINT
+    SESSION_PROCEDURE_RESPONSE_TP_CREATED_BINDING
 };
 
 typedef struct
@@ -2592,6 +2672,7 @@ typedef struct
     pfcp_additional_usage_reports_information_t
     additional_usage_reports_information;
   pfcp_created_traffic_endpoint_t *created_traffic_endpoint;
+  pfcp_tp_created_binding_t created_binding;
 } pfcp_session_procedure_response_t;
 
 enum

--- a/upf/test/test_upf.py
+++ b/upf/test/test_upf.py
@@ -95,8 +95,8 @@ class IPv4Mixin(object):
             r"^https?://(.*\\.)*(example)\\.com/",
             "upf application TST rule 3001 add ipfilter " +
             "permit out ip from %s to assigned" % APP_RULE_IP_V4,
-            "upf nat pool nwi sgi 78.32.0.2 - 78.32.0.25 block_size 512 vrf 200 name testing",
-            "upf nat pool nwi sgi 78.32.20.2 - 78.32.20.25 block_size 512 vrf 200 name not-testing",
+            "upf nat pool 78.32.0.2 - 78.32.0.25 block_size 512 nwi sgi name testing",
+            "upf nat pool 78.32.20.2 - 78.32.20.25 block_size 512 nwi sgi name not-testing",
             "upf ueip pool nwi sgi id mypool",
         ]
 
@@ -113,8 +113,8 @@ class IPv4Mixin(object):
             (cls.if_sgi.remote_ip4, cls.if_sgi.name),
             "upf gtpu endpoint ip %s nwi cp teid 0x80000000/2" % cls.if_cp.local_ip4,
             "upf gtpu endpoint ip %s nwi epc teid 0x80000000/2" % cls.if_grx.local_ip4,
-            "upf nat pool nwi sgi 78.32.0.2 - 78.32.0.250 block_size 512 vrf 200 name testing",
-            "upf nat pool nwi sgi 78.32.20.2 - 78.32.20.25 block_size 512 vrf 200 name not-testing",
+            "upf nat pool 78.32.0.2 - 78.32.0.25 block_size 512 nwi sgi name testing",
+            "upf nat pool 78.32.20.2 - 78.32.20.25 block_size 512 nwi sgi name not-testing",
             "upf ueip pool nwi sgi id mypool",
         ]
 

--- a/upf/test/test_upf.py
+++ b/upf/test/test_upf.py
@@ -95,6 +95,9 @@ class IPv4Mixin(object):
             r"^https?://(.*\\.)*(example)\\.com/",
             "upf application TST rule 3001 add ipfilter " +
             "permit out ip from %s to assigned" % APP_RULE_IP_V4,
+            "upf nat pool nwi sgi 78.32.0.2 - 78.32.0.25 block_size 512 vrf 200 name testing",
+            "upf nat pool nwi sgi 78.32.20.2 - 78.32.20.25 block_size 512 vrf 200 name not-testing",
+            "upf ueip pool nwi sgi id mypool",
         ]
 
     @classmethod
@@ -110,6 +113,9 @@ class IPv4Mixin(object):
             (cls.if_sgi.remote_ip4, cls.if_sgi.name),
             "upf gtpu endpoint ip %s nwi cp teid 0x80000000/2" % cls.if_cp.local_ip4,
             "upf gtpu endpoint ip %s nwi epc teid 0x80000000/2" % cls.if_grx.local_ip4,
+            "upf nat pool nwi sgi 78.32.0.2 - 78.32.0.250 block_size 512 vrf 200 name testing",
+            "upf nat pool nwi sgi 78.32.20.2 - 78.32.20.25 block_size 512 vrf 200 name not-testing",
+            "upf ueip pool nwi sgi id mypool",
         ]
 
     @property
@@ -355,7 +361,6 @@ class PFCPHelper(object):
             IE_NodeId(id_type="FQDN", id="ergw")
         ]), PFCPAssociationSetupResponse)
         self.assertEqual(CauseValues[resp[IE_Cause].cause], "Request accepted")
-        self.assertIn(b"vpp", resp[IE_EnterpriseSpecific].data)
         if IE_NodeId in resp:
             if resp[IE_NodeId].id_type is 2:
                 self.assertEqual(resp[IE_NodeId].id, b"upg")

--- a/upf/upf.c
+++ b/upf/upf.c
@@ -55,7 +55,7 @@ int
 vnet_upf_ueip_pool_add_del (u8 * identity, u8 * nwi_name, int is_add)
 {
   upf_main_t *gtm = &upf_main;
-  upf_ueip_pool_info_t *ueip_pool = NULL;
+  upf_ue_ip_pool_info_t *ueip_pool = NULL;
   uword *p;
 
   p = hash_get_mem (gtm->ueip_pool_index_by_identity, identity);
@@ -104,36 +104,29 @@ get_nat_pool_by_name (u8 * name)
 }
 
 int
-upf_init_nat_addresses (upf_nat_pool_t * np, ip4_address_t * start_addr,
-			ip4_address_t * end_addr)
+upf_init_nat_addresses (upf_nat_pool_t * np, ip4_address_t start_addr,
+			ip4_address_t end_addr)
 {
-  u32 start_host_order, end_host_order;
-  u32 count;
-  ip4_address_t addr = *start_addr;
-  ip4_address_t end = *end_addr;
   u32 i = 0;
 
-  start_host_order = clib_host_to_net_u32 (addr.as_u32);
-  end_host_order = clib_host_to_net_u32 (end.as_u32);
-  count = (end_host_order - start_host_order) + 1;
   vec_reset_length (np->addresses);
 
-  do
+  for (i = clib_net_to_host_u32 (start_addr.as_u32);
+       i <= clib_net_to_host_u32 (end_addr.as_u32); i++)
     {
       upf_nat_addr_t *ap;
+
       vec_add2 (np->addresses, ap, 1);
-      ap->ext_addr = addr;
+      ap->ext_addr.as_u32 = clib_host_to_net_u32 (i);
       ap->used_blocks = 0;
-      increment_v4_address (&addr);
-      ++i;
-    }
-  while (i < count);
+    };
+
   return 0;
 }
 
 int
-vnet_upf_nat_pool_add_del (u8 * nwi_name, ip4_address_t * start_addr,
-			   ip4_address_t * end_addr, u8 * name,
+vnet_upf_nat_pool_add_del (u8 * nwi_name, ip4_address_t start_addr,
+			   ip4_address_t end_addr, u8 * name,
 			   u16 port_block_size, u16 min_port, u16 max_port,
 			   u32 vrf_id, u8 is_add)
 {

--- a/upf/upf.c
+++ b/upf/upf.c
@@ -91,16 +91,13 @@ upf_nat_pool_t *
 get_nat_pool_by_name (u8 * name)
 {
   upf_main_t *gtm = &upf_main;
-  upf_nat_pool_t *np = NULL;
   uword *p;
 
   p = hash_get_mem (gtm->nat_pool_index_by_name, name);
   if (!p)
     return NULL;
 
-  np = pool_elt_at_index (gtm->nat_pools, p[0]);
-
-  return np;
+  return pool_elt_at_index (gtm->nat_pools, p[0]);
 }
 
 int
@@ -108,11 +105,18 @@ upf_init_nat_addresses (upf_nat_pool_t * np, ip4_address_t start_addr,
 			ip4_address_t end_addr)
 {
   u32 i = 0;
+  u32 start;
+  u32 end;
 
-  vec_reset_length (np->addresses);
+  start = clib_net_to_host_u32 (start_addr.as_u32);
+  end = clib_net_to_host_u32 (end_addr.as_u32);
 
-  for (i = clib_net_to_host_u32 (start_addr.as_u32);
-       i <= clib_net_to_host_u32 (end_addr.as_u32); i++)
+  if (start > end)
+    return -1;
+
+  vec_alloc (np->addresses, end - start + 1);
+
+  for (i = start; i <= end; i++)
     {
       upf_nat_addr_t *ap;
 
@@ -128,7 +132,7 @@ int
 vnet_upf_nat_pool_add_del (u8 * nwi_name, ip4_address_t start_addr,
 			   ip4_address_t end_addr, u8 * name,
 			   u16 port_block_size, u16 min_port, u16 max_port,
-			   u32 vrf_id, u8 is_add)
+			   u8 is_add)
 {
   upf_main_t *gtm = &upf_main;
   upf_nat_pool_t *nat_pool = NULL;
@@ -142,16 +146,20 @@ vnet_upf_nat_pool_add_del (u8 * nwi_name, ip4_address_t start_addr,
 	return VNET_API_ERROR_VALUE_EXIST;
 
       pool_get (gtm->nat_pools, nat_pool);
+
+      if (upf_init_nat_addresses (nat_pool, start_addr, end_addr))
+	{
+	  pool_put (gtm->nat_pools, nat_pool);
+	  return -1;
+	}
+
       nat_pool->name = vec_dup (name);
       nat_pool->network_instance = vec_dup (nwi_name);
       nat_pool->port_block_size = port_block_size;
       nat_pool->min_port = UPF_NAT_MIN_PORT;
       nat_pool->max_port = UPF_NAT_MAX_PORT;
-      nat_pool->vrf_id = vrf_id;
       nat_pool->max_blocks_per_addr =
 	(u16) ((nat_pool->max_port - nat_pool->min_port) / port_block_size);
-
-      upf_init_nat_addresses (nat_pool, start_addr, end_addr);
 
       hash_set_mem (gtm->nat_pool_index_by_name, name,
 		    nat_pool - gtm->nat_pools);
@@ -163,7 +171,7 @@ vnet_upf_nat_pool_add_del (u8 * nwi_name, ip4_address_t start_addr,
 	return VNET_API_ERROR_NO_SUCH_ENTRY;
 
       nat_pool = pool_elt_at_index (gtm->nat_pools, p[0]);
-      //TBD: nat pool cleanup upf_delete_nat_addresses(nat_pool);
+      vec_free (nat_pool->addresses);
       hash_unset_mem (gtm->nat_pool_index_by_name, name);
       vec_free (nat_pool->name);
       vec_free (nat_pool->network_instance);

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -340,6 +340,30 @@ typedef struct
 
 #define INTF_INVALID	((u8)~0)
 
+typedef struct
+{
+  ip4_address_t ext_addr;
+  u32 used_blocks;
+} upf_nat_addr_t;
+
+typedef struct
+{
+  u8 *name;
+  upf_nat_addr_t *addresses;
+  u16 port_block_size;
+  u16 min_port;
+  u16 max_port;
+  u32 vrf_id;
+  u16 max_blocks_per_addr;
+  u8 *network_instance;
+} upf_nat_pool_t;
+
+typedef struct
+{
+  u8 *identity;
+  u8 *nwi_name;
+} upf_ueip_pool_info_t;
+
 typedef enum
 {
   UPF_UL = 0,
@@ -672,6 +696,11 @@ typedef struct
   /* TEID table by choose_id */
   u32 *teid_by_chid;
 
+  //TODO: this is temporary, should be removed
+  ip4_address_t user_addr;
+
+  upf_nat_addr_t *nat_addr;
+
   f64 unix_time_start;
 
   u16 generation;
@@ -879,6 +908,12 @@ typedef struct
   u32 rand_base;
 
   pfcp_node_id_t node_id;
+
+  upf_nat_pool_t *nat_pools;
+  uword *nat_pool_index_by_name;
+  upf_ueip_pool_info_t *ueip_pools;
+  uword *ueip_pool_index_by_identity;
+
 } upf_main_t;
 
 extern const fib_node_vft_t upf_vft;
@@ -933,6 +968,14 @@ const dpo_id_t *upf_get_session_dpo_ip6 (upf_nwi_t * nwi,
 
 dpo_type_t upf_session_dpo_get_type (void);
 
+int
+vnet_upf_nat_pool_add_del (u8 * nwi_name, ip4_address_t * start_addr,
+			   ip4_address_t * end_addr, u8 * name,
+			   u16 port_block_size, u16 min_port, u16 max_port,
+			   u32 vrf_id, u8 is_add);
+
+int vnet_upf_ueip_pool_add_del (u8 * identity, u8 * nwi_name, int is_add);
+
 static_always_inline void
 upf_vnet_buffer_l3_hdr_offset_is_current (vlib_buffer_t * b)
 {
@@ -941,6 +984,26 @@ upf_vnet_buffer_l3_hdr_offset_is_current (vlib_buffer_t * b)
 }
 
 void upf_proxy_init (vlib_main_t * vm);
+
+#define UPF_NAT_MIN_PORT 10128
+#define UPF_NAT_MAX_PORT 64000
+
+upf_nat_pool_t *get_nat_pool_by_name (u8 * name);
+
+static int (*upf_nat_del_binding) (ip4_address_t user_addr);
+
+static int
+  (*upf_nat_create_binding) (ip4_address_t user_addr, ip4_address_t ext_addr,
+			     u16 start, u16 end, u32 vrf);
+
+static inline void
+increment_v4_address (ip4_address_t * a)
+{
+  u32 v;
+
+  v = clib_net_to_host_u32 (a->as_u32) + 1;
+  a->as_u32 = clib_host_to_net_u32 (v);
+}
 
 #endif /* __included_upf_h__ */
 

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -362,7 +362,7 @@ typedef struct
 {
   u8 *identity;
   u8 *nwi_name;
-} upf_ueip_pool_info_t;
+} upf_ue_ip_pool_info_t;
 
 typedef enum
 {
@@ -911,7 +911,7 @@ typedef struct
 
   upf_nat_pool_t *nat_pools;
   uword *nat_pool_index_by_name;
-  upf_ueip_pool_info_t *ueip_pools;
+  upf_ue_ip_pool_info_t *ueip_pools;
   uword *ueip_pool_index_by_identity;
 
 } upf_main_t;
@@ -969,8 +969,8 @@ const dpo_id_t *upf_get_session_dpo_ip6 (upf_nwi_t * nwi,
 dpo_type_t upf_session_dpo_get_type (void);
 
 int
-vnet_upf_nat_pool_add_del (u8 * nwi_name, ip4_address_t * start_addr,
-			   ip4_address_t * end_addr, u8 * name,
+vnet_upf_nat_pool_add_del (u8 * nwi_name, ip4_address_t start_addr,
+			   ip4_address_t end_addr, u8 * name,
 			   u16 port_block_size, u16 min_port, u16 max_port,
 			   u32 vrf_id, u8 is_add);
 
@@ -994,7 +994,7 @@ static int (*upf_nat_del_binding) (ip4_address_t user_addr);
 
 static int
   (*upf_nat_create_binding) (ip4_address_t user_addr, ip4_address_t ext_addr,
-			     u16 start, u16 end, u32 vrf);
+			     u16 min_port, u16 block_size, u32 vrf);
 
 static inline void
 increment_v4_address (ip4_address_t * a)

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -972,7 +972,7 @@ int
 vnet_upf_nat_pool_add_del (u8 * nwi_name, ip4_address_t start_addr,
 			   ip4_address_t end_addr, u8 * name,
 			   u16 port_block_size, u16 min_port, u16 max_port,
-			   u32 vrf_id, u8 is_add);
+			   u8 is_add);
 
 int vnet_upf_ueip_pool_add_del (u8 * identity, u8 * nwi_name, int is_add);
 
@@ -994,7 +994,7 @@ static int (*upf_nat_del_binding) (ip4_address_t user_addr);
 
 static int
   (*upf_nat_create_binding) (ip4_address_t user_addr, ip4_address_t ext_addr,
-			     u16 min_port, u16 block_size, u32 vrf);
+			     u16 min_port, u16 block_size);
 
 static inline void
 increment_v4_address (ip4_address_t * a)

--- a/upf/upf_cli.c
+++ b/upf/upf_cli.c
@@ -445,7 +445,7 @@ upf_show_nwi_command_fn (vlib_main_t * vm,
       continue;
 
     vlib_cli_output (vm, "%U, ip4-fib-index %u, ip6-fib-index %u\n",
-		     format_network_instance, nwi->name,
+		     format_dns_labels, nwi->name,
 		     nwi->fib_index[FIB_PROTOCOL_IP4],
 		     nwi->fib_index[FIB_PROTOCOL_IP6]);
   }));

--- a/upf/upf_cli.c
+++ b/upf/upf_cli.c
@@ -217,8 +217,8 @@ upf_ueip_pool_add_del_command_fn (vlib_main_t * vm,
 {
   unformat_input_t _line_input, *line_input = &_line_input;
   clib_error_t *error = NULL;
-  u8 *name;
-  u8 *nwi_s;
+  u8 *name = 0;
+  u8 *nwi_s = 0;
   u8 *nwi_name;
   int rc = 0;
   int is_add = 1;
@@ -262,15 +262,13 @@ upf_nat_pool_add_del_command_fn (vlib_main_t * vm,
 {
   unformat_input_t _line_input, *line_input = &_line_input;
   clib_error_t *error = NULL;
-  u8 *name;
+  u8 *name = 0;
   u8 *nwi_name;
   u8 *nwi_s = 0;
-  u32 vrf_id = 0;
   ip4_address_t start, end;
   u16 min_port;
   u16 max_port;
   u16 port_block_size;
-  //u32 vrf_id;
   u8 is_add = 1;
   int rv;
 
@@ -287,27 +285,23 @@ upf_nat_pool_add_del_command_fn (vlib_main_t * vm,
 	;
       else if (unformat (line_input, "block_size %u", &port_block_size))
 	;
-      else if (unformat (line_input, "vrf %u", &vrf_id))
+      else if (unformat (line_input, "nwi %_%v%_", &nwi_s))
 	;
       else if (unformat (line_input, "name %_%v%_", &name))
 	;
       else if (unformat (line_input, "del"))
 	is_add = 0;
-      else if (unformat (line_input, "nwi %_%v%_", &nwi_s))
-	;
     }
 
   nwi_name = upf_name_to_labels (nwi_s);
   vec_free (nwi_s);
 
-  upf_debug
-    ("POOL\n  START %U END %U\n PORTSTART %u PORTEND %u PORTBLOCK %u VRF %u",
-     format_ip4_address, &start, format_ip4_address, &end, min_port, max_port,
-     port_block_size, vrf_id);
-
   rv =
     vnet_upf_nat_pool_add_del (nwi_name, start, end, name, port_block_size,
-			       min_port, max_port, vrf_id, is_add);
+			       min_port, max_port, is_add);
+
+  if (rv)
+    error = clib_error_return (0, "Unable to create NAT Pool");
   return error;
 }
 

--- a/upf/upf_cli.c
+++ b/upf/upf_cli.c
@@ -306,7 +306,7 @@ upf_nat_pool_add_del_command_fn (vlib_main_t * vm,
      port_block_size, vrf_id);
 
   rv =
-    vnet_upf_nat_pool_add_del (nwi_name, &start, &end, name, port_block_size,
+    vnet_upf_nat_pool_add_del (nwi_name, start, end, name, port_block_size,
 			       min_port, max_port, vrf_id, is_add);
   return error;
 }

--- a/upf/upf_cli.c
+++ b/upf/upf_cli.c
@@ -35,6 +35,13 @@
 #include <upf/flowtable.h>
 #include <upf/upf_app_db.h>
 
+#if CLIB_DEBUG > 1
+#define upf_debug clib_warning
+#else
+#define upf_debug(...)                          \
+  do { } while (0)
+#endif
+
 static clib_error_t *
 upf_pfcp_endpoint_ip_add_del_command_fn (vlib_main_t * vm,
 					 unformat_input_t * main_input,
@@ -202,6 +209,117 @@ upf_name_to_labels (u8 * name)
 
   return rv;
 }
+
+static clib_error_t *
+upf_ueip_pool_add_del_command_fn (vlib_main_t * vm,
+				  unformat_input_t * main_input,
+				  vlib_cli_command_t * cmd)
+{
+  unformat_input_t _line_input, *line_input = &_line_input;
+  clib_error_t *error = NULL;
+  u8 *name;
+  u8 *nwi_s;
+  u8 *nwi_name;
+  int rc = 0;
+  int is_add = 1;
+
+  if (!unformat_user (main_input, unformat_line_input, line_input))
+    return 0;
+
+  while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
+    {
+      if (unformat (line_input, "id %_%v%_", &name))
+	;
+      else if (unformat (line_input, "del"))
+	is_add = 0;
+      else if (unformat (line_input, "nwi %_%v%_", &nwi_s))
+	;
+    }
+
+  nwi_name = upf_name_to_labels (nwi_s);
+  vec_free (nwi_s);
+
+  rc = vnet_upf_ueip_pool_add_del (name, nwi_name, is_add);
+
+  return error;
+
+}
+
+/* *INDENT-OFF* */
+VLIB_CLI_COMMAND (upf_ueip_pool_add_del_command, static) =
+{
+  .path = "upf ueip pool",
+  .short_help =
+  "upf ueip pool nwi <nwi-name> id <identity> [del]",
+  .function = upf_ueip_pool_add_del_command_fn,
+};
+/* *INDENT-ON* */
+
+static clib_error_t *
+upf_nat_pool_add_del_command_fn (vlib_main_t * vm,
+				 unformat_input_t * main_input,
+				 vlib_cli_command_t * cmd)
+{
+  unformat_input_t _line_input, *line_input = &_line_input;
+  clib_error_t *error = NULL;
+  u8 *name;
+  u8 *nwi_name;
+  u8 *nwi_s = 0;
+  u32 vrf_id = 0;
+  ip4_address_t start, end;
+  u16 min_port;
+  u16 max_port;
+  u16 port_block_size;
+  //u32 vrf_id;
+  u8 is_add = 1;
+  int rv;
+
+  min_port = UPF_NAT_MIN_PORT;
+  max_port = UPF_NAT_MAX_PORT;
+
+  if (!unformat_user (main_input, unformat_line_input, line_input))
+    return 0;
+
+  while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
+    {
+      if (unformat (line_input, "%U - %U",
+		    unformat_ip4_address, &start, unformat_ip4_address, &end))
+	;
+      else if (unformat (line_input, "block_size %u", &port_block_size))
+	;
+      else if (unformat (line_input, "vrf %u", &vrf_id))
+	;
+      else if (unformat (line_input, "name %_%v%_", &name))
+	;
+      else if (unformat (line_input, "del"))
+	is_add = 0;
+      else if (unformat (line_input, "nwi %_%v%_", &nwi_s))
+	;
+    }
+
+  nwi_name = upf_name_to_labels (nwi_s);
+  vec_free (nwi_s);
+
+  upf_debug
+    ("POOL\n  START %U END %U\n PORTSTART %u PORTEND %u PORTBLOCK %u VRF %u",
+     format_ip4_address, &start, format_ip4_address, &end, min_port, max_port,
+     port_block_size, vrf_id);
+
+  rv =
+    vnet_upf_nat_pool_add_del (nwi_name, &start, &end, name, port_block_size,
+			       min_port, max_port, vrf_id, is_add);
+  return error;
+}
+
+/* *INDENT-OFF* */
+VLIB_CLI_COMMAND (upf_nat_pool_add_del_command, static) =
+{
+  .path = "upf nat pool",
+  .short_help =
+  "upf nat pool nwi <nwi-name> start <ip4-addr> end <ip4-addr> min_port <min-port> max_port <max-port> block_size <port-block-size> vrf <vrf-id> name <name> [del]",
+  .function = upf_nat_pool_add_del_command_fn,
+};
+/* *INDENT-ON* */
 
 static clib_error_t *
 upf_nwi_add_del_command_fn (vlib_main_t * vm,

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -76,7 +76,7 @@ format_upf_device_name (u8 * s, va_list * args)
   upf_nwi_t *nwi;
 
   nwi = pool_elt_at_index (gtm->nwis, i);
-  s = format (s, "upf-nwi-%U", format_network_instance, &nwi->name);
+  s = format (s, "upf-nwi-%U", format_dns_labels, nwi->name);
 
   return s;
 }
@@ -2579,7 +2579,7 @@ format_upf_far (u8 * s, va_list * args)
 		  "%UDestination Interface: %u\n",
 		  format_white_space, indent + 2,
 		  format_white_space, indent + 4,
-		  format_network_instance, nwi ? &nwi->name : NULL,
+		  format_dns_labels, nwi ? nwi->name : NULL,
 		  format_white_space, indent + 4, ff->dst_intf);
       if (ff->flags & FAR_F_REDIRECT_INFORMATION)
 	s = format (s, "%URedirect Information: %U\n",
@@ -2676,7 +2676,7 @@ format_pfcp_session (u8 * s, va_list * args)
       s = format (s, "    Source Interface: %d\n", pdr->pdi.src_intf);
 
     s = format (s, "    Network Instance: %U\n",
-		format_network_instance, nwi ? &nwi->name : NULL);
+		format_dns_labels, nwi ? nwi->name : NULL);
 
     if (pdr->pdi.fields & F_PDI_LOCAL_F_TEID)
       {
@@ -2967,7 +2967,7 @@ format_network_instance_index (u8 * s, va_list * args)
     return format (s, "(@~0)");
 
   upf_nwi_t *nwi = pool_elt_at_index (gtm->nwis, n);
-  return format (s, "(@%u) %U", n, format_network_instance, &nwi->name);
+  return format (s, "(@%u) %U", n, format_dns_labels, nwi->name);
 }
 
 u8 *

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -76,7 +76,7 @@ format_upf_device_name (u8 * s, va_list * args)
   upf_nwi_t *nwi;
 
   nwi = pool_elt_at_index (gtm->nwis, i);
-  s = format (s, "upf-nwi-%U", format_network_instance, nwi->name);
+  s = format (s, "upf-nwi-%U", format_network_instance, &nwi->name);
 
   return s;
 }
@@ -2579,7 +2579,7 @@ format_upf_far (u8 * s, va_list * args)
 		  "%UDestination Interface: %u\n",
 		  format_white_space, indent + 2,
 		  format_white_space, indent + 4,
-		  format_network_instance, nwi ? nwi->name : NULL,
+		  format_network_instance, nwi ? &nwi->name : NULL,
 		  format_white_space, indent + 4, ff->dst_intf);
       if (ff->flags & FAR_F_REDIRECT_INFORMATION)
 	s = format (s, "%URedirect Information: %U\n",
@@ -2676,7 +2676,7 @@ format_pfcp_session (u8 * s, va_list * args)
       s = format (s, "    Source Interface: %d\n", pdr->pdi.src_intf);
 
     s = format (s, "    Network Instance: %U\n",
-		format_network_instance, nwi ? nwi->name : NULL);
+		format_network_instance, nwi ? &nwi->name : NULL);
 
     if (pdr->pdi.fields & F_PDI_LOCAL_F_TEID)
       {
@@ -2967,7 +2967,7 @@ format_network_instance_index (u8 * s, va_list * args)
     return format (s, "(@~0)");
 
   upf_nwi_t *nwi = pool_elt_at_index (gtm->nwis, n);
-  return format (s, "(@%u) %U", n, format_network_instance, nwi->name);
+  return format (s, "(@%u) %U", n, format_network_instance, &nwi->name);
 }
 
 u8 *

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -1027,10 +1027,14 @@ void
 upf_delete_nat_binding (upf_session_t * sx)
 {
   upf_nat_addr_t *ap = sx->nat_addr;
-  if (ap->used_blocks > 0)
-    ap->used_blocks -= 1;
+
+  ASSERT (ap->used_blocks > 0);
+
+  --ap->used_blocks;
+
   upf_nat_del_binding =
     vlib_get_plugin_symbol ("nat_plugin.so", "nat_del_binding");
+
   upf_nat_del_binding (sx->user_addr);
 }
 

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -35,6 +35,7 @@
 #include <vnet/udp/udp_packet.h>
 #include <search.h>
 #include <netinet/ip.h>
+#include <vlib/unix/plugin.h>
 
 #include "pfcp.h"
 #include "upf.h"
@@ -44,7 +45,7 @@
 #include "upf_pfcp_server.h"
 #include "upf_ipfilter.h"
 
-#if CLIB_DEBUG > 2
+#if CLIB_DEBUG > 1
 #define upf_debug clib_warning
 #else
 #define upf_debug(...)				\
@@ -1023,6 +1024,17 @@ pfcp_disable_session (upf_session_t * sx)
 }
 
 void
+upf_delete_nat_binding (upf_session_t * sx)
+{
+  upf_nat_addr_t *ap = sx->nat_addr;
+  if (ap->used_blocks > 0)
+    ap->used_blocks -= 1;
+  upf_nat_del_binding =
+    vlib_get_plugin_symbol ("nat_plugin.so", "nat_del_binding");
+  upf_nat_del_binding (sx->user_addr);
+}
+
+void
 pfcp_free_session (upf_session_t * sx)
 {
   vlib_main_t *vm = vlib_get_main ();
@@ -1034,6 +1046,11 @@ pfcp_free_session (upf_session_t * sx)
     pfcp_free_rules (sx, i);
 
   sparse_vec_free (sx->teid_by_chid);
+
+  if (sx->nat_addr)
+    {
+      upf_delete_nat_binding (sx);
+    }
 
   clib_spinlock_free (&sx->lock);
   pool_put (gtm->sessions, sx);
@@ -1670,12 +1687,12 @@ build_pfcp_rules (upf_session_t * sx)
       }
 
     if ((pdr->pdi.fields & F_PDI_APPLICATION_ID) &&
-        (pdr->pdi.adr.flags & UPF_ADR_PROXY) &&
-        pdr->precedence < pending->proxy_precedence)
+	(pdr->pdi.adr.flags & UPF_ADR_PROXY) &&
+	pdr->precedence < pending->proxy_precedence)
       {
-        pending->proxy_precedence = pdr->precedence;
-        pending->proxy_pdr_idx = idx;
-        pending->flags |= PFCP_ADR;
+	pending->proxy_precedence = pdr->precedence;
+	pending->proxy_pdr_idx = idx;
+	pending->flags |= PFCP_ADR;
       }
   }
 

--- a/upf/upf_pfcp_api.c
+++ b/upf/upf_pfcp_api.c
@@ -922,7 +922,7 @@ upf_alloc_and_assign_nat_binding (upf_nat_pool_t * np, upf_nat_addr_t * addr,
 
   port_start =
     upf_nat_create_binding (user_ip, addr->ext_addr, np->min_port,
-			    np->port_block_size, np->vrf_id);
+			    np->port_block_size);
   if (port_start)
     {
       port_end = port_start + np->port_block_size;

--- a/upf/upf_pfcp_api.c
+++ b/upf/upf_pfcp_api.c
@@ -45,6 +45,8 @@
 #include "upf_app_db.h"
 #include "upf_ipfilter.h"
 
+#include <vlib/unix/plugin.h>
+
 #if CLIB_DEBUG > 1
 #define upf_debug clib_warning
 #else
@@ -189,6 +191,43 @@ upf_pfcp_handle_msg (pfcp_msg_t * msg)
 }
 
 /* message helpers */
+
+static void
+build_ue_ip_address_information (pfcp_ue_ip_address_pool_information_t **
+				 ue_pool_info)
+{
+  upf_main_t *gtm = &upf_main;
+  upf_nat_pool_t *np;
+  upf_ueip_pool_info_t *ue_p;
+
+  vec_alloc (*ue_pool_info, pool_elts (gtm->ueip_pools));
+
+  /* *INDENT-OFF* */
+  pool_foreach (ue_p, gtm->ueip_pools,
+  ({
+    pfcp_ue_ip_address_pool_information_t *ueif;
+    vec_add2 (*ue_pool_info, ueif, 1);
+    ueif->ue_ip_address_pool_identity = vec_dup (ue_p->identity);
+    SET_BIT (ueif->grp.fields, UE_IP_ADDRESS_POOL_INFORMATION_POOL_IDENTIFY);
+
+    ueif->network_instance = vec_dup (ue_p->nwi_name);
+    SET_BIT (ueif->grp.fields,
+	     UE_IP_ADDRESS_POOL_INFORMATION_NETWORK_INSTANCE);
+
+    pool_foreach (np, gtm->nat_pools,
+    ({
+      if (!(vec_is_equal (np->network_instance, ue_p->nwi_name)))
+	continue;
+      pfcp_bbf_nat_port_block_t *block;
+      vec_add2 (ueif->port_blocks, block, 1);
+      *block = vec_dup (np->name);
+      SET_BIT (ueif->grp.fields,
+	       UE_IP_ADDRESS_POOL_INFORMATION_BBF_NAT_PORT_BLOCK);
+    }));
+
+  }));
+  /* *INDENT-ON* */
+}
 
 static void
   build_user_plane_ip_resource_information
@@ -369,6 +408,13 @@ handle_association_setup_request (pfcp_msg_t * req,
   if (gtm->pfcp_spec_version >= 16)
     {
       resp.up_function_features |= F_UPFF_FTUP;
+      build_ue_ip_address_information (&resp.ue_ip_address_pool_information);
+      if (vec_len (resp.ue_ip_address_pool_information) != 0)
+	SET_BIT (resp.grp.fields,
+		 ASSOCIATION_PROCEDURE_RESPONSE_UE_IP_ADDRESS_POOL_INFORMATION);
+      SET_BIT (resp.grp.fields,
+	       ASSOCIATION_PROCEDURE_RESPONSE_BBF_UP_FUNCTION_FEATURES);
+      resp.bbf_up_function_features |= BBF_UP_NAT;
     }
   else
     {
@@ -844,6 +890,66 @@ validate_ue_ip (upf_session_t * sx, upf_nwi_t * nwi,
     response->failed_rule_id.id = pdr->pdr_id;				\
   } while (0)
 
+upf_nat_addr_t *
+get_nat_addr (upf_nat_pool_t * np)
+{
+  upf_nat_addr_t *this_addr = NULL, *addr = NULL;
+  u32 least_locked_ports = ~0;
+  vec_foreach (this_addr, np->addresses)
+  {
+    if ((this_addr->used_blocks < least_locked_ports)
+	&& (this_addr->used_blocks < np->max_blocks_per_addr))
+      {
+	least_locked_ports = this_addr->used_blocks;
+	addr = this_addr;
+      }
+  }
+  return addr;
+}
+
+int
+upf_alloc_and_assign_nat_binding (upf_nat_pool_t * np, upf_nat_addr_t * addr,
+				  ip4_address_t user_ip, upf_session_t * sx,
+				  pfcp_tp_created_binding_t * created_binding)
+{
+  u16 port_start, port_end;
+  int err = 0;
+
+  port_start = np->min_port;
+  port_end = port_start + np->port_block_size;
+
+  upf_nat_create_binding =
+    vlib_get_plugin_symbol ("nat_plugin.so", "nat_create_binding");
+
+  do
+    {
+      err =
+	upf_nat_create_binding (user_ip, addr->ext_addr, port_start, port_end,
+				np->vrf_id);
+      if (!err)
+	{
+	  addr->used_blocks += 1;
+	  sx->nat_addr = addr;
+	  created_binding->block = vec_dup (np->name);
+	  created_binding->outside_addr.as_u32 = addr->ext_addr.as_u32;
+	  created_binding->port_range.start_port = port_start;
+	  created_binding->port_range.end_port = port_end;
+	  SET_BIT (created_binding->grp.fields,
+		   TP_CREATED_BINDING_NAT_PORT_BLOCK);
+	  SET_BIT (created_binding->grp.fields,
+		   TP_CREATED_BINDING_NAT_OUTSIDE_ADDRESS);
+	  SET_BIT (created_binding->grp.fields,
+		   TP_CREATED_BINDING_NAT_EXTERNAL_PORT_RANGE);
+	  return 0;
+	}
+      port_start += np->port_block_size;
+      port_end = port_start + np->port_block_size;
+    }
+  while (port_end < np->max_port);
+  return err;
+
+}
+
 static int
 handle_create_pdr (upf_session_t * sx, pfcp_create_pdr_t * create_pdr,
 		   pfcp_session_procedure_response_t * response)
@@ -927,9 +1033,11 @@ handle_create_pdr (upf_session_t * sx, pfcp_create_pdr_t * create_pdr,
       {
 	create->pdi.fields |= F_PDI_UE_IP_ADDR;
 	create->pdi.ue_addr = pdr->pdi.ue_ip_address;
+	if (create->pdi.ue_addr.flags & IE_UE_IP_ADDRESS_V4)
+	  sx->user_addr.as_u32 = create->pdi.ue_addr.ip4.as_u32;
 
-        if (!ISSET_BIT (pdr->pdi.grp.fields, PDI_SDF_FILTER) &&
-            !ISSET_BIT (pdr->pdi.grp.fields, PDI_APPLICATION_ID))
+	if (!ISSET_BIT (pdr->pdi.grp.fields, PDI_SDF_FILTER) &&
+	    !ISSET_BIT (pdr->pdi.grp.fields, PDI_APPLICATION_ID))
 	  {
 	    /* neither SDF, nor Application Id, generate a wildcard
 	       ACL to make ACL scanning simpler */
@@ -987,12 +1095,12 @@ handle_create_pdr (upf_session_t * sx, pfcp_create_pdr_t * create_pdr,
 	create->pdi.adr.db_id = upf_adf_get_adr_db (p[0]);
 	create->pdi.adr.flags = app->flags;
 
-        if (!ISSET_BIT (pdr->pdi.grp.fields, PDI_SDF_FILTER) &&
-            (create->pdi.adr.flags & UPF_ADR_IP_RULES))
-          {
-            create->pdi.fields |= F_PDI_SDF_FILTER;
-            vec_add1 (create->pdi.acl, wildcard_acl);
-          }
+	if (!ISSET_BIT (pdr->pdi.grp.fields, PDI_SDF_FILTER) &&
+	    (create->pdi.adr.flags & UPF_ADR_IP_RULES))
+	  {
+	    create->pdi.fields |= F_PDI_SDF_FILTER;
+	    vec_add1 (create->pdi.acl, wildcard_acl);
+	  }
 	upf_debug ("app: %v, ADR DB id %u", app->name, create->pdi.adr.db_id);
       }
 
@@ -1114,8 +1222,8 @@ handle_update_pdr (upf_session_t * sx, pfcp_update_pdr_t * update_pdr,
 	update->pdi.fields |= F_PDI_UE_IP_ADDR;
 	update->pdi.ue_addr = pdr->pdi.ue_ip_address;
 
-        if (!ISSET_BIT (pdr->pdi.grp.fields, PDI_SDF_FILTER) &&
-            !ISSET_BIT (pdr->pdi.grp.fields, PDI_APPLICATION_ID))
+	if (!ISSET_BIT (pdr->pdi.grp.fields, PDI_SDF_FILTER) &&
+	    !ISSET_BIT (pdr->pdi.grp.fields, PDI_APPLICATION_ID))
 	  {
 	    /* neither SDF, nor Application Id, generate a wildcard
 	       ACL to make ACL scanning simpler */
@@ -1175,15 +1283,15 @@ handle_update_pdr (upf_session_t * sx, pfcp_update_pdr_t * update_pdr,
 	update->pdi.adr.db_id = upf_adf_get_adr_db (p[0]);
 	update->pdi.adr.flags = app->flags;
 
-        if (!ISSET_BIT (pdr->pdi.grp.fields, PDI_SDF_FILTER))
-          {
-          vec_reset_length (update->pdi.acl);
-          if (update->pdi.adr.flags & UPF_ADR_IP_RULES)
-            {
-              update->pdi.fields |= F_PDI_SDF_FILTER;
-              vec_add1 (update->pdi.acl, wildcard_acl);
-            }
-          }
+	if (!ISSET_BIT (pdr->pdi.grp.fields, PDI_SDF_FILTER))
+	  {
+	    vec_reset_length (update->pdi.acl);
+	    if (update->pdi.adr.flags & UPF_ADR_IP_RULES)
+	      {
+		update->pdi.fields |= F_PDI_SDF_FILTER;
+		vec_add1 (update->pdi.acl, wildcard_acl);
+	      }
+	  }
 
 	upf_debug ("app: %v, ADR DB id %u", app->name, update->pdi.adr.db_id);
       }
@@ -1421,6 +1529,37 @@ upf_ip46_get_resolving_interface (u32 fib_index, ip46_address_t * pa46,
   } while (0)
 
 static int
+handle_nat_binding_creation (upf_session_t * sx, u8 * nat_pool_name,
+			     pfcp_session_procedure_response_t * response)
+{
+  upf_nat_pool_t *np;
+  upf_nat_addr_t *ap;
+  int rc = 0;
+
+  if (!sx->user_addr.as_u32)
+    return -1;
+
+  np = get_nat_pool_by_name (nat_pool_name);
+
+  if (!np)
+    return -1;
+
+  ap = get_nat_addr (np);
+  if (!ap)
+    return -1;
+
+  rc =
+    upf_alloc_and_assign_nat_binding (np, ap, sx->user_addr, sx,
+				      &response->created_binding);
+  if (!rc)
+    SET_BIT (response->grp.fields,
+	     SESSION_PROCEDURE_RESPONSE_TP_CREATED_BINDING);
+
+  return rc;
+
+}
+
+static int
 handle_create_far (upf_session_t * sx, pfcp_create_far_t * create_far,
 		   pfcp_session_procedure_response_t * response)
 {
@@ -1479,6 +1618,23 @@ handle_create_far (upf_session_t * sx, pfcp_create_far_t * create_far,
 	      (&create->forward.redirect_information,
 	       &far->forwarding_parameters.redirect_information);
 
+	  }
+
+	if (ISSET_BIT (far->forwarding_parameters.grp.fields,
+		       FORWARDING_PARAMETERS_BBF_APPLY_ACTION))
+	  {
+	    if (far->forwarding_parameters.bbf_apply_action &
+		BBF_APPLY_ACTION_NAT)
+	      {
+		if (ISSET_BIT (far->forwarding_parameters.grp.fields,
+			       FORWARDING_PARAMETERS_BBF_NAT_PORT_BLOCK))
+		  {
+		    pfcp_bbf_nat_port_block_t pool_name =
+		      vec_dup (far->forwarding_parameters.nat_port_block);
+		    if (handle_nat_binding_creation (sx, pool_name, response))
+		      goto out_error;
+		  }
+	      }
 	  }
 
 	if (ISSET_BIT (far->forwarding_parameters.grp.fields,

--- a/upf/upf_pfcp_api.c
+++ b/upf/upf_pfcp_api.c
@@ -198,7 +198,7 @@ build_ue_ip_address_information (pfcp_ue_ip_address_pool_information_t **
 {
   upf_main_t *gtm = &upf_main;
   upf_nat_pool_t *np;
-  upf_ueip_pool_info_t *ue_p;
+  upf_ue_ip_pool_info_t *ue_p;
 
   vec_alloc (*ue_pool_info, pool_elts (gtm->ueip_pools));
 
@@ -206,6 +206,7 @@ build_ue_ip_address_information (pfcp_ue_ip_address_pool_information_t **
   pool_foreach (ue_p, gtm->ueip_pools,
   ({
     pfcp_ue_ip_address_pool_information_t *ueif;
+
     vec_add2 (*ue_pool_info, ueif, 1);
     ueif->ue_ip_address_pool_identity = vec_dup (ue_p->identity);
     SET_BIT (ueif->grp.fields, UE_IP_ADDRESS_POOL_INFORMATION_POOL_IDENTIFY);
@@ -218,7 +219,9 @@ build_ue_ip_address_information (pfcp_ue_ip_address_pool_information_t **
     ({
       if (!(vec_is_equal (np->network_instance, ue_p->nwi_name)))
 	continue;
+
       pfcp_bbf_nat_port_block_t *block;
+
       vec_add2 (ueif->port_blocks, block, 1);
       *block = vec_dup (np->name);
       SET_BIT (ueif->grp.fields,
@@ -913,41 +916,32 @@ upf_alloc_and_assign_nat_binding (upf_nat_pool_t * np, upf_nat_addr_t * addr,
 				  pfcp_tp_created_binding_t * created_binding)
 {
   u16 port_start, port_end;
-  int err = 0;
-
-  port_start = np->min_port;
-  port_end = port_start + np->port_block_size;
 
   upf_nat_create_binding =
     vlib_get_plugin_symbol ("nat_plugin.so", "nat_create_binding");
 
-  do
+  port_start =
+    upf_nat_create_binding (user_ip, addr->ext_addr, np->min_port,
+			    np->port_block_size, np->vrf_id);
+  if (port_start)
     {
-      err =
-	upf_nat_create_binding (user_ip, addr->ext_addr, port_start, port_end,
-				np->vrf_id);
-      if (!err)
-	{
-	  addr->used_blocks += 1;
-	  sx->nat_addr = addr;
-	  created_binding->block = vec_dup (np->name);
-	  created_binding->outside_addr.as_u32 = addr->ext_addr.as_u32;
-	  created_binding->port_range.start_port = port_start;
-	  created_binding->port_range.end_port = port_end;
-	  SET_BIT (created_binding->grp.fields,
-		   TP_CREATED_BINDING_NAT_PORT_BLOCK);
-	  SET_BIT (created_binding->grp.fields,
-		   TP_CREATED_BINDING_NAT_OUTSIDE_ADDRESS);
-	  SET_BIT (created_binding->grp.fields,
-		   TP_CREATED_BINDING_NAT_EXTERNAL_PORT_RANGE);
-	  return 0;
-	}
-      port_start += np->port_block_size;
       port_end = port_start + np->port_block_size;
+      addr->used_blocks += 1;
+      sx->nat_addr = addr;
+      created_binding->block = vec_dup (np->name);
+      created_binding->outside_addr.as_u32 = addr->ext_addr.as_u32;
+      created_binding->port_range.start_port = port_start;
+      created_binding->port_range.end_port = port_end;
+      SET_BIT (created_binding->grp.fields,
+	       TP_CREATED_BINDING_NAT_PORT_BLOCK);
+      SET_BIT (created_binding->grp.fields,
+	       TP_CREATED_BINDING_NAT_OUTSIDE_ADDRESS);
+      SET_BIT (created_binding->grp.fields,
+	       TP_CREATED_BINDING_NAT_EXTERNAL_PORT_RANGE);
+      return 0;
     }
-  while (port_end < np->max_port);
-  return err;
 
+  return 1;
 }
 
 static int
@@ -1620,21 +1614,19 @@ handle_create_far (upf_session_t * sx, pfcp_create_far_t * create_far,
 
 	  }
 
-	if (ISSET_BIT (far->forwarding_parameters.grp.fields,
-		       FORWARDING_PARAMETERS_BBF_APPLY_ACTION))
+	if ((ISSET_BIT (far->forwarding_parameters.grp.fields,
+			FORWARDING_PARAMETERS_BBF_APPLY_ACTION))
+	    && (far->
+		forwarding_parameters.bbf_apply_action & BBF_APPLY_ACTION_NAT)
+	    &&
+	    (ISSET_BIT
+	     (far->forwarding_parameters.grp.fields,
+	      FORWARDING_PARAMETERS_BBF_NAT_PORT_BLOCK)))
 	  {
-	    if (far->forwarding_parameters.bbf_apply_action &
-		BBF_APPLY_ACTION_NAT)
-	      {
-		if (ISSET_BIT (far->forwarding_parameters.grp.fields,
-			       FORWARDING_PARAMETERS_BBF_NAT_PORT_BLOCK))
-		  {
-		    pfcp_bbf_nat_port_block_t pool_name =
-		      vec_dup (far->forwarding_parameters.nat_port_block);
-		    if (handle_nat_binding_creation (sx, pool_name, response))
-		      goto out_error;
-		  }
-	      }
+	    pfcp_bbf_nat_port_block_t pool_name =
+	      vec_dup (far->forwarding_parameters.nat_port_block);
+	    if (handle_nat_binding_creation (sx, pool_name, response))
+	      goto out_error;
 	  }
 
 	if (ISSET_BIT (far->forwarding_parameters.grp.fields,

--- a/vpp-patches/0015-Controlled-NAT-function.patch
+++ b/vpp-patches/0015-Controlled-NAT-function.patch
@@ -1,4 +1,4 @@
-From a514f7d0b2d03d4f34ad33118fd0e871f2eea537 Mon Sep 17 00:00:00 2001
+From 3bd6d1740501750ba8612169199237c3f2dc235d Mon Sep 17 00:00:00 2001
 From: Sergey Matov <sergey.matov@travelping.com>
 Date: Tue, 18 May 2021 17:07:31 +0400
 Subject: [PATCH] Controlled NAT function
@@ -198,7 +198,7 @@ index 7153a6035..7a7895a72 100644
        /* Add to lookup tables */
        init_ed_kv (&s_kv, s->in2out.addr, 0, ip->dst_address, 0, rx_fib_index,
 diff --git a/src/plugins/nat/nat.c b/src/plugins/nat/nat.c
-index fa62250cb..c3b732085 100644
+index fa62250cb..2e9cd0c6b 100644
 --- a/src/plugins/nat/nat.c
 +++ b/src/plugins/nat/nat.c
 @@ -37,6 +37,13 @@
@@ -417,7 +417,7 @@ index fa62250cb..c3b732085 100644
 +
 +u16
 +nat_create_binding (ip4_address_t user_addr, ip4_address_t ext_addr,
-+		    u16 min_port, u16 block_size, u32 vrf)
++		    u16 min_port, u16 block_size)
 +{
 +  snat_main_t *sm = &snat_main;
 +  snat_main_per_thread_data_t *tsm = &sm->per_thread_data[0];
@@ -461,7 +461,7 @@ index fa62250cb..c3b732085 100644
  nat_ip4_add_del_addr_only_sm_cb (ip4_main_t * im,
  				 uword opaque,
 diff --git a/src/plugins/nat/nat.h b/src/plugins/nat/nat.h
-index 1885ab57d..a66533a55 100644
+index 1885ab57d..ad9e21d7f 100644
 --- a/src/plugins/nat/nat.h
 +++ b/src/plugins/nat/nat.h
 @@ -227,6 +227,16 @@ typedef enum
@@ -553,7 +553,7 @@ index 1885ab57d..a66533a55 100644
 +
 +u16
 +nat_create_binding (ip4_address_t user_addr, ip4_address_t ext_addr,
-+		    u16 min_port, u16 block_size, u32 vrf);
++		    u16 min_port, u16 block_size);
  /**
   * @brief Set address and port assignment algorithm to default/standard
   */

--- a/vpp-patches/0015-Controlled-NAT-function.patch
+++ b/vpp-patches/0015-Controlled-NAT-function.patch
@@ -1,0 +1,705 @@
+From 7658001729b6258d1d1d168d43427e27487a5249 Mon Sep 17 00:00:00 2001
+From: Sergey Matov <sergey.matov@travelping.com>
+Date: Tue, 18 May 2021 17:07:31 +0400
+Subject: [PATCH] Controlled NAT function
+
+Allow to override ED NAT address and port selection in slow path
+by dedicated NAT bindings per user address. Bindings are created via
+UPG plugin and stored in bihash table.
+---
+ src/plugins/nat/in2out_ed.c   | 133 ++++++++++++++++++++-----
+ src/plugins/nat/nat.c         | 177 +++++++++++++++++++++++++++++++++-
+ src/plugins/nat/nat.h         |  43 +++++++++
+ src/plugins/nat/nat44_cli.c   |  72 ++++++++++++++
+ src/plugins/nat/nat_format.c  |  17 ++++
+ src/plugins/nat/nat_inlines.h |  39 ++++++++
+ 6 files changed, 452 insertions(+), 29 deletions(-)
+
+diff --git a/src/plugins/nat/in2out_ed.c b/src/plugins/nat/in2out_ed.c
+index 7153a6035..7a7895a72 100644
+--- a/src/plugins/nat/in2out_ed.c
++++ b/src/plugins/nat/in2out_ed.c
+@@ -196,6 +196,65 @@ icmp_in2out_ed_slow_path (snat_main_t * sm, vlib_buffer_t * b0,
+   return next0;
+ }
+ 
++
++static int
++nat_controlled_alloc_addr_and_port (snat_main_t * sm, u32 rx_fib_index,
++				    u32 nat_proto, u32 thread_index,
++				    ip4_address_t r_addr, u16 r_port,
++				    u8 proto, u16 port_per_thread,
++				    u32 snat_thread_index, snat_session_t * s,
++				    ip4_address_t * outside_addr,
++				    u16 * outside_port,
++				    clib_bihash_kv_16_8_t * out2in_ed_kv)
++{
++  snat_main_per_thread_data_t *tsm = &sm->per_thread_data[thread_index];
++  snat_binding_t *bn;
++  ip4_address_t ext_addr;
++  u16 start_port;
++  u16 end_port;
++  u16 block_size;
++
++  bn = nat_get_binding (tsm, s->in2out.addr);
++
++  if (!bn)
++    {
++      return 1;
++    }
++  start_port = bn->start_port;
++  end_port = bn->end_port;
++  block_size = end_port - start_port;
++  ext_addr.as_u32 = bn->external_addr.as_u32;
++
++  u16 port = clib_net_to_host_u16 (*outside_port);
++  if (port < start_port || port > end_port)
++    port = start_port;
++  u16 attempts = end_port - start_port;
++  do
++    {
++      init_ed_kv (out2in_ed_kv, ext_addr, clib_host_to_net_u16 (port),
++		  r_addr, r_port, s->out2in.fib_index, proto,
++		  thread_index, s - tsm->sessions);
++      int rv = rv =
++	clib_bihash_add_del_16_8 (&sm->out2in_ed, out2in_ed_kv, 2);
++      if (rv == 0)
++	{
++	  outside_addr->as_u32 = ext_addr.as_u32;
++	  *outside_port = clib_host_to_net_u16 (port);
++	  vec_add1 (bn->bound_sessions, s - tsm->sessions);
++	  s->binding = bn;
++	  return 0;
++	}
++      ++port;
++      --attempts;
++    }
++  while (attempts > 0);
++
++  /* Totally out of translations to use... */
++  snat_ipfix_logging_addresses_exhausted (thread_index, 0);
++  return 1;
++}
++
++
+ static int
+ nat_ed_alloc_addr_and_port (snat_main_t * sm, u32 rx_fib_index,
+ 			    u32 nat_proto, u32 thread_index,
+@@ -340,16 +399,16 @@ slow_path_ed (snat_main_t * sm,
+   snat_session_t *s = NULL;
+   lb_nat_type_t lb = 0;
+ 
+-  if (PREDICT_TRUE (nat_proto == NAT_PROTOCOL_TCP))
+-    {
+-      if (PREDICT_FALSE
+-	  (!tcp_flags_is_init
+-	   (vnet_buffer (b)->ip.reass.icmp_type_or_tcp_flags)))
+-	{
+-	  b->error = node->errors[NAT_IN2OUT_ED_ERROR_NON_SYN];
+-	  return NAT_NEXT_DROP;
+-	}
+-    }
++  /*if (PREDICT_TRUE (nat_proto == NAT_PROTOCOL_TCP))
++     {
++     if (PREDICT_FALSE
++     (!tcp_flags_is_init
++     (vnet_buffer (b)->ip.reass.icmp_type_or_tcp_flags)))
++     {
++     b->error = node->errors[NAT_IN2OUT_ED_ERROR_NON_SYN];
++     return NAT_NEXT_DROP;
++     }
++     } */
+ 
+   if (PREDICT_FALSE
+       (nat44_ed_maximum_sessions_exceeded (sm, rx_fib_index, thread_index)))
+@@ -395,12 +454,29 @@ slow_path_ed (snat_main_t * sm,
+ 
+       /* Try to create dynamic translation */
+       outside_port = l_port;	// suggest using local port to allocation function
+-      if (nat_ed_alloc_addr_and_port (sm, rx_fib_index, nat_proto,
+-				      thread_index, r_addr, r_port, proto,
+-				      sm->port_per_thread,
+-				      tsm->snat_thread_index, s,
+-				      &outside_addr,
+-				      &outside_port, &out2in_ed_kv))
++      if (sm->controlled)
++	{
++	  if (nat_controlled_alloc_addr_and_port (sm, rx_fib_index, nat_proto,
++						  thread_index, r_addr,
++						  r_port, proto,
++						  sm->port_per_thread,
++						  tsm->snat_thread_index, s,
++						  &outside_addr,
++						  &outside_port,
++						  &out2in_ed_kv))
++	    {
++	      nat_elog_notice ("addresses exhausted");
++	      b->error = node->errors[NAT_IN2OUT_ED_ERROR_OUT_OF_PORTS];
++	      nat_ed_session_delete (sm, s, thread_index, 1);
++	      return NAT_NEXT_DROP;
++	    }
++	}
++      else if (nat_ed_alloc_addr_and_port (sm, rx_fib_index, nat_proto,
++					   thread_index, r_addr, r_port,
++					   proto, sm->port_per_thread,
++					   tsm->snat_thread_index, s,
++					   &outside_addr, &outside_port,
++					   &out2in_ed_kv))
+ 	{
+ 	  nat_elog_notice ("addresses exhausted");
+ 	  b->error = node->errors[NAT_IN2OUT_ED_ERROR_OUT_OF_PORTS];
+@@ -772,8 +848,9 @@ nat44_ed_in2out_unknown_proto (snat_main_t * sm,
+   ip_csum_t sum;
+   snat_main_per_thread_data_t *tsm = &sm->per_thread_data[thread_index];
+   snat_session_t *s;
++  snat_binding_t *bn;
+   u32 outside_fib_index = sm->outside_fib_index;
+-  int i;
++  ip4_address_t ext_addr;
+   u8 is_sm = 0;
+ 
+   switch (vec_len (sm->outside_fibs))
+@@ -840,17 +917,19 @@ nat44_ed_in2out_unknown_proto (snat_main_t * sm,
+       	      }
+       	  });
+       	  /* *INDENT-ON* */
++	  bn = nat_get_binding (tsm, ip->src_address);
+ 
+-	  for (i = 0; i < vec_len (sm->addresses); i++)
++	  if (!bn)
+ 	    {
+-	      init_ed_k (&s_kv, sm->addresses[i].addr, 0, ip->dst_address, 0,
+-			 outside_fib_index, ip->protocol);
+-	      if (clib_bihash_search_16_8 (&sm->out2in_ed, &s_kv, &s_value))
+-		{
+-		  new_addr = ip->src_address.as_u32 =
+-		    sm->addresses[i].addr.as_u32;
+-		  goto create_ses;
+-		}
++	      return NULL;
++	    }
++	  ext_addr = bn->external_addr;
++	  init_ed_k (&s_kv, ext_addr, 0, ip->dst_address, 0,
++		     outside_fib_index, ip->protocol);
++	  if (clib_bihash_search_16_8 (&sm->out2in_ed, &s_kv, &s_value))
++	    {
++	      new_addr = ip->src_address.as_u32 = ext_addr.as_u32;
++	      goto create_ses;
+ 	    }
+ 	  return 0;
+ 	}
+@@ -874,6 +953,8 @@ nat44_ed_in2out_unknown_proto (snat_main_t * sm,
+       s->in2out.port = s->out2in.port = ip->protocol;
+       if (is_sm)
+ 	s->flags |= SNAT_SESSION_FLAG_STATIC_MAPPING;
++      s->binding = bn;
++      vec_add1 (bn->bound_sessions, s - tsm->sessions);
+ 
+       /* Add to lookup tables */
+       init_ed_kv (&s_kv, s->in2out.addr, 0, ip->dst_address, 0, rx_fib_index,
+diff --git a/src/plugins/nat/nat.c b/src/plugins/nat/nat.c
+index fa62250cb..5d1303097 100644
+--- a/src/plugins/nat/nat.c
++++ b/src/plugins/nat/nat.c
+@@ -37,6 +37,13 @@
+ 
+ #include <vpp/app/version.h>
+ 
++#if CLIB_DEBUG > 1
++#define nat_debug clib_warning
++#else
++#define nat_debug(...)                          \
++  do { } while (0)
++#endif
++
+ snat_main_t snat_main;
+ 
+ fib_source_t nat_fib_src_hi;
+@@ -320,9 +327,13 @@ nat_free_session_data (snat_main_t * sm, snat_session_t * s, u32 thread_index,
+   if (snat_is_session_static (s))
+     return;
+ 
+-  snat_free_outside_address_and_port (sm->addresses, thread_index,
+-				      &s->out2in.addr, s->out2in.port,
+-				      s->nat_proto);
++  s->binding = NULL;
++
++  if (!sm->controlled)
++    snat_free_outside_address_and_port (sm->addresses, thread_index,
++					&s->out2in.addr, s->out2in.port,
++					s->nat_proto);
++
+ }
+ 
+ int
+@@ -2621,10 +2632,14 @@ snat_free_outside_address_and_port (snat_address_t * addresses,
+ 				    ip4_address_t * addr,
+ 				    u16 port, nat_protocol_t protocol)
+ {
++  snat_main_t *sm = &snat_main;
+   snat_address_t *a;
+   u32 address_index;
+   u16 port_host_byte_order = clib_net_to_host_u16 (port);
+ 
++  if (sm->controlled)
++    return;
++
+   for (address_index = 0; address_index < vec_len (addresses);
+        address_index++)
+     {
+@@ -3073,6 +3088,17 @@ nat44_add_del_address_dpo (ip4_address_t addr, u8 is_add)
+     }
+ }
+ 
++u8 *
++format_binding_mapping_kvp (u8 * s, va_list * args)
++{
++  clib_bihash_kv_8_8_t *v = va_arg (*args, clib_bihash_kv_8_8_t *);
++
++  s = format (s, "%U binding-mapping-index %llu",
++	      format_binding_key, v->key, v->value);
++
++  return s;
++}
++
+ u8 *
+ format_session_kvp (u8 * s, va_list * args)
+ {
+@@ -3847,6 +3873,9 @@ nat44_db_init (snat_main_per_thread_data_t * tsm)
+   clib_bihash_init_8_8 (&tsm->user_hash, "users", sm->user_buckets,
+ 			sm->user_memory_size);
+   clib_bihash_set_kvp_format_fn_8_8 (&tsm->user_hash, format_user_kvp);
++
++  mhash_init (&tsm->binding_index_by_ip, sizeof (uword),
++	      sizeof (ip4_address_t));
+ }
+ 
+ void
+@@ -4155,11 +4184,153 @@ snat_config (vlib_main_t * vm, unformat_input_t * input)
+ 					 format_static_mapping_kvp);
+     }
+ 
++  sm->controlled = 0;
++
++  clib_bihash_init_8_8 (&sm->binding_mapping_by_external,
++			"binding_mapping_by_external",
++			sm->translation_buckets, sm->translation_memory_size);
++  clib_bihash_set_kvp_format_fn_8_8 (&sm->binding_mapping_by_external,
++				     format_binding_mapping_kvp);
++
+   return 0;
+ }
+ 
+ VLIB_CONFIG_FUNCTION (snat_config, "nat");
+ 
++snat_binding_t *
++nat_get_binding (snat_main_per_thread_data_t * tsm, ip4_address_t addr)
++{
++  uword *p = NULL;
++  p = mhash_get (&tsm->binding_index_by_ip, &addr);
++  if (!p)
++    return NULL;
++
++  return pool_elt_at_index (tsm->bindings, p[0]);
++}
++
++void
++nat_del_sessions_per_binding (snat_main_per_thread_data_t * tsm,
++			      snat_binding_t * bn)
++{
++  snat_main_t *sm = &snat_main;
++  snat_session_t *ses;
++  u32 *ses_idx = 0;
++  snat_binding_t *this_bn;
++
++  vec_foreach (ses_idx, bn->bound_sessions)
++  {
++    if (pool_is_free_index (tsm->sessions, ses_idx[0]))
++      continue;
++    ses = pool_elt_at_index (tsm->sessions, ses_idx[0]);
++    this_bn = ses->binding;
++    if (!this_bn)
++      return;
++    if ((this_bn->external_addr.as_u32 == bn->external_addr.as_u32)
++	&& (this_bn->framed_addr.as_u32 == bn->framed_addr.as_u32)
++	&& (this_bn->start_port == bn->start_port)
++	&& (this_bn->end_port == bn->end_port))
++      {
++	nat_free_session_data (sm, ses, tsm - sm->per_thread_data, 0);
++	nat_ed_session_delete (sm, ses, tsm - sm->per_thread_data, 1);
++      }
++  }
++
++}
++
++int
++verify_nat_binding (snat_main_per_thread_data_t * tsm, snat_binding_t * bn)
++{
++  snat_main_t *sm = &snat_main;
++
++  clib_bihash_kv_8_8_t kv, value;
++
++
++  init_binding_k (&kv, bn->external_addr, bn->start_port, bn->end_port);
++  if (!clib_bihash_search_8_8 (&sm->binding_mapping_by_external, &kv, &value))
++    {
++      return 1;
++    }
++  return 0;
++}
++
++int
++nat_add_binding (snat_main_per_thread_data_t * tsm, ip4_address_t user_addr,
++		 ip4_address_t ext_addr, u16 start_port, u16 end_port)
++{
++  snat_main_t *sm = &snat_main;
++  snat_binding_t *bn = NULL;
++  clib_bihash_kv_8_8_t kv;
++  uword *p = NULL;
++
++  p = mhash_get (&tsm->binding_index_by_ip, &user_addr);
++  if (p)
++    return 1;
++
++  pool_get (tsm->bindings, bn);
++  memset (bn, 0, sizeof (*bn));
++  bn->framed_addr = user_addr;
++  bn->external_addr = ext_addr;
++  bn->start_port = start_port;
++  bn->end_port = end_port;
++
++  if (verify_nat_binding (tsm, bn))
++    {
++      pool_put (tsm->bindings, bn);
++      return 1;
++    }
++
++  mhash_set (&tsm->binding_index_by_ip, &bn->framed_addr, bn - tsm->bindings,
++	     NULL);
++  init_binding_kv (&kv, bn->external_addr, bn->start_port, bn->end_port,
++		   bn - tsm->bindings);
++  clib_bihash_add_del_8_8 (&sm->binding_mapping_by_external, &kv, 1);
++
++  return 0;
++}
++
++int
++nat_create_binding (ip4_address_t user_addr, ip4_address_t ext_addr,
++		    u16 start, u16 end, u32 vrf)
++{
++  snat_main_t *sm = &snat_main;
++  snat_main_per_thread_data_t *tsm = &sm->per_thread_data[0];
++  int err;
++
++  err = nat_add_binding (tsm, user_addr, ext_addr, start, end);
++  nat_debug ("SMATOV: Created binding");
++  nat_debug ("SMATOV: ext %U start %u end %u", format_ip4_address, &ext_addr,
++	     start, end);
++  return err;
++}
++
++int
++nat_del_binding (ip4_address_t user_addr)
++{
++  snat_main_t *sm = &snat_main;
++  snat_main_per_thread_data_t *tsm;
++  clib_bihash_kv_8_8_t kv;
++  snat_binding_t *bn = NULL;
++  uword *p = NULL;
++
++  vec_foreach (tsm, sm->per_thread_data)
++  {
++    p = mhash_get (&tsm->binding_index_by_ip, &user_addr);
++    if (p)
++      {
++	bn = pool_elt_at_index (tsm->bindings, p[0]);
++	nat_del_sessions_per_binding (tsm, bn);
++	mhash_unset (&tsm->binding_index_by_ip, &bn->framed_addr, NULL);
++	init_binding_k (&kv, bn->external_addr, bn->start_port, bn->end_port);
++	if (clib_bihash_add_del_8_8
++	    (&sm->binding_mapping_by_external, &kv, 0))
++	  nat_debug ("Binding by external key del failed");
++	vec_free (bn->bound_sessions);
++	pool_put (tsm->bindings, bn);
++      }
++  }
++  return 0;
++}
++
+ static void
+ nat_ip4_add_del_addr_only_sm_cb (ip4_main_t * im,
+ 				 uword opaque,
+diff --git a/src/plugins/nat/nat.h b/src/plugins/nat/nat.h
+index 1885ab57d..ebdda3613 100644
+--- a/src/plugins/nat/nat.h
++++ b/src/plugins/nat/nat.h
+@@ -227,6 +227,16 @@ typedef enum
+ #define NAT_STATIC_MAPPING_FLAG_IDENTITY_NAT 4
+ #define NAT_STATIC_MAPPING_FLAG_LB           8
+ 
++typedef struct
++{
++  ip4_address_t framed_addr;
++  ip4_address_t external_addr;
++  u16 start_port;
++  u16 end_port;
++  u16 block_size;
++  u32 *bound_sessions;
++} snat_binding_t;
++
+ /* *INDENT-OFF* */
+ typedef CLIB_PACKED(struct
+ {
+@@ -287,6 +297,9 @@ typedef CLIB_PACKED(struct
+ 
+   /* user index */
+   u32 user_index;
++
++  snat_binding_t *binding;
++
+ }) snat_session_t;
+ /* *INDENT-ON* */
+ 
+@@ -438,6 +451,9 @@ typedef struct
+   u8 *tag;
+ } snat_static_map_resolve_t;
+ 
++#define SNAT_BINDINGS_BUCKETS 524288
++#define SNAT_BINDINGS_MEMORY UINT32_MAX
++
+ typedef struct
+ {
+   /* Main lookup tables */
+@@ -473,6 +489,9 @@ typedef struct
+   /* real thread index */
+   u32 thread_index;
+ 
++  mhash_t binding_index_by_ip;
++  snat_binding_t *bindings;
++
+ } snat_main_per_thread_data_t;
+ 
+ struct snat_main_s;
+@@ -669,6 +688,12 @@ typedef struct snat_main_s
+   ip4_main_t *ip4_main;
+   ip_lookup_main_t *ip4_lookup_main;
+   api_main_t *api_main;
++
++  /* Find a nat binding by external */
++  clib_bihash_8_8_t binding_mapping_by_external;
++
++  u8 controlled;
++
+ } snat_main_t;
+ 
+ typedef struct
+@@ -706,6 +731,7 @@ extern fib_source_t nat_fib_src_hi;
+ extern fib_source_t nat_fib_src_low;
+ 
+ /* format functions */
++format_function_t format_binding_key;
+ format_function_t format_snat_user;
+ format_function_t format_snat_static_mapping;
+ format_function_t format_snat_static_map_to_resolve;
+@@ -1341,6 +1367,23 @@ void nat_set_alloc_addr_and_port_mape (u16 psid, u16 psid_offset,
+  */
+ void nat_set_alloc_addr_and_port_range (u16 start_port, u16 end_port);
+ 
++snat_binding_t *nat_get_binding (snat_main_per_thread_data_t * tsm,
++				 ip4_address_t addr);
++
++void
++nat_del_sessions_per_binding (snat_main_per_thread_data_t * tsm,
++			      snat_binding_t * bn);
++
++int
++nat_add_binding (snat_main_per_thread_data_t * tsm, ip4_address_t user_addr,
++		 ip4_address_t ext_addr, u16 start_port, u16 end_port);
++
++int nat_del_binding (ip4_address_t user_addr);
++
++int
++nat_create_binding (ip4_address_t user_addr, ip4_address_t ext_addr,
++		    u16 start, u16 end, u32 vrf);
++
+ /**
+  * @brief Set address and port assignment algorithm to default/standard
+  */
+diff --git a/src/plugins/nat/nat44_cli.c b/src/plugins/nat/nat44_cli.c
+index 7d74f36c7..20c1cede8 100644
+--- a/src/plugins/nat/nat44_cli.c
++++ b/src/plugins/nat/nat44_cli.c
+@@ -39,6 +39,65 @@
+ #define SUPPORTED_ONLY_IN_DET_MODE_STR \
+   "This command is supported only in deterministic mode"
+ 
++
++static clib_error_t *
++nat44_show_nat_bindings_command_fn (vlib_main_t * vm,
++				    unformat_input_t * input,
++				    vlib_cli_command_t * cmd)
++{
++  snat_main_t *sm = &snat_main;
++  snat_main_per_thread_data_t *tsm = &sm->per_thread_data[0];
++  snat_binding_t *bn;
++
++  {
++    /* *INDENT-OFF* */
++    pool_foreach (bn, tsm->bindings,
++    ({
++      vlib_cli_output (vm, "  FRAMED: %U", format_ip4_address,
++                       &bn->framed_addr);
++      vlib_cli_output (vm, "  EXTERNAL: %U", format_ip4_address,
++                       &bn->external_addr);
++      vlib_cli_output (vm, "  port start %u port end %u\n", bn->start_port,
++                       bn->end_port);
++    }));
++    /* *INDENT-ON* */
++  }
++  return NULL;
++}
++
++static clib_error_t *
++snat_controlled_set_command_fn (vlib_main_t * vm,
++				unformat_input_t * input,
++				vlib_cli_command_t * cmd)
++{
++  snat_main_t *sm = &snat_main;
++  unformat_input_t _line_input, *line_input = &_line_input;
++  clib_error_t *error = 0;
++
++  if (!unformat_user (input, unformat_line_input, line_input))
++    return clib_error_return (0, "'enable' or 'disable' expected");
++
++  while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
++    {
++      if (unformat (line_input, "enable"))
++	{
++	  sm->controlled = 1;
++	}
++      else if (unformat (line_input, "disable"))
++	{
++	  sm->controlled = 0;
++	}
++      else
++	{
++	  error = clib_error_return (0, "unknown input '%U'",
++				     format_unformat_error, line_input);
++	}
++    }
++
++  return error;
++
++}
++
+ static clib_error_t *
+ set_workers_command_fn (vlib_main_t * vm,
+ 			unformat_input_t * input, vlib_cli_command_t * cmd)
+@@ -2893,6 +2952,19 @@ VLIB_CLI_COMMAND (snat_det_close_session_in_command, static) = {
+   .function = snat_det_close_session_in_fn,
+ };
+ 
++VLIB_CLI_COMMAND (snat_controlled_set_command, static) = {
++  .path = "nat44 controlled",
++  .short_help = "nat44 controlled enable|disable",
++  .function = snat_controlled_set_command_fn,
++};
++
++/* *INDENT-OFF* */
++VLIB_CLI_COMMAND (snat_show_nat_bindings_command, static) = {
++  .path = "show nat44 bindings",
++  .short_help = "show nat44 bindings",
++  .function = nat44_show_nat_bindings_command_fn,
++};
++
+ /* *INDENT-ON* */
+ 
+ /*
+diff --git a/src/plugins/nat/nat_format.c b/src/plugins/nat/nat_format.c
+index 8287968e0..645cf9fba 100644
+--- a/src/plugins/nat/nat_format.c
++++ b/src/plugins/nat/nat_format.c
+@@ -73,6 +73,23 @@ format_nat_addr_and_port_alloc_alg (u8 * s, va_list * args)
+   return s;
+ }
+ 
++u8 *
++format_binding_key (u8 * s, va_list * args)
++{
++  u64 key = va_arg (*args, u64);
++
++  ip4_address_t addr;
++  u16 s_port;
++  u16 e_port;
++
++  split_binding_key (key, &addr, &s_port, &e_port);
++
++  s = format (s, "%U start_port %d end_port %d",
++	      format_ip4_address, &addr,
++	      clib_net_to_host_u16 (s_port), clib_net_to_host_u16 (e_port));
++  return s;
++}
++
+ u8 *
+ format_snat_key (u8 * s, va_list * args)
+ {
+diff --git a/src/plugins/nat/nat_inlines.h b/src/plugins/nat/nat_inlines.h
+index 01c866a07..6f78d1493 100644
+--- a/src/plugins/nat/nat_inlines.h
++++ b/src/plugins/nat/nat_inlines.h
+@@ -32,6 +32,12 @@ calc_nat_key (ip4_address_t addr, u16 port, u32 fib_index, u8 proto)
+     (proto & 0x7);
+ }
+ 
++always_inline u64
++calc_binding_key (ip4_address_t addr, u16 sport, u16 eport)
++{
++  return (u64) addr.as_u32 << 32 | (u64) sport << 16 | (u64) eport;
++}
++
+ always_inline void
+ split_nat_key (u64 key, ip4_address_t * addr, u16 * port,
+ 	       u32 * fib_index, nat_protocol_t * proto)
+@@ -54,6 +60,39 @@ split_nat_key (u64 key, ip4_address_t * addr, u16 * port,
+     }
+ }
+ 
++always_inline void
++split_binding_key (u64 key, ip4_address_t * addr, u16 * sport, u16 * eport)
++{
++  if (addr)
++    {
++      addr->as_u32 = key >> 32;
++    }
++  if (sport)
++    {
++      *sport = (key >> 16) & (u16) ~ 0;
++    }
++  if (eport)
++    {
++      *eport = (key & ((1 << 16) - 1));
++    }
++}
++
++always_inline void
++init_binding_k (clib_bihash_kv_8_8_t * kv, ip4_address_t addr, u16 sport,
++		u16 eport)
++{
++  kv->key = calc_binding_key (addr, sport, eport);
++  kv->value = ~0ULL;
++}
++
++always_inline void
++init_binding_kv (clib_bihash_kv_8_8_t * kv, ip4_address_t addr, u16 sport,
++		 u16 eport, u64 value)
++{
++  init_binding_k (kv, addr, sport, eport);
++  kv->value = value;
++}
++
+ always_inline void
+ init_nat_k (clib_bihash_kv_8_8_t * kv, ip4_address_t addr, u16 port,
+ 	    u32 fib_index, nat_protocol_t proto)
+-- 
+2.24.3 (Apple Git-128)
+

--- a/vpp-patches/0015-Controlled-NAT-function.patch
+++ b/vpp-patches/0015-Controlled-NAT-function.patch
@@ -1,4 +1,4 @@
-From 7658001729b6258d1d1d168d43427e27487a5249 Mon Sep 17 00:00:00 2001
+From a514f7d0b2d03d4f34ad33118fd0e871f2eea537 Mon Sep 17 00:00:00 2001
 From: Sergey Matov <sergey.matov@travelping.com>
 Date: Tue, 18 May 2021 17:07:31 +0400
 Subject: [PATCH] Controlled NAT function
@@ -7,13 +7,13 @@ Allow to override ED NAT address and port selection in slow path
 by dedicated NAT bindings per user address. Bindings are created via
 UPG plugin and stored in bihash table.
 ---
- src/plugins/nat/in2out_ed.c   | 133 ++++++++++++++++++++-----
- src/plugins/nat/nat.c         | 177 +++++++++++++++++++++++++++++++++-
- src/plugins/nat/nat.h         |  43 +++++++++
- src/plugins/nat/nat44_cli.c   |  72 ++++++++++++++
- src/plugins/nat/nat_format.c  |  17 ++++
- src/plugins/nat/nat_inlines.h |  39 ++++++++
- 6 files changed, 452 insertions(+), 29 deletions(-)
+ src/plugins/nat/in2out_ed.c   | 133 +++++++++++++++++-----
+ src/plugins/nat/nat.c         | 208 +++++++++++++++++++++++++++++++++-
+ src/plugins/nat/nat.h         |  44 +++++++
+ src/plugins/nat/nat44_cli.c   |  72 ++++++++++++
+ src/plugins/nat/nat_format.c  |  17 +++
+ src/plugins/nat/nat_inlines.h |  39 +++++++
+ 6 files changed, 484 insertions(+), 29 deletions(-)
 
 diff --git a/src/plugins/nat/in2out_ed.c b/src/plugins/nat/in2out_ed.c
 index 7153a6035..7a7895a72 100644
@@ -198,7 +198,7 @@ index 7153a6035..7a7895a72 100644
        /* Add to lookup tables */
        init_ed_kv (&s_kv, s->in2out.addr, 0, ip->dst_address, 0, rx_fib_index,
 diff --git a/src/plugins/nat/nat.c b/src/plugins/nat/nat.c
-index fa62250cb..5d1303097 100644
+index fa62250cb..c3b732085 100644
 --- a/src/plugins/nat/nat.c
 +++ b/src/plugins/nat/nat.c
 @@ -37,6 +37,13 @@
@@ -275,7 +275,7 @@ index fa62250cb..5d1303097 100644
  }
  
  void
-@@ -4155,11 +4184,153 @@ snat_config (vlib_main_t * vm, unformat_input_t * input)
+@@ -4155,11 +4184,184 @@ snat_config (vlib_main_t * vm, unformat_input_t * input)
  					 format_static_mapping_kvp);
      }
  
@@ -348,18 +348,56 @@ index fa62250cb..5d1303097 100644
 +  return 0;
 +}
 +
-+int
++u16
++nat_calc_block (ip4_address_t ext_addr, u16 start_port, u16 block_size)
++{
++  snat_main_t *sm = &snat_main;
++  clib_bihash_kv_8_8_t kv, value;
++  u16 start, end = 0;
++
++  start = start_port;
++  end = start + block_size;
++
++  while (end < NAT_CONTROLLED_MAX_PORT)
++    {
++      init_binding_k (&kv, ext_addr, start, end);
++      if (clib_bihash_search_8_8
++	  (&sm->binding_mapping_by_external, &kv, &value))
++	return start;
++
++      start += block_size;
++      end += block_size;
++    }
++
++  return 0;
++
++}
++
++u16
 +nat_add_binding (snat_main_per_thread_data_t * tsm, ip4_address_t user_addr,
-+		 ip4_address_t ext_addr, u16 start_port, u16 end_port)
++		 ip4_address_t ext_addr, u16 min_port, u16 block_size)
 +{
 +  snat_main_t *sm = &snat_main;
 +  snat_binding_t *bn = NULL;
 +  clib_bihash_kv_8_8_t kv;
++  u16 start_port;
++  u16 end_port;
 +  uword *p = NULL;
 +
 +  p = mhash_get (&tsm->binding_index_by_ip, &user_addr);
 +  if (p)
-+    return 1;
++    return 0;
++
++  start_port = nat_calc_block (ext_addr, min_port, block_size);
++
++  if (!start_port)
++    {
++      nat_debug ("NAT Controlled: Can't find start port for given addr %U",
++		 format_ip4_address, &ext_addr);
++      return 0;
++    }
++
++  end_port = start_port + block_size;
 +
 +  pool_get (tsm->bindings, bn);
 +  memset (bn, 0, sizeof (*bn));
@@ -368,34 +406,27 @@ index fa62250cb..5d1303097 100644
 +  bn->start_port = start_port;
 +  bn->end_port = end_port;
 +
-+  if (verify_nat_binding (tsm, bn))
-+    {
-+      pool_put (tsm->bindings, bn);
-+      return 1;
-+    }
-+
 +  mhash_set (&tsm->binding_index_by_ip, &bn->framed_addr, bn - tsm->bindings,
 +	     NULL);
 +  init_binding_kv (&kv, bn->external_addr, bn->start_port, bn->end_port,
 +		   bn - tsm->bindings);
 +  clib_bihash_add_del_8_8 (&sm->binding_mapping_by_external, &kv, 1);
 +
-+  return 0;
++  return start_port;
 +}
 +
-+int
++u16
 +nat_create_binding (ip4_address_t user_addr, ip4_address_t ext_addr,
-+		    u16 start, u16 end, u32 vrf)
++		    u16 min_port, u16 block_size, u32 vrf)
 +{
 +  snat_main_t *sm = &snat_main;
 +  snat_main_per_thread_data_t *tsm = &sm->per_thread_data[0];
-+  int err;
++  u16 start_block;
 +
-+  err = nat_add_binding (tsm, user_addr, ext_addr, start, end);
-+  nat_debug ("SMATOV: Created binding");
-+  nat_debug ("SMATOV: ext %U start %u end %u", format_ip4_address, &ext_addr,
-+	     start, end);
-+  return err;
++  start_block =
++    nat_add_binding (tsm, user_addr, ext_addr, min_port, block_size);
++
++  return start_block;
 +}
 +
 +int
@@ -430,7 +461,7 @@ index fa62250cb..5d1303097 100644
  nat_ip4_add_del_addr_only_sm_cb (ip4_main_t * im,
  				 uword opaque,
 diff --git a/src/plugins/nat/nat.h b/src/plugins/nat/nat.h
-index 1885ab57d..ebdda3613 100644
+index 1885ab57d..a66533a55 100644
 --- a/src/plugins/nat/nat.h
 +++ b/src/plugins/nat/nat.h
 @@ -227,6 +227,16 @@ typedef enum
@@ -501,27 +532,28 @@ index 1885ab57d..ebdda3613 100644
  format_function_t format_snat_user;
  format_function_t format_snat_static_mapping;
  format_function_t format_snat_static_map_to_resolve;
-@@ -1341,6 +1367,23 @@ void nat_set_alloc_addr_and_port_mape (u16 psid, u16 psid_offset,
+@@ -1341,6 +1367,24 @@ void nat_set_alloc_addr_and_port_mape (u16 psid, u16 psid_offset,
   */
  void nat_set_alloc_addr_and_port_range (u16 start_port, u16 end_port);
  
 +snat_binding_t *nat_get_binding (snat_main_per_thread_data_t * tsm,
 +				 ip4_address_t addr);
 +
++#define NAT_CONTROLLED_MAX_PORT 64000
++
 +void
 +nat_del_sessions_per_binding (snat_main_per_thread_data_t * tsm,
 +			      snat_binding_t * bn);
 +
-+int
++u16
 +nat_add_binding (snat_main_per_thread_data_t * tsm, ip4_address_t user_addr,
-+		 ip4_address_t ext_addr, u16 start_port, u16 end_port);
++		 ip4_address_t ext_addr, u16 min_port, u16 block_size);
 +
 +int nat_del_binding (ip4_address_t user_addr);
 +
-+int
++u16
 +nat_create_binding (ip4_address_t user_addr, ip4_address_t ext_addr,
-+		    u16 start, u16 end, u32 vrf);
-+
++		    u16 min_port, u16 block_size, u32 vrf);
  /**
   * @brief Set address and port assignment algorithm to default/standard
   */


### PR DESCRIPTION
In order to allow UPG perform CG-NAT function following changes has been introduced:
To UPG:

- Ability to allocate and manage NAT Pools
- UE IP Address pool information IE to communicate NAT Pools to SMC
- BBF PFCP IEs to manage NAT Pool lookup and applying NAT to given UE IP
- UPG can manage NAT bindings configured for VPP NAT plugin

To NAT plugin:

- NAT bindings allocation/deletion mechanics exposed to UPG
- Binding lookup via bihash
- Override ED-NAT slow-path address and port allocation in respect to NAT binding created for given user address

This chain includes PFCP formatters fixes.