### PR TITLE
[UPG-NAT] Per pool stats binary API

### DIFF
--- a/upf/upf.api
+++ b/upf/upf.api
@@ -177,3 +177,18 @@ define upf_pfcp_format_reply {
   u32 text_len;
   u8 text[text_len];
 };
+
+define upf_nat_pool_details {
+  u32 context;
+
+  u8 name[64];
+  u8 nwi[64];
+  u16 block_size;
+  u32 max_users;
+  u32 current_users;
+};
+
+define upf_nat_pool_dump {
+  u32 client_index;
+  u32 context;
+};

--- a/upf/upf_test.c
+++ b/upf/upf_test.c
@@ -71,6 +71,7 @@ api_upf_update_app (vat_main_t * vam)
 
 #define vl_api_upf_application_l7_rule_details_t_handler vl_noop_handler
 #define vl_api_upf_applications_details_t_handler vl_noop_handler
+#define vl_api_upf_nat_pool_details_t_handler vl_noop_handler
 
 static int
 api_upf_applications_dump (vat_main_t * vam)
@@ -110,6 +111,12 @@ static void vl_api_upf_pfcp_format_reply_t_handler
   vat_main_t *vam = upf_test_main.vat_main;
 
   fformat (vam->ofp, "retval %d text_len %u\n", mp->retval, mp->text_len);
+}
+
+static int
+api_upf_nat_pool_dump (vat_main_t * vam)
+{
+  return -1;
 }
 
 #include <upf/upf.api_test.c>


### PR DESCRIPTION
Binapi used to claim following statistics per NAT pool:
  - NAT Pool name
  - Network instance name
  - Port Block size
  - Maximum number of bindings
  - Current amount of allocated bindings