### PR TITLE
Drop sessions with duplicate UE IP

### DIFF
--- a/test/e2e/framework/sessionconfig.go
+++ b/test/e2e/framework/sessionconfig.go
@@ -38,6 +38,7 @@ type SessionConfig struct {
 	ProxyCoreIP     net.IP
 	ProxyAccessTEID uint32
 	ProxyCoreTEID   uint32
+	NoURRs          bool
 }
 
 const (
@@ -226,28 +227,37 @@ func (cfg SessionConfig) SessionIEs() []*ie.IE {
 	ies := []*ie.IE{
 		cfg.forwardFAR(1),
 		cfg.reverseFAR(2),
-		ie.NewCreateURR(
-			ie.NewURRID(1),
-			ie.NewMeasurementMethod(0, 1, 1), // VOLUM=1 DURAT=1
-			ie.NewReportingTriggers(0)),
-		ie.NewCreateURR(
-			ie.NewURRID(2),
-			ie.NewMeasurementMethod(0, 1, 1), // VOLUM=1 DURAT=1
-			ie.NewReportingTriggers(0)),
+	}
+	if !cfg.NoURRs {
+		ies = append(ies,
+			ie.NewCreateURR(
+				ie.NewURRID(1),
+				ie.NewMeasurementMethod(0, 1, 1), // VOLUM=1 DURAT=1
+				ie.NewReportingTriggers(0)),
+			ie.NewCreateURR(
+				ie.NewURRID(2),
+				ie.NewMeasurementMethod(0, 1, 1), // VOLUM=1 DURAT=1
+				ie.NewReportingTriggers(0)))
 	}
 
 	return append(ies, cfg.CreatePDRs()...)
 }
 
 func (cfg SessionConfig) CreatePDRs() []*ie.IE {
+	defaultURRId := uint32(1)
+	appURRId := uint32(2)
+	if cfg.NoURRs {
+		defaultURRId = 0
+		appURRId = 0
+	}
 	ies := []*ie.IE{
-		cfg.forwardPDR(cfg.IdBase, 1, 1, 200, ""),
-		cfg.reversePDR(cfg.IdBase+1, 2, 1, 200, ""),
+		cfg.forwardPDR(cfg.IdBase, 1, defaultURRId, 200, ""),
+		cfg.reversePDR(cfg.IdBase+1, 2, defaultURRId, 200, ""),
 	}
 	if cfg.AppName != "" {
 		ies = append(ies,
-			cfg.forwardPDR(cfg.IdBase+2, 1, 2, 100, cfg.AppName),
-			cfg.reversePDR(cfg.IdBase+3, 2, 2, 100, cfg.AppName))
+			cfg.forwardPDR(cfg.IdBase+2, 1, appURRId, 100, cfg.AppName),
+			cfg.reversePDR(cfg.IdBase+3, 2, appURRId, 100, cfg.AppName))
 	}
 	return ies
 }

--- a/test/e2e/pfcp/request_queue.go
+++ b/test/e2e/pfcp/request_queue.go
@@ -20,13 +20,20 @@ import (
 	"container/heap"
 	"time"
 
-	"github.com/wmnsk/go-pfcp/message"
+	"github.com/pkg/errors"
 )
 
