### PR TITLE
[UPG NAT] Fix output FIB index selection for controlled NAT

### DIFF
--- a/vpp-patches/0015-Controlled-NAT-function.patch
+++ b/vpp-patches/0015-Controlled-NAT-function.patch
@@ -1,4 +1,4 @@
-From 06174d9c37e47d1a6098aeafb8ae64ba0167d43f Mon Sep 17 00:00:00 2001
+From 1366ac45f10a36d9fbf7e5abd449e40c16fd6c7f Mon Sep 17 00:00:00 2001
 From: Sergey Matov <sergey.matov@travelping.com>
 Date: Wed, 31 Mar 2021 15:19:02 +0400
 Subject: [PATCH] Controlled NAT function
@@ -12,16 +12,16 @@ When a packet hits ED slowpath, external address and port are
 picked from dedicated binding. If there is no binding for given
 user address or port range exceeded, packet should be dropped.
 ---
- src/plugins/nat/in2out_ed.c   | 118 +++++++++++++++---
+ src/plugins/nat/in2out_ed.c   | 127 ++++++++++++++++---
  src/plugins/nat/nat.c         | 221 +++++++++++++++++++++++++++++++++-
  src/plugins/nat/nat.h         |  44 +++++++
  src/plugins/nat/nat44_cli.c   |  69 +++++++++++
  src/plugins/nat/nat_format.c  |  17 +++
  src/plugins/nat/nat_inlines.h |  39 ++++++
- 6 files changed, 485 insertions(+), 23 deletions(-)
+ 6 files changed, 493 insertions(+), 24 deletions(-)
 
 diff --git a/src/plugins/nat/in2out_ed.c b/src/plugins/nat/in2out_ed.c
-index 776efdf13..fc91d6f13 100644
+index 776efdf13..50b665f60 100644
 --- a/src/plugins/nat/in2out_ed.c
 +++ b/src/plugins/nat/in2out_ed.c
 @@ -32,7 +32,7 @@
@@ -33,19 +33,19 @@ index 776efdf13..fc91d6f13 100644
  /* number of attempts to get a port for ED overloading algorithm, if rolling
   * a dice this many times doesn't produce a free port, it's treated
   * as if there were no free ports available to conserve resources */
