### PR TITLE
[Stable] [Backport] [UPG-NAT] Per pool stats binary API

### DIFF
--- a/upf/upf.api
+++ b/upf/upf.api
@@ -149,3 +149,18 @@ define upf_application_l7_rule_dump {
 
   u8 app[64];
 };
+
+define upf_nat_pool_details {
+  u32 context;
+
+  u8 name[64];
+  u8 nwi[64];
+  u16 block_size;
+  u32 max_users;
+  u32 current_users;
+};
+
+define upf_nat_pool_dump {
+  u32 client_index;
+  u32 context;
+};

--- a/upf/upf_api.c
+++ b/upf/upf_api.c
@@ -233,6 +233,69 @@ vl_api_upf_update_app_t_handler (vl_api_upf_update_app_t * mp)
   REPLY_MACRO (VL_API_UPF_UPDATE_APP_REPLY);
 }
 
+static void
+send_upf_nat_pool_details (vl_api_registration_t * reg,
+			   upf_nat_pool_t * np, u32 context)
+{
+  vl_api_upf_nat_pool_details_t *mp;
+  upf_main_t *sm = &upf_main;
+  upf_nat_addr_t *ap;
+  u8 *nwi_name = 0;
+  u32 name_len;
+  u32 max_users = 0;
+  u32 current_users = 0;
+
+  mp = vl_msg_api_alloc (sizeof (*mp));
+  clib_memset (mp, 0, sizeof (*mp));
+
+  mp->_vl_msg_id = htons (VL_API_UPF_NAT_POOL_DETAILS + sm->msg_id_base);
+  mp->context = context;
+
+  name_len = clib_min (vec_len (np->name) + 1, ARRAY_LEN (mp->name));
+  memcpy (mp->name, np->name, name_len - 1);
+  ASSERT (0 == mp->name[name_len - 1]);
+
+  nwi_name = format (nwi_name, "%U", format_dns_labels, np->network_instance);
+  name_len = clib_min (vec_len (nwi_name) + 1, ARRAY_LEN (mp->name));
+  memcpy (mp->nwi, nwi_name, name_len - 1);
+  ASSERT (0 == mp->nwi[name_len - 1]);
+  vec_free (nwi_name);
+
+  max_users = vec_len (np->addresses) * np->max_blocks_per_addr;
+  mp->max_users = htonl (max_users);
+
+  vec_foreach (ap, np->addresses) current_users += ap->used_blocks;
+
+  mp->current_users = htonl (current_users);
+
+  mp->block_size = htons (np->port_block_size);
+
+  vl_api_send_msg (reg, (u8 *) mp);
+}
+
+/* API message handler */
+static void vl_api_upf_nat_pool_dump_t_handler
+  (vl_api_upf_nat_pool_dump_t * mp)
+{
+  upf_main_t *sm = &upf_main;
+  vl_api_registration_t *reg;
+  upf_nat_pool_t *np = NULL;
+
+  reg = vl_api_client_index_to_registration (mp->client_index);
+  if (!reg)
+    {
+      return;
+    }
+
+  /* *INDENT-OFF* */
+  pool_foreach(np, sm->nat_pools,
+    ({
+      send_upf_nat_pool_details (reg, np, mp->context);
+    }));
+  /* *INDENT-ON* */
+
+}
+
 #include <upf/upf.api.c>
 
 static clib_error_t *

--- a/upf/upf_test.c
+++ b/upf/upf_test.c
@@ -71,6 +71,7 @@ api_upf_update_app (vat_main_t * vam)
 
 #define vl_api_upf_application_l7_rule_details_t_handler vl_noop_handler
 #define vl_api_upf_applications_details_t_handler vl_noop_handler
+#define vl_api_upf_nat_pool_details_t_handler vl_noop_handler
 
 static int
 api_upf_applications_dump (vat_main_t * vam)
@@ -80,6 +81,12 @@ api_upf_applications_dump (vat_main_t * vam)
 
 static int
 api_upf_application_l7_rule_dump (vat_main_t * vam)
+{
+  return -1;
+}
+
+static int
+api_upf_nat_pool_dump (vat_main_t * vam)
 {
   return -1;
 }


### PR DESCRIPTION
Binapi used to claim following statistics per NAT pool:
  - NAT Pool name
  - Network instance name
  - Port Block size
  - Maximum number of bindings
  - Current amount of allocated bindings