+var NoMoreRetransmitsErr = errors.New("max number of retransmits reached")
+
+type queueEntry interface {
+	Sequence() uint32
+}
+
 type pendingRequest struct {
-	msg         message.Message
-	nextAttempt time.Time
-	index       int
+	entry        queueEntry
+	nextAttempt  time.Time
+	index        int
+	attemptsLeft int
 }
 
 type requestQueue struct {
@@ -71,40 +78,53 @@ func (rq *requestQueue) Pop() interface{} {
 	return r
 }
 
-func (rq *requestQueue) add(m message.Message, now time.Time) {
-	r := &pendingRequest{
-		msg:         m,
-		nextAttempt: now.Add(rq.timeout),
+func (rq *requestQueue) add(e queueEntry, now time.Time, maxAttempts int) {
+	if e.Sequence() == 0 {
+		panic("can't add an entry with zero sequence number")
 	}
-	rq.bySeq[m.Sequence()] = r
+	if maxAttempts <= 0 {
+		panic("N of attempts must be > 0")
+	}
+	r := &pendingRequest{
+		entry:        e,
+		nextAttempt:  now.Add(rq.timeout),
+		attemptsLeft: maxAttempts - 1,
+	}
+	rq.bySeq[e.Sequence()] = r
 	heap.Push(rq, r)
 }
 
-func (rq *requestQueue) remove(m message.Message) bool {
-	seq := m.Sequence()
+func (rq *requestQueue) remove(e queueEntry) *queueEntry {
+	seq := e.Sequence()
 	r, found := rq.bySeq[seq]
 	if !found {
-		return false
+		return nil
 	}
 	heap.Remove(rq, r.index)
 	delete(rq.bySeq, seq)
-	return true
+	return &r.entry
 }
 
-func (rq *requestQueue) reschedule(m message.Message, now time.Time) {
-	r, found := rq.bySeq[m.Sequence()]
+func (rq *requestQueue) reschedule(e queueEntry, now time.Time) {
+	r, found := rq.bySeq[e.Sequence()]
 	if !found {
-		return
+		panic("rescheduling non-existent message")
 	}
 	r.nextAttempt = now.Add(rq.timeout)
 	heap.Fix(rq, r.index)
 }
 
-func (rq *requestQueue) next() (message.Message, time.Time) {
+func (rq *requestQueue) next() (queueEntry, time.Time) {
 	if rq.Len() == 0 {
+		if len(rq.bySeq) != 0 {
+			panic("bySeq not empty")
+		}
 		return nil, time.Time{}
 	}
-	return rq.rs[0].msg, rq.rs[0].nextAttempt
+	if rq.rs[0].entry == nil {
+		panic("null entry")
+	}
+	return rq.rs[0].entry, rq.rs[0].nextAttempt
 }
 
 func (rq *requestQueue) clear() {

--- a/test/e2e/upg_e2e.go
+++ b/test/e2e/upg_e2e.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pkg/errors"
 	gtpumessage "github.com/wmnsk/go-gtp/gtpv1/message"
 	"github.com/wmnsk/go-pfcp/ie"
+	"github.com/wmnsk/go-pfcp/message"
 
 	"github.com/travelping/upg-vpp/test/e2e/framework"
 	"github.com/travelping/upg-vpp/test/e2e/network"
@@ -588,27 +589,57 @@ var _ = ginkgo.Describe("Multiple PFCP Sessions", func() {
 				UEIP:   f.UEIP(),
 				Mode:   f.Mode,
 			}
-			seid, err := f.PFCP.EstablishSession(f.Context, sessionCfg.SessionIEs()...)
+			reportCh := f.PFCP.AcquireReportCh()
+			seid, err := f.PFCP.EstablishSession(f.Context, 0, sessionCfg.SessionIEs()...)
 			framework.ExpectNoError(err)
 			// with older UPG versions, the duplicate session creation attempts
 			// succeed till some amount of sessions is reached (about 256), after
 			// which it crashes
 			unexpectedSuccess := false
+			var newSEID pfcp.SEID
 			for i := 0; i < 1000; i++ {
-				_, err := f.PFCP.EstablishSession(f.Context, sessionCfg.SessionIEs()...)
+				newSEID = f.PFCP.NewSEID()
+				_, err := f.PFCP.EstablishSession(f.Context, newSEID, sessionCfg.SessionIEs()...)
 				if err == nil {
 					unexpectedSuccess = true
 				} else {
 					var serverErr *pfcp.PFCPServerError
 					gomega.Expect(errors.As(err, &serverErr)).To(gomega.BeTrue())
+					framework.ExpectEqual(newSEID, serverErr.SEID)
 					framework.ExpectEqual(serverErr.Cause, ie.CauseRuleCreationModificationFailure)
+					framework.Logf("Server error (expected): %v", err)
 					// TODO: decode and verify TP error report
 					break
 				}
 
 			}
 			gomega.Expect(unexpectedSuccess).To(gomega.BeFalse(), "EstablishSession succeeded unexpectedly")
-			deleteSession(f, seid, true)
+			var m message.Message
+			gomega.Eventually(reportCh, 10*time.Second, 50*time.Millisecond).Should(gomega.Receive(&m))
+			framework.ExpectEqual(m.MessageType(), message.MsgTypeSessionReportRequest)
+
+			rr := m.(*message.SessionReportRequest)
+			gomega.Expect(rr.ReportType).NotTo(gomega.BeNil())
+			_, err = rr.ReportType.ReportType()
+			framework.ExpectNoError(err)
+			gomega.Expect(rr.ReportType.HasUPIR()).To(gomega.BeFalse())
+			gomega.Expect(rr.ReportType.HasERIR()).To(gomega.BeFalse())
+			gomega.Expect(rr.ReportType.HasUSAR()).To(gomega.BeTrue())
+			gomega.Expect(rr.ReportType.HasDLDR()).To(gomega.BeFalse())
+
+			gomega.Expect(rr.PFCPSRReqFlags).NotTo(gomega.BeNil())
+			gomega.Expect(rr.PFCPSRReqFlags.HasPSDBU()).To(gomega.BeTrue())
+
+			gomega.Expect(rr.UsageReport).To(gomega.HaveLen(2))
+			for _, ur := range rr.UsageReport {
+				urt, err := ur.FindByType(ie.UsageReportTrigger)
+				framework.ExpectNoError(err)
+				gomega.Expect(len(urt.Payload)).To(gomega.BeNumerically(">=", 3))
+				gomega.Expect(urt.Payload[2] & 2).NotTo(gomega.BeZero()) // TEBUR bit is set
+			}
+
+			verifyNoSession(f, seid)
+			verifyNoSession(f, newSEID)
 		})
 
 		ginkgo.It("should not be allowed to conflict on SEIDs", func() {
@@ -617,18 +648,19 @@ var _ = ginkgo.Describe("Multiple PFCP Sessions", func() {
 				UEIP:   f.UEIP(),
 				Mode:   f.Mode,
 			}
-			seid, err := f.PFCP.EstablishSession(f.Context, sessionCfg.SessionIEs()...)
+			seid, err := f.PFCP.EstablishSession(f.Context, 0, sessionCfg.SessionIEs()...)
 			framework.ExpectNoError(err)
 
 			f.PFCP.ForgetSession(seid)
 			sessionCfg.UEIP = f.AddUEIP()
-			ies := append(sessionCfg.SessionIEs(), ie.NewFSEID(uint64(seid), nil, nil, nil))
-			_, err = f.PFCP.EstablishSession(f.Context, ies...)
+			_, err = f.PFCP.EstablishSession(f.Context, seid, sessionCfg.SessionIEs()...)
 			framework.ExpectError(err)
 
 			var serverErr *pfcp.PFCPServerError
 			gomega.Expect(errors.As(err, &serverErr)).To(gomega.BeTrue())
+			gomega.Expect(serverErr.SEID).To(gomega.Equal(seid))
 			framework.ExpectEqual(serverErr.Cause, ie.CauseRequestRejected)
+			framework.Logf("Server error (expected): %v", err)
 			// TODO: decode and verify TP error report
 		})
 	})
@@ -645,7 +677,7 @@ var _ = ginkgo.Describe("Multiple PFCP Sessions", func() {
 				PGWIP:      f.VPPCfg.GetVPPAddress("grx").IP,
 				SGWIP:      f.VPPCfg.GetNamespaceAddress("grx").IP,
 			}
-			seid, err := f.PFCP.EstablishSession(f.Context, sessionCfg.SessionIEs()...)
+			seid, err := f.PFCP.EstablishSession(f.Context, 0, sessionCfg.SessionIEs()...)
 			framework.ExpectNoError(err)
 			defer deleteSession(f, seid, true)
 
@@ -659,13 +691,13 @@ var _ = ginkgo.Describe("Multiple PFCP Sessions", func() {
 				PGWIP:      f.VPPCfg.GetVPPAddress("grx").IP,
 				SGWIP:      f.VPPCfg.GetNamespaceAddress("grx").IP,
 			}
-			_, err = f.PFCP.EstablishSession(f.Context, sessionCfg.SessionIEs()...)
+			_, err = f.PFCP.EstablishSession(f.Context, 0, sessionCfg.SessionIEs()...)
 			var serverErr *pfcp.PFCPServerError
 			gomega.Expect(errors.As(err, &serverErr)).To(gomega.BeTrue())
 			framework.ExpectEqual(serverErr.Cause, ie.CauseRuleCreationModificationFailure)
 
 			sessionCfg.TEIDPGWs5u += 10
-			seid1, err := f.PFCP.EstablishSession(f.Context, sessionCfg.SessionIEs()...)
+			seid1, err := f.PFCP.EstablishSession(f.Context, 0, sessionCfg.SessionIEs()...)
 			framework.ExpectNoError(err)
 			deleteSession(f, seid1, true)
 		})
@@ -753,7 +785,7 @@ func describeGTPProxy(title string, ipMode framework.UPGIPMode) {
 				ProxyCoreIP:     f.VPPCfg.GetVPPAddress("core").IP,
 			}
 			var err error
-			seid, err = f.PFCP.EstablishSession(f.Context, cfg.SessionIEs()...)
+			seid, err = f.PFCP.EstablishSession(f.Context, 0, cfg.SessionIEs()...)
 			framework.ExpectNoError(err)
 		})
 
@@ -818,7 +850,7 @@ func startMeasurementSession(f *framework.Framework, cfg *framework.SessionConfi
 		cfg.PGWIP = f.VPPCfg.GetVPPAddress("grx").IP
 		cfg.SGWIP = f.VPPCfg.GetNamespaceAddress("grx").IP
 	}
-	seid, err := f.PFCP.EstablishSession(f.Context, cfg.SessionIEs()...)
+	seid, err := f.PFCP.EstablishSession(f.Context, 0, cfg.SessionIEs()...)
 	framework.ExpectNoError(err)
 	return seid
 }
@@ -831,6 +863,24 @@ func deleteSession(f *framework.Framework, seid pfcp.SEID, showInfo bool) *pfcp.
 
 	ms, err := f.PFCP.DeleteSession(f.Context, seid)
 	framework.ExpectNoError(err)
+	return ms
+}
+
+func deleteSessions(f *framework.Framework, seids []pfcp.SEID, showInfo bool) []*pfcp.PFCPMeasurement {
+	if showInfo {
+		f.VPP.Ctl("show upf session")
+		f.VPP.Ctl("show upf flows")
+	}
+
+	specs := make([]pfcp.SessionOpSpec, len(seids))
+	for n, seid := range seids {
+		specs[n].SEID = seid
+	}
+
+	ms, errs := f.PFCP.DeleteSessions(f.Context, specs)
+	for _, err := range errs {
+		framework.ExpectNoError(err)
+	}
 	return ms
 }
 
@@ -1072,4 +1122,14 @@ func verifyActiveSessions(f *framework.Framework, expectedSEIDs []pfcp.SEID) {
 		return actualSEIDs[i] < actualSEIDs[j]
 	})
 	framework.ExpectEqual(actualSEIDs, expectedSEIDs, "active sessions")