-@@ -195,6 +195,63 @@ icmp_in2out_ed_slow_path (snat_main_t * sm, vlib_buffer_t * b0,
+@@ -195,6 +195,65 @@ icmp_in2out_ed_slow_path (snat_main_t * sm, vlib_buffer_t * b0,
    return next0;
  }
  
 +static int
-+nat_controlled_alloc_addr_and_port (snat_main_t * sm, u32 rx_fib_index,
-+				    u32 nat_proto, u32 thread_index,
-+				    ip4_address_t r_addr, u16 r_port,
-+				    u8 proto, u16 port_per_thread,
++nat_controlled_alloc_addr_and_port (snat_main_t * sm,
++				    u32 thread_index, ip4_address_t r_addr,
++				    u16 r_port, u8 proto,
 +				    u32 snat_thread_index, snat_session_t * s,
 +				    ip4_address_t * outside_addr,
 +				    u16 * outside_port,
-+				    clib_bihash_kv_16_8_t * out2in_ed_kv)
++				    clib_bihash_kv_16_8_t * out2in_ed_kv,
++				    u32 buf_out_fib_index)
 +{
 +  snat_main_per_thread_data_t *tsm = &sm->per_thread_data[thread_index];
 +  snat_binding_t *bn;
@@ -60,6 +60,8 @@ index 776efdf13..fc91d6f13 100644
 +    {
 +      return 1;
 +    }
++
++  s->out2in.fib_index = buf_out_fib_index;
 +  start_port = bn->start_port;
 +  end_port = bn->end_port;
 +  block_size = end_port - start_port;
@@ -97,7 +99,7 @@ index 776efdf13..fc91d6f13 100644
  static int
  nat_ed_alloc_addr_and_port (snat_main_t * sm, u32 rx_fib_index,
  			    u32 nat_proto, u32 thread_index,
-@@ -214,6 +271,7 @@ nat_ed_alloc_addr_and_port (snat_main_t * sm, u32 rx_fib_index,
+@@ -214,6 +273,7 @@ nat_ed_alloc_addr_and_port (snat_main_t * sm, u32 rx_fib_index,
    for (i = 0; i < vec_len (sm->addresses); i++)
      {
        a = sm->addresses + i;
@@ -105,7 +107,12 @@ index 776efdf13..fc91d6f13 100644
        switch (nat_proto)
  	{
  #define _(N, j, n, unused)                                                   \
-@@ -339,7 +397,7 @@ slow_path_ed (snat_main_t * sm,
+@@ -335,11 +395,12 @@ slow_path_ed (snat_main_t * sm,
+   u16 outside_port;
+   u8 identity_nat;
+ 
++  u32 out_fib_index = vnet_buffer (b)->sw_if_index[VLIB_TX];
+   u32 nat_proto = ip_proto_to_nat_proto (proto);
    snat_session_t *s = NULL;
    lb_nat_type_t lb = 0;
  
@@ -114,7 +121,7 @@ index 776efdf13..fc91d6f13 100644
      {
        if (PREDICT_FALSE
  	  (!tcp_flags_is_init
-@@ -348,7 +406,7 @@ slow_path_ed (snat_main_t * sm,
+@@ -348,7 +409,7 @@ slow_path_ed (snat_main_t * sm,
  	  b->error = node->errors[NAT_IN2OUT_ED_ERROR_NON_SYN];
  	  return NAT_NEXT_DROP;
  	}
@@ -123,7 +130,7 @@ index 776efdf13..fc91d6f13 100644
  
    if (PREDICT_FALSE
        (nat44_ed_maximum_sessions_exceeded (sm, rx_fib_index, thread_index)))
-@@ -394,12 +452,29 @@ slow_path_ed (snat_main_t * sm,
+@@ -394,12 +455,28 @@ slow_path_ed (snat_main_t * sm,
  
        /* Try to create dynamic translation */
        outside_port = l_port;	// suggest using local port to allocation function
@@ -135,14 +142,13 @@ index 776efdf13..fc91d6f13 100644
 -				      &outside_port, &out2in_ed_kv))
 +      if (sm->controlled)
 +	{
-+	  if (nat_controlled_alloc_addr_and_port (sm, rx_fib_index, nat_proto,
-+						  thread_index, r_addr,
++	  if (nat_controlled_alloc_addr_and_port (sm, thread_index, r_addr,
 +						  r_port, proto,
-+						  sm->port_per_thread,
 +						  tsm->snat_thread_index, s,
 +						  &outside_addr,
 +						  &outside_port,
-+						  &out2in_ed_kv))
++						  &out2in_ed_kv,
++						  out_fib_index))
 +	    {
 +	      nat_elog_notice ("addresses exhausted");
 +	      b->error = node->errors[NAT_IN2OUT_ED_ERROR_OUT_OF_PORTS];
@@ -159,7 +165,7 @@ index 776efdf13..fc91d6f13 100644
  	{
  	  nat_elog_notice ("addresses exhausted");
  	  b->error = node->errors[NAT_IN2OUT_ED_ERROR_OUT_OF_PORTS];
-@@ -771,8 +846,9 @@ nat44_ed_in2out_unknown_proto (snat_main_t * sm,
+@@ -771,8 +848,9 @@ nat44_ed_in2out_unknown_proto (snat_main_t * sm,
    ip_csum_t sum;
    snat_main_per_thread_data_t *tsm = &sm->per_thread_data[thread_index];
    snat_session_t *s;
@@ -170,7 +176,7 @@ index 776efdf13..fc91d6f13 100644
    u8 is_sm = 0;
  
    switch (vec_len (sm->outside_fibs))
-@@ -839,17 +915,19 @@ nat44_ed_in2out_unknown_proto (snat_main_t * sm,
+@@ -839,17 +917,19 @@ nat44_ed_in2out_unknown_proto (snat_main_t * sm,
        	      }
        	  }
        	  /* *INDENT-ON* */
@@ -199,7 +205,19 @@ index 776efdf13..fc91d6f13 100644
  	    }
  	  return 0;
  	}
-@@ -873,6 +951,8 @@ nat44_ed_in2out_unknown_proto (snat_main_t * sm,
+@@ -867,12 +947,19 @@ nat44_ed_in2out_unknown_proto (snat_main_t * sm,
+       s->flags |= SNAT_SESSION_FLAG_UNKNOWN_PROTO;
+       s->flags |= SNAT_SESSION_FLAG_ENDPOINT_DEPENDENT;
+       s->out2in.addr.as_u32 = new_addr;
+-      s->out2in.fib_index = outside_fib_index;
++
++      if (!bn)
++	s->out2in.fib_index = outside_fib_index;
++      else
++	s->out2in.fib_index = vnet_buffer (b)->sw_if_index[VLIB_TX];
++
+       s->in2out.addr.as_u32 = old_addr;
+       s->in2out.fib_index = rx_fib_index;
        s->in2out.port = s->out2in.port = ip->protocol;
        if (is_sm)
  	s->flags |= SNAT_SESSION_FLAG_STATIC_MAPPING;


### PR DESCRIPTION
For multi-NWI setup, NAT function vanilla mechanism of output FIB selection is not working correctly if controlled NAT function is used. Outisde FIB index can be used based on NWI in which NAT pool has been created.