### PR TITLE
[NAT] Fix NAT-ed for unknown protocol and port block calculation

### DIFF
--- a/vpp-patches/0015-Controlled-NAT-function.patch
+++ b/vpp-patches/0015-Controlled-NAT-function.patch
@@ -1,4 +1,4 @@
-From 1366ac45f10a36d9fbf7e5abd449e40c16fd6c7f Mon Sep 17 00:00:00 2001
+From a84a30b9224d2d104e77bdbbf9177684889f3ecf Mon Sep 17 00:00:00 2001
 From: Sergey Matov <sergey.matov@travelping.com>
 Date: Wed, 31 Mar 2021 15:19:02 +0400
 Subject: [PATCH] Controlled NAT function
@@ -12,16 +12,16 @@ When a packet hits ED slowpath, external address and port are
 picked from dedicated binding. If there is no binding for given
 user address or port range exceeded, packet should be dropped.
 ---
- src/plugins/nat/in2out_ed.c   | 127 ++++++++++++++++---
+ src/plugins/nat/in2out_ed.c   | 145 +++++++++++++++++++---
  src/plugins/nat/nat.c         | 221 +++++++++++++++++++++++++++++++++-
  src/plugins/nat/nat.h         |  44 +++++++
  src/plugins/nat/nat44_cli.c   |  69 +++++++++++
  src/plugins/nat/nat_format.c  |  17 +++
  src/plugins/nat/nat_inlines.h |  39 ++++++
- 6 files changed, 493 insertions(+), 24 deletions(-)
+ 6 files changed, 514 insertions(+), 21 deletions(-)
 
 diff --git a/src/plugins/nat/in2out_ed.c b/src/plugins/nat/in2out_ed.c
-index 776efdf13..50b665f60 100644
+index 776efdf13..0e0f6704c 100644
 --- a/src/plugins/nat/in2out_ed.c
 +++ b/src/plugins/nat/in2out_ed.c
 @@ -32,7 +32,7 @@
@@ -165,7 +165,7 @@ index 776efdf13..50b665f60 100644
  	{
  	  nat_elog_notice ("addresses exhausted");
  	  b->error = node->errors[NAT_IN2OUT_ED_ERROR_OUT_OF_PORTS];
-@@ -771,8 +848,9 @@ nat44_ed_in2out_unknown_proto (snat_main_t * sm,
+@@ -771,9 +848,11 @@ nat44_ed_in2out_unknown_proto (snat_main_t * sm,
    ip_csum_t sum;
    snat_main_per_thread_data_t *tsm = &sm->per_thread_data[thread_index];
    snat_session_t *s;
@@ -174,38 +174,61 @@ index 776efdf13..50b665f60 100644
 -  int i;
 +  ip4_address_t ext_addr;
    u8 is_sm = 0;
++  int i;
  
    switch (vec_len (sm->outside_fibs))
-@@ -839,17 +917,19 @@ nat44_ed_in2out_unknown_proto (snat_main_t * sm,
+     {
+@@ -839,21 +918,43 @@ nat44_ed_in2out_unknown_proto (snat_main_t * sm,
        	      }
        	  }
        	  /* *INDENT-ON* */
-+	  bn = nat_get_binding (tsm, ip->src_address);
- 
+-
 -	  for (i = 0; i < vec_len (sm->addresses); i++)
-+	  if (!bn)
++	  if (sm->controlled)
  	    {
 -	      init_ed_k (&s_kv, sm->addresses[i].addr, 0, ip->dst_address, 0,
--			 outside_fib_index, ip->protocol);
--	      if (clib_bihash_search_16_8 (&sm->out2in_ed, &s_kv, &s_value))
--		{
++	      bn = nat_get_binding (tsm, ip->src_address);
++
++	      if (!bn)
++		{
++		  return NULL;
++		}
++	      ext_addr = bn->external_addr;
++	      init_ed_k (&s_kv, ext_addr, 0, ip->dst_address, 0,
+ 			 outside_fib_index, ip->protocol);
+ 	      if (clib_bihash_search_16_8 (&sm->out2in_ed, &s_kv, &s_value))
+ 		{
 -		  new_addr = ip->src_address.as_u32 =
 -		    sm->addresses[i].addr.as_u32;
--		  goto create_ses;
--		}
-+	      return NULL;
++		  new_addr = ip->src_address.as_u32 = ext_addr.as_u32;
+ 		  goto create_ses;
+ 		}
++	      return 0;
 +	    }
-+	  ext_addr = bn->external_addr;
-+	  init_ed_k (&s_kv, ext_addr, 0, ip->dst_address, 0,
-+		     outside_fib_index, ip->protocol);
-+	  if (clib_bihash_search_16_8 (&sm->out2in_ed, &s_kv, &s_value))
++	  else
 +	    {
-+	      new_addr = ip->src_address.as_u32 = ext_addr.as_u32;
-+	      goto create_ses;
++	      for (i = 0; i < vec_len (sm->addresses); i++)
++		{
++		  init_ed_k (&s_kv, sm->addresses[i].addr, 0, ip->dst_address,
++			     0, outside_fib_index, ip->protocol);
++		  if (clib_bihash_search_16_8
++		      (&sm->out2in_ed, &s_kv, &s_value))
++		    {
++		      new_addr = ip->src_address.as_u32 =
++			sm->addresses[i].addr.as_u32;
++		      goto create_ses;
++		    }
++		}
++	      return 0;
  	    }
- 	  return 0;
+-	  return 0;
  	}
-@@ -867,12 +947,19 @@ nat44_ed_in2out_unknown_proto (snat_main_t * sm,
+ 
++
+     create_ses:
+       s = nat_ed_session_alloc (sm, thread_index, now, ip->protocol);
+       if (!s)
+@@ -867,12 +968,22 @@ nat44_ed_in2out_unknown_proto (snat_main_t * sm,
        s->flags |= SNAT_SESSION_FLAG_UNKNOWN_PROTO;
        s->flags |= SNAT_SESSION_FLAG_ENDPOINT_DEPENDENT;
        s->out2in.addr.as_u32 = new_addr;
@@ -221,13 +244,16 @@ index 776efdf13..50b665f60 100644
        s->in2out.port = s->out2in.port = ip->protocol;
        if (is_sm)
  	s->flags |= SNAT_SESSION_FLAG_STATIC_MAPPING;
-+      s->binding = bn;
-+      vec_add1 (bn->bound_sessions, s - tsm->sessions);
++      if (sm->controlled)
++	{
++	  s->binding = bn;
++	  vec_add1 (bn->bound_sessions, s - tsm->sessions);
++	}
  
        /* Add to lookup tables */
        init_ed_kv (&s_kv, s->in2out.addr, 0, ip->dst_address, 0, rx_fib_index,
 diff --git a/src/plugins/nat/nat.c b/src/plugins/nat/nat.c
-index eeaa443bf..be7da8877 100644
+index eeaa443bf..a5c052244 100644
 --- a/src/plugins/nat/nat.c
 +++ b/src/plugins/nat/nat.c
 @@ -36,6 +36,13 @@
@@ -422,7 +448,7 @@ index eeaa443bf..be7da8877 100644
 +      return 0;
 +    }
 +
-+  end_port = start_port + block_size;
++  end_port = start_port + block_size - 1;
 +
 +  pool_get (tsm->bindings, bn);
 +  memset (bn, 0, sizeof (*bn));


### PR DESCRIPTION
In case on non-controlled NAT appropriate checks should be added
for unknown protocol translation.
Also, fixes issue with incorrect end port calculation for given
block size.