+}
+
+func verifyNoSession(f *framework.Framework, seid pfcp.SEID) {
+	_, err := f.PFCP.DeleteSession(f.Context, seid)
+	framework.ExpectError(err)
+	var serverErr *pfcp.PFCPServerError
+	gomega.Expect(errors.As(err, &serverErr)).To(gomega.BeTrue())
+	// // 3GPP TS 29.244 Clause 7.2.2.4.2: Conditions for Sending SEID=0 in PFCP Header
+	// framework.ExpectEqual(serverErr.SEID, pfcp.SEID(0))
+	framework.ExpectEqual(serverErr.Cause, ie.CauseSessionContextNotFound)
 }

--- a/test/e2e/upg_e2e.go
+++ b/test/e2e/upg_e2e.go
@@ -583,7 +583,7 @@ var _ = ginkgo.Describe("Multiple PFCP Sessions", func() {
 				"session-related memory leak detected")
 		})
 
-		ginkgo.It("should not be allowed to conflict on UE IPs", func() {
+		ginkgo.It("should not be allowed to conflict on UE IPs and drop the older conflicting session", func() {
 			sessionCfg := &framework.SessionConfig{
 				IdBase: 1,
 				UEIP:   f.UEIP(),
@@ -637,6 +637,53 @@ var _ = ginkgo.Describe("Multiple PFCP Sessions", func() {
 				gomega.Expect(len(urt.Payload)).To(gomega.BeNumerically(">=", 3))
 				gomega.Expect(urt.Payload[2] & 2).NotTo(gomega.BeZero()) // TEBUR bit is set
 			}
+
+			verifyNoSession(f, seid)
+			verifyNoSession(f, newSEID)
+		})
+
+		ginkgo.It("should not be allowed to conflict on UE IPs and drop the older conflicting session [no URRs]", func() {
+			sessionCfg := &framework.SessionConfig{
+				IdBase: 1,
+				UEIP:   f.UEIP(),
+				Mode:   f.Mode,
+				NoURRs: true,
+			}
+			reportCh := f.PFCP.AcquireReportCh()
+			seid, err := f.PFCP.EstablishSession(f.Context, 0, sessionCfg.SessionIEs()...)
+			framework.ExpectNoError(err)
+
+			var newSEID pfcp.SEID
+			newSEID = f.PFCP.NewSEID()
+			_, err = f.PFCP.EstablishSession(f.Context, newSEID, sessionCfg.SessionIEs()...)
+			framework.ExpectError(err)
+
+			var serverErr *pfcp.PFCPServerError
+			gomega.Expect(errors.As(err, &serverErr)).To(gomega.BeTrue())
+			framework.ExpectEqual(newSEID, serverErr.SEID)
+			framework.ExpectEqual(serverErr.Cause, ie.CauseRuleCreationModificationFailure)
+			framework.Logf("Server error (expected): %v", err)
+
+			var m message.Message
+			gomega.Eventually(reportCh, 10*time.Second, 50*time.Millisecond).Should(gomega.Receive(&m))
+			framework.ExpectEqual(m.MessageType(), message.MsgTypeSessionReportRequest)
+
+			rr := m.(*message.SessionReportRequest)
+			gomega.Expect(rr.ReportType).NotTo(gomega.BeNil())
+			_, err = rr.ReportType.ReportType()
+			framework.ExpectNoError(err)
+			gomega.Expect(rr.ReportType.HasUPIR()).To(gomega.BeFalse())
+			gomega.Expect(rr.ReportType.HasERIR()).To(gomega.BeFalse())
+			gomega.Expect(rr.ReportType.HasUSAR()).To(gomega.BeFalse())
+			gomega.Expect(rr.ReportType.HasDLDR()).To(gomega.BeFalse())
+			// FIXME: UISR bit is not yet handled by go-pfcp
+			rt, _ := rr.ReportType.ReportType()
+			gomega.Expect(rt & 0x40).NotTo(gomega.BeZero())
+
+			gomega.Expect(rr.PFCPSRReqFlags).NotTo(gomega.BeNil())
+			gomega.Expect(rr.PFCPSRReqFlags.HasPSDBU()).To(gomega.BeTrue())
+
+			gomega.Expect(rr.UsageReport).To(gomega.HaveLen(0))
 
 			verifyNoSession(f, seid)
 			verifyNoSession(f, newSEID)

--- a/test/e2e/vpp/vpp.go
+++ b/test/e2e/vpp/vpp.go
@@ -579,7 +579,9 @@ func (vi *VPPInstance) Configure() error {
 		}
 	}
 
-	var allCmds []string
+	allCmds := []string{
+		"upf pfcp server set fifo-size 512",
+	}
 	for _, nsCfg := range vi.cfg.Namespaces {
 		allCmds = append(allCmds, vi.interfaceCmds(nsCfg)...)
 	}

--- a/upf/pfcp.c
+++ b/upf/pfcp.c
@@ -1374,10 +1374,11 @@ format_report_type (u8 * s, va_list * args)
 {
   pfcp_report_type_t *v = va_arg (*args, pfcp_report_type_t *);
 
-  return format (s, "DLDR:%d,USAR:%d,ERIR:%d,UPIR:%d,PMIR:%d,SESR:%d",
+  return format (s, "DLDR:%d,USAR:%d,ERIR:%d,UPIR:%d,PMIR:%d,SESR:%d,UISR:%d",
 		 !!(*v & REPORT_TYPE_DLDR), !!(*v & REPORT_TYPE_USAR),
 		 !!(*v & REPORT_TYPE_ERIR), !!(*v & REPORT_TYPE_UPIR),
-		 !!(*v & REPORT_TYPE_PMIR), !!(*v & REPORT_TYPE_SESR));
+		 !!(*v & REPORT_TYPE_PMIR), !!(*v & REPORT_TYPE_SESR),
+		 !!(*v & REPORT_TYPE_UISR));
 }
 
 #define decode_report_type decode_u8_ie

--- a/upf/pfcp.c
+++ b/upf/pfcp.c
@@ -2675,7 +2675,7 @@ free_flow_information (void *p)
   vec_free (v->flow_description);
 }
 
-static u8 *
+u8 *
 format_ue_ip_address (u8 * s, va_list * args)
 {
   pfcp_ue_ip_address_t *v = va_arg (*args, pfcp_ue_ip_address_t *);

--- a/upf/pfcp.h
+++ b/upf/pfcp.h
@@ -323,6 +323,7 @@ typedef u8 pfcp_report_type_t;
 #define REPORT_TYPE_UPIR				BIT(3)
 #define REPORT_TYPE_PMIR				BIT(4)
 #define REPORT_TYPE_SESR				BIT(5)
+#define REPORT_TYPE_UISR				BIT(6)
 
 #define PFCP_IE_OFFENDING_IE				40
 typedef u32 pfcp_offending_ie_t;

--- a/upf/pfcp.h
+++ b/upf/pfcp.h
@@ -2713,6 +2713,7 @@ u8 *format_pfcp_msg_type (u8 * s, va_list * args);
 u8 *format_pfcp_msg_hdr (u8 * s, va_list * args);
 u8 *format_user_plane_ip_resource_information (u8 * s, va_list * args);
 u8 *format_redirect_information (u8 * s, va_list * args);
+u8 *format_ue_ip_address (u8 * s, va_list * args);
 u8 *format_node_id (u8 * s, va_list * args);
 u8 *format_outer_header_creation (u8 * s, va_list * args);
 u8 *format_dmsg (u8 * s, va_list * args);

--- a/upf/test/session_report_request.txt
+++ b/upf/test/session_report_request.txt
@@ -1,5 +1,5 @@
 PFCP: seq 49, Session Report Request (56), SEID: 0x0ffde7210bf94000.
-Report Type: DLDR:0,USAR:1,ERIR:0,UPIR:0,PMIR:0,SESR:0
+Report Type: DLDR:0,USAR:1,ERIR:0,UPIR:0,PMIR:0,SESR:0,UISR:0
 Usage Report SRR
   URR ID: 3
   UR-SEQN: 24

--- a/upf/test/test_upf.py
+++ b/upf/test/test_upf.py
@@ -321,6 +321,7 @@ class IPv6Mixin(object):
     def IP(self):
         return IPv6
 
+global_seq = 1
 
 class PFCPHelper(object):
     """PFCP Helper class"""
@@ -332,7 +333,10 @@ class PFCPHelper(object):
 
     def setUp(self):
         super(PFCPHelper, self).setUp()
-        self.seq = 1
+        # avoid reusing sequence numbers so as not to receive cached responses
+        global global_seq
+        self.seq = global_seq
+        global_seq += 10000
 
     def chat(self, pkt, expectedResponse, seid=None):
         self.logger.info("REQ: %r" % pkt)

--- a/upf/upf_pfcp_api.c
+++ b/upf/upf_pfcp_api.c
@@ -657,28 +657,63 @@ handle_f_teid (upf_session_t * sx, upf_main_t * gtm, pfcp_pdi_t * pdi,
 
 }
 
+/*
+ * Delete session that conflicts on UE IP if it resides
+ * on the same CP node as the new one.
+ */
+static void
+purge_conflicting_session (upf_session_t * sx_old,
+			   upf_session_t * sx_new,
+			   pfcp_ue_ip_address_t * ue_addr)
+{
+  if (sx_old->assoc.node != sx_new->assoc.node)
+    return;
+
+  clib_warning ("UE IP conflict: deleting session CP SEID=0x%016" PRIx64
+		" %U " "due to attempt to create CP SEID=0x%0x16" PRIx64,
+		sx_old->cp_seid, format_ue_ip_address, ue_addr,
+		sx_new->cp_seid);
+
+  upf_pfcp_session_up_deletion_report (sx_old);
+
+  if (pfcp_disable_session (sx_old) != 0)
+    clib_warning ("PFCP Session %" PRIu64 " could no be disabled\n",
+		  sx_old->cp_seid);
+  else
+    pfcp_free_session (sx_old);
+}
+
 static int
-validate_ue_ip (upf_session_t * sx, upf_nwi_t * nwi,
-		pfcp_ue_ip_address_t * ue_addr)
+resolve_ue_ip_conflicts (upf_session_t * sx, upf_nwi_t * nwi,
+			 pfcp_ue_ip_address_t * ue_addr)
 {
   upf_main_t *gtm = &upf_main;
   const dpo_id_t *dpo;
+  int r = 0;
 
   if (ue_addr->flags & IE_UE_IP_ADDRESS_V4)
     {
       dpo = upf_get_session_dpo_ip4 (nwi, &ue_addr->ip4);
       if (dpo && dpo->dpoi_index != sx - gtm->sessions)
-	return -1;
+	{
+	  purge_conflicting_session (gtm->sessions + dpo->dpoi_index, sx,
+				     ue_addr);
+	  r = -1;
+	}
     }
 
   if (ue_addr->flags & IE_UE_IP_ADDRESS_V6)
     {
       dpo = upf_get_session_dpo_ip6 (nwi, &ue_addr->ip6);
       if (dpo && dpo->dpoi_index != sx - gtm->sessions)
-	return -1;
+	{
+	  purge_conflicting_session (gtm->sessions + dpo->dpoi_index, sx,
+				     ue_addr);
+	  r = -1;
+	}
     }
 
-  return 0;
+  return r;
 }
 
 #define pdr_error(r, pdr, fmt, ...)					\
@@ -863,7 +898,7 @@ handle_create_pdr (upf_session_t * sx, pfcp_create_pdr_t * create_pdr,
       }
 
     if ((create->pdi.fields & F_PDI_UE_IP_ADDR) && nwi &&
-	validate_ue_ip (sx, nwi, &create->pdi.ue_addr))
+	resolve_ue_ip_conflicts (sx, nwi, &create->pdi.ue_addr) != 0)
       {
 	pdr_error (response, pdr, "duplicate UE IP");
 	goto out_error;
@@ -1055,7 +1090,7 @@ handle_update_pdr (upf_session_t * sx, pfcp_update_pdr_t * update_pdr,
       }
 
     if ((update->pdi.fields & F_PDI_UE_IP_ADDR) && nwi &&
-	validate_ue_ip (sx, nwi, &update->pdi.ue_addr))
+	resolve_ue_ip_conflicts (sx, nwi, &update->pdi.ue_addr) != 0)
       {
 	pdr_error (response, pdr, "duplicate UE IP");
 	goto out_error;

--- a/upf/upf_pfcp_api.c
+++ b/upf/upf_pfcp_api.c
@@ -2520,7 +2520,6 @@ handle_session_modification_response (pfcp_msg_t * msg,
 static int
 handle_session_deletion_request (pfcp_msg_t * msg, pfcp_decoded_msg_t * dmsg)
 {
-  upf_main_t *gtm = &upf_main;
   pfcp_server_main_t *psm = &pfcp_server_main;
   pfcp_decoded_msg_t resp_dmsg = {
     .type = PFCP_SESSION_DELETION_RESPONSE,
@@ -2553,8 +2552,6 @@ handle_session_deletion_request (pfcp_msg_t * msg, pfcp_decoded_msg_t * dmsg)
 		 dmsg->seid);
       goto out_send_resp;
     }
-
-  upf_pfcp_server_deferred_free_msgs_by_sidx (sess - gtm->sessions);
 
   active = pfcp_get_rules (sess, PFCP_ACTIVE);
   if (vec_len (active->urr) != 0)

--- a/upf/upf_pfcp_server.c
+++ b/upf/upf_pfcp_server.c
@@ -533,12 +533,13 @@ upf_pfcp_session_up_deletion_report (upf_session_t * sx)
 
   memset (req, 0, sizeof (*req));
   SET_BIT (req->grp.fields, SESSION_REPORT_REQUEST_REPORT_TYPE);
-  req->report_type = REPORT_TYPE_USAR;
 
   active = pfcp_get_rules (sx, PFCP_ACTIVE);
   if (vec_len (active->urr) != 0)
     {
       upf_usage_report_t report;
+
+      req->report_type = REPORT_TYPE_USAR;
 
       SET_BIT (req->grp.fields, SESSION_REPORT_REQUEST_USAGE_REPORT);
 
@@ -550,6 +551,8 @@ upf_pfcp_session_up_deletion_report (upf_session_t * sx)
 			      &req->usage_report);
       upf_usage_report_free (&report);
     }
+  else
+    req->report_type = REPORT_TYPE_UISR;
 
   SET_BIT (req->grp.fields, SESSION_REPORT_REQUEST_PFCPSRREQ_FLAGS);
   /* PSDBU = PFCP Session Deleted By the UP function */

--- a/upf/upf_pfcp_server.c
+++ b/upf/upf_pfcp_server.c
@@ -1026,12 +1026,6 @@ void upf_pfcp_server_deferred_free_msgs_by_node (u32 node)
   hash_set (psm->free_msgs_by_node, node, 1);
 }
 
-void upf_pfcp_server_deferred_free_msgs_by_sidx (u32 sidx)
-{
-  pfcp_server_main_t *psm = &pfcp_server_main;
-  hash_set (psm->free_msgs_by_sidx, sidx, 1);
-}
-
 void upf_server_send_heartbeat (u32 node_idx)
 {
   pfcp_server_main_t *psm = &pfcp_server_main;
@@ -1237,8 +1231,7 @@ static uword
 
 	ASSERT (msg->expires_at);
 
-	if (!hash_get (psm->free_msgs_by_node, msg->node) &&
-	    !hash_get (psm->free_msgs_by_sidx, msg->session_index))
+	if (!hash_get (psm->free_msgs_by_node, msg->node))
 	  {
 	    /*
 	     * This should not happen unless a timer didn't fire for some reason
@@ -1264,7 +1257,6 @@ static uword
       vec_reset_length (psm->expired);
       vec_reset_length (event_data);
       hash_free (psm->free_msgs_by_node);
-      hash_free (psm->free_msgs_by_sidx);
 
 #if CLIB_DEBUG > 10
       upf_validate_session_timers ();

--- a/upf/upf_pfcp_server.h
+++ b/upf/upf_pfcp_server.h
@@ -104,7 +104,6 @@ typedef struct
   vlib_main_t *vlib_main;
 
   uword *free_msgs_by_node;
-  uword *free_msgs_by_sidx;
   u32 *expired;
 } pfcp_server_main_t;
 
@@ -135,7 +134,6 @@ void upf_pfcp_session_start_stop_urr_time (u32 si, urr_time_t * t,
 u32 upf_pfcp_server_start_timer (u8 type, u32 id, u32 seconds);
 void upf_pfcp_server_stop_msg_timer (pfcp_msg_t * msg);
 void upf_pfcp_server_deferred_free_msgs_by_node (u32 node);
-void upf_pfcp_server_deferred_free_msgs_by_sidx (u32 sidx);
 
 int upf_pfcp_send_request (upf_session_t * sx, pfcp_decoded_msg_t * dmsg);
 

--- a/upf/upf_pfcp_server.h
+++ b/upf/upf_pfcp_server.h
@@ -139,6 +139,8 @@ int upf_pfcp_send_request (upf_session_t * sx, pfcp_decoded_msg_t * dmsg);
 
 int upf_pfcp_send_response (pfcp_msg_t * req, pfcp_decoded_msg_t * dmsg);
 
+void upf_pfcp_session_up_deletion_report (upf_session_t * sx);
+
 void upf_pfcp_server_session_usage_report (upf_event_urr_data_t * uev);
 
 clib_error_t *pfcp_server_main_init (vlib_main_t * vm);


### PR DESCRIPTION
Drop the conflicting session upon a UE IP conflict, sending
Session Report Request for the dropped session as per
TS 29.244 clause 5.18.2: UP Function Initiated PFCP Session Release
