### PR TITLE
Put association back in pool when released

### DIFF
--- a/test/e2e/upg_e2e.go
+++ b/test/e2e/upg_e2e.go
@@ -523,7 +523,7 @@ var _ = ginkgo.Describe("Clearing message queue", func() {
 				time.Sleep(10 * time.Millisecond)
 			}
 
-			gomega.Eventually(listNodes, 2*time.Minute, 5*time.Second).Should(gomega.Equal("invalid,invalid,invalid"))
+			gomega.Eventually(listNodes, 2*time.Minute, 5*time.Second).Should(gomega.Equal(""))
 
 			ginkgo.By("Waiting for the extra PFCP associations to drop")
 			wg.Wait()

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -437,6 +437,8 @@ pfcp_release_association (upf_node_assoc_t * n)
 
   upf_pfcp_server_deferred_free_msgs_by_node (node_id);
 
+  pool_put (gtm->nodes, n);
+
   vlib_decrement_simple_counter (&gtm->upf_simple_counters[UPF_ASSOC_COUNTER],
 				 vlib_get_thread_index (), 0, 1);
 


### PR DESCRIPTION
If there are heartbeat requests for already released association
been sent from UPG yet another association release will be caused by timer.
So, assoc counter will be decreased twice.
This fix prevents secondary association release.
"show upf association" command won't show "invalid" associations anymore.

Also, fix basic e2e test to compare for an empty string