### PR TITLE
Fix forwarding policy handling for the proxy output

### DIFF
--- a/test/e2e/upg_e2e.go
+++ b/test/e2e/upg_e2e.go
@@ -1390,8 +1390,7 @@ func describeRoutingPolicy(f *framework.Framework) {
 			verify(framework.SessionConfig{})
 		})
 
-		// FIXME: disabled due to the TCP output subgraph issues
-		ginkgo.XIt("applies to the proxied traffic", func() {
+		ginkgo.It("applies to the proxied traffic", func() {
 			verify(framework.SessionConfig{AppName: "TST"})
 		})
 	})

--- a/upf/flowtable.h
+++ b/upf/flowtable.h
@@ -276,14 +276,19 @@ parse_packet_protocol (udp_header_t * udp, uword is_reverse, flow_key_t * key)
     }
 }
 
+static inline flow_direction_t
+ip4_packet_is_reverse (ip4_header_t * ip4)
+{
+  return (ip4_address_compare (&ip4->src_address, &ip4->dst_address) < 0) ?
+    FT_REVERSE : FT_ORIGIN;
+}
+
 static inline void
 parse_ip4_packet (ip4_header_t * ip4, uword * is_reverse, flow_key_t * key)
 {
   key->proto = ip4->protocol;
 
-  *is_reverse =
-    (ip4_address_compare (&ip4->src_address, &ip4->dst_address) < 0) ?
-    FT_REVERSE : FT_ORIGIN;
+  *is_reverse = ip4_packet_is_reverse (ip4);
 
   ip46_address_set_ip4 (&key->ip[FT_ORIGIN ^ *is_reverse], &ip4->src_address);
   ip46_address_set_ip4 (&key->ip[FT_REVERSE ^ *is_reverse],
@@ -293,14 +298,19 @@ parse_ip4_packet (ip4_header_t * ip4, uword * is_reverse, flow_key_t * key)
 			 key);
 }
 
+static inline flow_direction_t
+ip6_packet_is_reverse (ip6_header_t * ip6)
+{
+  return (ip6_address_compare (&ip6->src_address, &ip6->dst_address) < 0) ?
+    FT_REVERSE : FT_ORIGIN;
+}
+
 static inline void
 parse_ip6_packet (ip6_header_t * ip6, uword * is_reverse, flow_key_t * key)
 {
   key->proto = ip6->protocol;
 
-  *is_reverse =
-    (ip6_address_compare (&ip6->src_address, &ip6->dst_address) < 0) ?
-    FT_REVERSE : FT_ORIGIN;
+  *is_reverse = ip6_packet_is_reverse (ip6);
 
   ip46_address_set_ip6 (&key->ip[FT_ORIGIN ^ *is_reverse], &ip6->src_address);
   ip46_address_set_ip6 (&key->ip[FT_REVERSE ^ *is_reverse],

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -108,6 +108,7 @@ STRUCT_OFFSET_OF (vnet_buffer_opaque_t, unused)))
 
 #endif
 
+#define BUFFER_FAR_ONLY     (1<<3)	/* don't include in QER/URR processing */
 #define BUFFER_HAS_GTP_HDR  (1<<4)
 #define BUFFER_HAS_UDP_HDR  (1<<5)
 #define BUFFER_HAS_IP4_HDR  (1<<6)

--- a/upf/upf_forward.c
+++ b/upf/upf_forward.c
@@ -259,11 +259,14 @@ upf_forward (vlib_main_t * vm, vlib_node_runtime_t * node,
 #define IS_UL(_pdr, _far)						\
 	  ((_pdr)->pdi.src_intf == SRC_INTF_ACCESS || (_far)->forward.dst_intf == DST_INTF_CORE)
 
-	  upf_debug ("pdr: %d, far: %d\n", pdr->id, far->id);
-	  next = process_qers (vm, sess, active, pdr, b,
-			       IS_DL (pdr, far), IS_UL (pdr, far), next);
-	  next = process_urrs (vm, sess, node_name, active, pdr, b,
-			       IS_DL (pdr, far), IS_UL (pdr, far), next);
+	  if (!(upf_buffer_opaque (b)->gtpu.flags & BUFFER_FAR_ONLY))
+	    {
+	      upf_debug ("pdr: %d, far: %d\n", pdr->id, far->id);
+	      next = process_qers (vm, sess, active, pdr, b,
+				   IS_DL (pdr, far), IS_UL (pdr, far), next);
+	      next = process_urrs (vm, sess, node_name, active, pdr, b,
+				   IS_DL (pdr, far), IS_UL (pdr, far), next);
+	    }
 
 #undef IS_DL
 #undef IS_UL

--- a/upf/upf_proxy.h
+++ b/upf/upf_proxy.h
@@ -20,9 +20,14 @@
 
 #include <vnet/vnet.h>
 #include <vnet/session/application.h>
+#include <vnet/tcp/tcp.h>
 
 extern vlib_node_registration_t upf_ip4_proxy_server_output_node;
 extern vlib_node_registration_t upf_ip6_proxy_server_output_node;
+extern vlib_node_registration_t upf_ip4_proxy_server_no_conn_output_node;
+extern vlib_node_registration_t upf_ip6_proxy_server_no_conn_output_node;
+extern vlib_node_registration_t upf_ip4_proxy_server_far_only_output_node;
+extern vlib_node_registration_t upf_ip6_proxy_server_far_only_output_node;
 
 u8 *format_upf_proxy_session (u8 * s, va_list * args);
 
@@ -62,6 +67,8 @@ typedef struct
 {
   u16 tcp4_server_output_next;
   u16 tcp6_server_output_next;
+  u16 tcp4_server_output_next_active;
+  u16 tcp6_server_output_next_active;
 
   svm_queue_t *vl_input_queue;	/**< vpe input queue */
   /** per-thread vectors */
@@ -146,6 +153,10 @@ proxy_session_lookup_by_index (u32 session_index, u32 thread_index)
     }
   return 0;
 }
+
+tcp_connection_t *upf_tcp_lookup_connection (u32 fib_index, vlib_buffer_t * b,
+					     u8 thread_index, u8 is_ip4,
+					     u8 is_reverse);
 
 #endif
 

--- a/vpp.spec
+++ b/vpp.spec
@@ -1,1 +1,1 @@
-VPP_IMAGE_BASE=registry.cennso.com/upg/vpp-base:21.01.0-21-f69cc6ddc
+VPP_IMAGE_BASE=registry.cennso.com/upg/vpp-base:21.01.0-22-da93a6618


### PR DESCRIPTION
TODO:
- [x] merge https://github.com/travelping/vpp-base/pull/2 and update this PR

This directs all of the TCP connection packets for both active and
passive proxy connections through the UPG subgraph. Care is taken not
do traffic accounting twice on the same packets. This also applies to
RSTs that are sent by the proxy to terminate a particular connection
upon an error. TCP frames not related to a particular connection, such
as RSTs sent in response to late frames after the connection is
already gone, still don't go through the subgraph at the moment, but
fixing that part would be more problematic as it would require flow
lookup without having SEID.

Newer VPP versions (21.10) does not have separate half-open and normal
connection pools and uses `tcp[46]-output` nodes for all of the
connection-related packets, which is followed by the node that can be
specified per-connection, so there will be a possibility to simplify
the approach. At the moment, only the part that adds next node index /
opaque value is backported (travelping/vpp-base#2), and the opaque
value storing the flow id is obtained by looking up the TCP
connection.