### PR TITLE
[Proxy] Stitch TCP transport connections regardless to proxy fifos

### DIFF
--- a/upf/flowtable.c
+++ b/upf/flowtable.c
@@ -201,6 +201,16 @@ expire_single_flow (flowtable_main_t * fm, flowtable_main_per_cpu_t * fmt,
 				     [UPF_FLOW_COUNTER],
 				     vlib_get_thread_index (), 0, 1);
 
+      if (f->is_spliced)
+	vlib_decrement_simple_counter (&gtm->upf_simple_counters
+				       [UPF_FLOWS_STITCHED],
+				       vlib_get_thread_index (), 0, 1);
+      if (f->spliced_dirty)
+	vlib_decrement_simple_counter (&gtm->upf_simple_counters
+				       [UPF_FLOWS_STITCHED_DIRTY_FIFOS],
+				       vlib_get_thread_index (), 0, 1);
+
+
       /* free to flow cache && pool (last) */
       flow_entry_free (fm, fmt, f);
       return true;

--- a/upf/flowtable.h
+++ b/upf/flowtable.h
@@ -120,6 +120,7 @@ typedef struct flow_entry
   u8 is_redirect:1;
   u8 is_l3_proxy:1;
   u8 is_spliced:1;
+  u8 spliced_dirty:1;
   u8 dont_splice:1;
   u8 app_detection_done:1;
   u16 tcp_state;

--- a/upf/upf.c
+++ b/upf/upf.c
@@ -519,26 +519,14 @@ upf_init (vlib_main_t * vm)
 
   vec_validate (sm->upf_simple_counters, UPF_N_COUNTERS - 1);
 
-  sm->upf_simple_counters[UPF_ASSOC_COUNTER].name = "total_assoc";
-  sm->upf_simple_counters[UPF_ASSOC_COUNTER].stat_segment_name =
-    "/upf/total_assoc";
-  vlib_validate_simple_counter (&sm->upf_simple_counters
-				[UPF_ASSOC_COUNTER], 0);
-  vlib_zero_simple_counter (&sm->upf_simple_counters[UPF_ASSOC_COUNTER], 0);
-
-  sm->upf_simple_counters[UPF_SESSIONS_COUNTER].name = "total_sessions";
-  sm->upf_simple_counters[UPF_SESSIONS_COUNTER].stat_segment_name =
-    "/upf/total_sessions";
-  vlib_validate_simple_counter (&sm->upf_simple_counters
-				[UPF_SESSIONS_COUNTER], 0);
-  vlib_zero_simple_counter (&sm->upf_simple_counters
-			    [UPF_SESSIONS_COUNTER], 0);
-
-  sm->upf_simple_counters[UPF_FLOW_COUNTER].name = "total_flows";
-  sm->upf_simple_counters[UPF_FLOW_COUNTER].stat_segment_name =
-    "/upf/total_flows";
-
-  sm->node_id.type = NID_FQDN;
+#define _(E,n,p) \
+  sm->upf_simple_counters[UPF_##E].name = #n; \
+  sm->upf_simple_counters[UPF_##E].stat_segment_name = "/" #p "/" #n; \
+  vlib_validate_simple_counter (&sm->upf_simple_counters[UPF_##E], 0); \
+  vlib_zero_simple_counter (&sm->upf_simple_counters[UPF_##E], 0);
+  foreach_upf_counter_name
+#undef _
+    sm->node_id.type = NID_FQDN;
   sm->node_id.fqdn = format (0, (char *) "\x03upg");
 
   sm->nat_pool_index_by_name =

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -497,8 +497,23 @@ typedef enum
   UPF_ASSOC_COUNTER = 0,
   UPF_SESSIONS_COUNTER = 1,
   UPF_FLOW_COUNTER = 2,
-  UPF_N_COUNTERS = 3,
+  UPF_FLOWS_STITCHED = 3,
+  UPF_FLOWS_NOT_STITCHED_MSS_MISMATCH = 4,
+  UPF_FLOWS_NOT_STITCHED_TCP_OPS_TIMESTAMP = 5,
+  UPF_FLOWS_NOT_STITCHED_TCP_OPS_SACK_PERMIT = 6,
+  UPF_FLOWS_STITCHED_DIRTY_FIFOS = 7,
+  UPF_N_COUNTERS = 8,
 } upf_counters_type_t;
+
+#define foreach_upf_counter_name   \
+  _(ASSOC_COUNTER, total_assoc, upf)     \
+  _(SESSIONS_COUNTER, total_sessions, upf)      \
+  _(FLOW_COUNTER, total_flows, upf)             \
+  _(FLOWS_STITCHED, total_stitched, upf)         \
+  _(FLOWS_NOT_STITCHED_MSS_MISMATCH, mss_mismatch, upf) \
+  _(FLOWS_NOT_STITCHED_TCP_OPS_TIMESTAMP, tcp_ops_tstamp, upf) \
+  _(FLOWS_NOT_STITCHED_TCP_OPS_SACK_PERMIT, tcp_ops_sack_permit, upf) \
+  _(FLOWS_STITCHED_DIRTY_FIFOS, stitched_dirty_fifos, upf)
 
 /* TODO: measure if more optimize cache line aware layout
  *       of the counters and quotas has any performance impcat */


### PR DESCRIPTION
Original proxy flow is likely not needed if TCP transport session is
already established.
This commit also adds some amount of metrics to track UPG flows
stitching and number of stitched flows.