### PR TITLE
E2E and build improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,11 @@ to enable wrapping the internally run commands in a docker container:
 export UPG_BUILDENV=docker
 ```
 
-It is also possible to use a k8s cluster to run the build container:
+It is also possible to use a k8s cluster to run the build container in a pod:
 ```
 export UPG_BUILDENV=k8s
+# optional: specify the node to run the build pod
+export UPG_BUILDENV_NODE=somenode
 ```
 In this case, the buildenv is run as statefulset inside the cluster.
 It can be removed using

--- a/hack/ci-build.sh
+++ b/hack/ci-build.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set -o errtrace
 
 : ${REGISTRY:=quay.io}
-: ${CONTAINER_IMAGE:=travelping/upg-vpp}
+: ${IMAGE_NAME:=travelping/upg-vpp}
 : ${DOCKERFILE:=}
 : ${BUILDKITD_ADDR:=tcp://buildkitd:1234}
 : ${IMAGE_VARIANT:=debug}

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -71,7 +71,7 @@ if [[ ${E2E_VERBOSE} ]]; then
 fi
 
 if [[ ${E2E_PARALLEL} ]]; then
-  ginkgo_args+=(-stream -nodes "${E2E_PARALLEL_NODES}")
+  ginkgo_args+=(-nodes "${E2E_PARALLEL_NODES}")
 fi
 
 if [[ ${E2E_FOCUS} ]]; then

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -22,6 +22,7 @@ cd "$(dirname "${BASH_SOURCE}")/.."
 : "${E2E_PAUSE_ON_ERROR:=}"
 : "${E2E_MULTICORE:=}"
 : "${E2E_XDP:=}"
+: "${E2E_KEEP_ALL_ARTIFACTS:=}"
 
 if grep -q '^gtp ' /proc/modules; then
   echo >&2 "* Using kernel GTP-U support for IPv4 PGW tests"

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -36,6 +36,7 @@ The make commands accept following variables:
 * `E2E_DISPATCH_TRACE`: store the VPP dispatch trace as `dispatch-trace.pcap` in the test dir
 * `E2E_PAUSE_ON_ERROR`: pause on error for interactive debugging
 * `E2E_MULTICORE`: run tests with a single worker core enabled
+* `E2E_KEEP_ALL_ARTIFACTS`: store artifacts even for successful tests
 
 An example with multiple flags:
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -36,10 +36,11 @@ import (
 )
 
 const (
-	TEIDPGWs5u      = 1000000000
-	TEIDSGWs5u      = 1000000001
-	ProxyAccessTEID = 1000000002
-	ProxyCoreTEID   = 1000000003
+	TEIDPGWs5u          = 1000000000
+	TEIDSGWs5u          = 1000000001
+	ProxyAccessTEID     = 1000000002
+	ProxyCoreTEID       = 1000000003
+	KeepAllArtifactsEnv = "E2E_KEEP_ALL_ARTIFACTS"
 )
 
 var artifactsDir string
@@ -225,7 +226,7 @@ func (f *Framework) AfterEach() {
 	}
 
 	if f.VPPCfg != nil && f.VPPCfg.BaseDir != "" {
-		if artifactsDir != "" && ginkgo.CurrentGinkgoTestDescription().Failed {
+		if needArtifacts() {
 			ExpectNoError(os.MkdirAll(artifactsDir, os.ModePerm))
 			/// XXXXXX: use proper test desc
 			targetDir := filepath.Join(artifactsDir, toFilename(ginkgo.CurrentGinkgoTestDescription().FullTestText))
@@ -316,4 +317,14 @@ func DefaultPFCPConfig(vppCfg vpp.VPPConfig) pfcp.PFCPConfig {
 		CNodeIP: vppCfg.GetNamespaceAddress("cp").IP,
 		NodeID:  "pfcpstub",
 	}
+}
+
+func needArtifacts() bool {
+	if artifactsDir == "" {
+		return false
+	}
+	if os.Getenv(KeepAllArtifactsEnv) != "" {
+		return true
+	}
+	return ginkgo.CurrentGinkgoTestDescription().Failed
 }


### PR DESCRIPTION
* add E2E_KEEP_ALL_ARTIFACTS to keep artifacts for successful e2e
* add optional UPG_BUILDENV_NODE env var for k8s mode buildenv
* e2e: don't use -stream option for Ginkgo
* fix env var name for defaulting in hack/ci-build.sh 
