### PR TITLE
[Stable][Backport] Fix buildenv startup issue on CI

### DIFF
--- a/hack/buildenv.sh
+++ b/hack/buildenv.sh
@@ -11,7 +11,8 @@ set -o errtrace
 : ${GRAB_ARTIFACTS:=}
 
 if [[ ${GITHUB_RUN_ID:-} ]]; then
-  K8S_ID="${GITHUB_ACTOR}-${GITHUB_JOB}-${GITHUB_RUN_ID}"
+  # avoid overlong pod names (must be <= 63 chars including the -0 suffix)
+  K8S_ID=$(echo "${GITHUB_ACTOR}-${GITHUB_JOB}-${GITHUB_RUN_ID}" | md5sum | awk '{print substr($1,1,16)}')
   if [[ ${K8S_ID_SUFFIX:-} ]]; then
     K8S_ID="${K8S_ID}-${K8S_ID_SUFFIX}"
   fi
@@ -145,7 +146,7 @@ spec:
   selector:
     app: ${name}
 EOF
-  kubectl rollout status statefulset -n "${K8S_NAMESPACE}" "${name}"
+  kubectl rollout status --timeout=5m statefulset -n "${K8S_NAMESPACE}" "${name}"
 }
 
 function k8s_cleanup {


### PR DESCRIPTION
Use shorter devenv StatefulSet names, and, consequently, devenv pod
names.
Add 5m timeout for the devenv StatefulSet rollout.