### PR TITLE
GTPU Error indication

### DIFF
--- a/upf/test/test_upf.py
+++ b/upf/test/test_upf.py
@@ -1162,6 +1162,47 @@ class TestPGWBase(PFCPHelper):
         if payload is not None:
             self.assertEqual(innerPacket[Raw].load, payload)
 
+    def assert_error_indication_sent_from_upf(self):
+        pkt = self.if_grx.get_capture(1)[0]
+        self.logger.info(pkt.summary())
+        self.logger.info(pkt.show(dump = True))
+        self.assertTrue(GTP_U_Header in pkt)
+        self.assertEqual(pkt[self.IP].src, self.grx_local_ip)
+        self.assertEqual(pkt[self.IP].dst, self.grx_remote_ip)
+        hdr = pkt[GTP_U_Header]
+        self.assertEqual(hdr.version, 1)
+        self.assertTrue(hdr.PT)
+        self.assertTrue(hdr.E)
+        self.assertFalse(hdr.PN)
+        self.assertEqual(hdr.gtp_type, 0x1A) # GTP-U Error Indication
+        self.assertTrue(hdr.S)
+        extHeader = pkt[GTP_UDPPort_ExtensionHeader]
+        self.assertEqual(extHeader.length, 1)
+        self.assertEqual(extHeader.udp_port, 2152)
+        self.assertEqual(extHeader.next_ex, 0)
+        ##TODO: For some reasons, if ExtensionHeader is present in a pkt, scapy can't parse IE_List after extension header
+        ##TODO: while wireshark parses it's perfectly. Check if we can somehow convert Raw into IE_List
+        #errInd = pkt[GTPErrorIndication]
+        #ies = errInd.IE_list
+        #self.logger.info(ies)
+        #iesToCheck = 3 #IE_TEIDI, IE_Recovery, IE_GSNAddress
+        #for ie in ies:
+        #    if (ie.ietype == 14): #recovery
+        #        iesToCheck -= 1
+        #        self.assertEqual(ie.restart_counter, 0)
+        #    if (ie.ietype == 16): #TEID I
+        #        iesToCheck -= 1
+        #        self.assertEqual(ie.TEIDI, teid)
+        #    if (ie.ietype == 133): #IE_GSNAddress
+        #        iesToCheck -= 1
+        #        if self.expected_length == 32: #ipv4
+        #            self.assertEqual(ie.length, 4)
+        #            self.assertEqual(ie.ipv4_address, self.grx_remote_ip)
+        #        else:
+        #            self.assertEqual(ie.length, 16)
+        #            self.assertEqual(ie.ipv6_address, self.grx_remote_ip)
+        #self.assertEqual(iesToCheck, 0) # We met all IEs
+
     def verify_gtp_forwarding(self):
         payload = self.build_from_ue_to_sgi(b"42", remote_ip = self.remote_ip)
         # UE -> remote_ip
@@ -1170,6 +1211,9 @@ class TestPGWBase(PFCPHelper):
         # remote_ip -> UE
         self.send_from_sgi_to_ue(b"4242", remote_ip = self.remote_ip)
         self.assert_packet_sent_to_ue(b"4242", remote_ip = self.remote_ip)
+        # UE-> remote_ip, but no such TEID exists on UPF
+        self.send_from_grx(GTP_U_Header(seq=42, teid=(424242)) / payload)
+        self.assert_error_indication_sent_from_upf()
 
     def verify_gtp_error_indication(self):
         self.send_from_grx(

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -186,9 +186,31 @@ typedef CLIB_PACKED (struct
 #define GTPU_TYPE_END_MARKER  254
 #define GTPU_TYPE_GTPU  255
 
+#define GTPU_UDP_PORT 2152
+
+#define GTPU_EXT_HEADER_UDP_PORT_LENGTH 1
+
+#define GTPU_EXT_HEADER_NEXT_HEADER_NO_MORE 0
+#define GTPU_EXT_HEADER_UDP_PORT 0x40
+
 #define GTPU_IE_RECOVERY 14
+#define GTPU_IE_TEID_I 16
+#define GTPU_IE_GSN_ADDRESS 133
 
 /* *INDENT-OFF* */
+typedef CLIB_PACKED(struct
+{
+  u8 id;
+  u8 data[];
+}) gtpu_tv_ie_t;
+
+typedef CLIB_PACKED(struct
+{
+  u8 id;
+  u16 len;
+  u8 data[];
+}) gtpu_tlv_ie_t;
+
 typedef CLIB_PACKED(struct
 {
   ip4_header_t ip4;            /* 20 bytes */
@@ -1045,6 +1067,9 @@ vnet_upf_nat_pool_add_del (u8 * nwi_name, ip4_address_t start_addr,
 			   u8 is_add);
 
 int vnet_upf_ue_ip_pool_add_del (u8 * identity, u8 * nwi_name, int is_add);
+
+void upf_ip_lookup_tx (u32 bi, int is_ip4);
+void upf_gtpu_error_ind (vlib_buffer_t * b0, int is_ip4);
 
 static_always_inline void
 upf_vnet_buffer_l3_hdr_offset_is_current (vlib_buffer_t * b)

--- a/upf/upf_gtpu_decap.c
+++ b/upf/upf_gtpu_decap.c
@@ -259,6 +259,7 @@ upf_gtpu_input (vlib_main_t * vm,
 		       (&gtm->v4_tunnel_by_key, &kv, &value)))
 		    {
 		      error0 = UPF_GTPU_ERROR_NO_SUCH_TUNNEL;
+		      upf_gtpu_error_ind (b0, is_ip4);
 		      next0 = UPF_GTPU_INPUT_NEXT_DROP;
 		      goto trace0;
 		    }
@@ -297,6 +298,7 @@ upf_gtpu_input (vlib_main_t * vm,
 		       (&gtm->v6_tunnel_by_key, &kv, &value)))
 		    {
 		      error0 = UPF_GTPU_ERROR_NO_SUCH_TUNNEL;
+		      upf_gtpu_error_ind (b0, is_ip4);
 		      next0 = UPF_GTPU_INPUT_NEXT_DROP;
 		      goto trace0;
 		    }
@@ -445,6 +447,7 @@ upf_gtpu_input (vlib_main_t * vm,
 		       (&gtm->v4_tunnel_by_key, &kv, &value)))
 		    {
 		      error1 = UPF_GTPU_ERROR_NO_SUCH_TUNNEL;
+		      upf_gtpu_error_ind (b1, is_ip4);
 		      next1 = UPF_GTPU_INPUT_NEXT_DROP;
 		      goto trace1;
 		    }
@@ -483,6 +486,7 @@ upf_gtpu_input (vlib_main_t * vm,
 		       (&gtm->v6_tunnel_by_key, &kv, &value)))
 		    {
 		      error1 = UPF_GTPU_ERROR_NO_SUCH_TUNNEL;
+		      upf_gtpu_error_ind (b1, is_ip4);
 		      next1 = UPF_GTPU_INPUT_NEXT_DROP;
 		      goto trace1;
 		    }
@@ -683,6 +687,7 @@ upf_gtpu_input (vlib_main_t * vm,
 		       (&gtm->v4_tunnel_by_key, &kv, &value)))
 		    {
 		      error0 = UPF_GTPU_ERROR_NO_SUCH_TUNNEL;
+		      upf_gtpu_error_ind (b0, is_ip4);
 		      next0 = UPF_GTPU_INPUT_NEXT_DROP;
 		      goto trace00;
 		    }
@@ -721,6 +726,7 @@ upf_gtpu_input (vlib_main_t * vm,
 		       (&gtm->v6_tunnel_by_key, &kv, &value)))
 		    {
 		      error0 = UPF_GTPU_ERROR_NO_SUCH_TUNNEL;
+		      upf_gtpu_error_ind (b0, is_ip4);
 		      next0 = UPF_GTPU_INPUT_NEXT_DROP;
 		      goto trace00;
 		    }

--- a/upf/upf_gtpu_encap.c
+++ b/upf/upf_gtpu_encap.c
@@ -57,6 +57,273 @@ typedef enum
   UPF_ENCAP_N_NEXT,
 } upf_encap_next_t;
 
+static u16
+encode_ext_header_udp_port (vlib_buffer_t * b, u16 udp_port)
+{
+  u8 *p = vlib_buffer_get_current (b);
+  gtpu_ext_header_t *hdr = (gtpu_ext_header_t *)p;
+
+  hdr->type = GTPU_EXT_HEADER_UDP_PORT;
+  hdr->len = 1;   /* in 4 byte units */
+  *((u16 *)&hdr->pad) = udp_port; /* already in net order */
+  hdr++;
+
+  hdr->type = GTPU_EXT_HEADER_NEXT_HEADER_NO_MORE;
+  b->current_length = sizeof (*hdr) + sizeof (hdr->type);
+
+  return b->current_length;
+}
+
+static u16
+encode_error_indication (vlib_buffer_t * b, gtp_error_ind_t * error, int is_ip4)
+{
+  u8 *p = vlib_buffer_get_current (b);
+  u8 *start = vlib_buffer_get_current (b);
+  u16 ip_length, nlength;
+
+  gtpu_tv_ie_t *tv_ie;
+  gtpu_tlv_ie_t *tlv_ie;
+
+  tv_ie = (gtpu_tv_ie_t *)p;
+  tv_ie->id = GTPU_IE_TEID_I;
+  *((u32 *)&tv_ie->data) = error->teid;
+  p += sizeof(*tv_ie) + sizeof (u32);
+
+  tv_ie = (gtpu_tv_ie_t *)p;
+  tv_ie->id = GTPU_IE_RECOVERY;
+  *((u8 *)&tv_ie->data) = 0;
+  p += sizeof(*tv_ie) + sizeof (u8);
+
+  tlv_ie = (gtpu_tlv_ie_t *)p;
+  tlv_ie->id = GTPU_IE_GSN_ADDRESS;
+  if (is_ip4)
+    {
+      tlv_ie->len = clib_host_to_net_u16(sizeof (ip4_address_t));
+      clib_memcpy_fast (&tlv_ie->data, &error->addr.ip4, sizeof (ip4_address_t));
+    }
+  else
+    {
+      tlv_ie->len = clib_host_to_net_u16(sizeof (ip6_address_t));
+      clib_memcpy_fast (&tlv_ie->data, &error->addr.ip6, sizeof (ip6_address_t));
+    }
+
+  p += sizeof(*tlv_ie) + clib_net_to_host_u16 (tlv_ie->len);
+  b->current_length = p - start;
+
+  return b->current_length; //bytes encoded
+}
+
+void
+upf_gtpu_error_ind (vlib_buffer_t * b0, int is_ip4)
+{
+  ip4_main_t *i4m = &ip4_main;
+  ip6_main_t *i6m = &ip6_main;
+  upf_main_t *gtm = &upf_main;
+  vlib_main_t *vm = gtm->vlib_main;
+  u32 bi = 0;
+  gtp_error_ind_t error;
+  vlib_buffer_t *p0;
+  u16 len_p1, new_len1, new_ip_len1;
+  ip_csum_t sum1;
+  u32 fib_index1;
+  u16 gtp_len_encoded;
+  u16 ext_header_len;
+  u8 host_config_ttl = i4m->host_config.ttl;
+
+  if (vlib_buffer_alloc (vm, &bi, 1) != 1)
+    {
+      clib_warning ("No buffers available");
+      return;
+    }
+
+  p0 = vlib_get_buffer (vm, bi);
+  VLIB_BUFFER_TRACE_TRAJECTORY_INIT (p0);
+
+  /*
+   * b0 - received buffer, p0 - allocated buffer
+   * xxx0 header pointers used for b0
+   * xxx1 header pointers used for p1
+   */
+
+  if (is_ip4)
+    {
+      ip4_header_t *ip40, *ip41;
+      udp_header_t *udp0, *udp1;
+      gtpu_header_t *gtpu0, *gtpu1;
+
+      /* For ip46-lookup, set up FIB */
+      fib_index1 = vec_elt (i4m->fib_index_by_sw_if_index,
+			    vnet_buffer (b0)->sw_if_index[VLIB_RX]);
+      vnet_buffer (p0)->sw_if_index[VLIB_TX] = fib_index1;
+
+      /* Set buffer borders to include headers for now */
+      p0->current_length += sizeof (ip4_header_t) + sizeof (udp_header_t) + sizeof (gtpu_header_t);
+
+      vlib_buffer_reset (b0);
+      vlib_buffer_advance (b0, vnet_buffer (b0)->l4_hdr_offset);
+      gtpu0 = vlib_buffer_get_current (b0);
+
+      vlib_buffer_advance (b0, -(uword) (sizeof (ip4_header_t) + sizeof (udp_header_t)));
+      ip40 = vlib_buffer_get_current (b0);
+
+      udp0 = ip4_next_header (ip40);
+
+      ip41 = vlib_buffer_get_current (p0);
+      vlib_buffer_advance (p0, sizeof (ip4_header_t));
+      udp1 = vlib_buffer_get_current (p0);
+      vlib_buffer_advance (p0, sizeof (udp_header_t));
+      gtpu1 = vlib_buffer_get_current (p0);
+      // TODO: In a packet trace it looks fine, we can see p0 traced for TX
+      // But shouldn't we allocate new trace for it?
+      p0->trace_handle = b0->trace_handle;
+
+      /* Reuse IP settings of original packet */
+      memcpy (ip41, ip40, sizeof (ip4_header_t));
+
+      /* Swap addresses, save src addr to be encoded */
+      ip41->dst_address = ip40->src_address;
+      ip41->src_address = ip40->dst_address;
+      error.addr.ip4 = ip40->src_address;
+
+      /* Swap udp ports */
+      udp1->src_port = udp0->dst_port;
+      udp1->dst_port = clib_host_to_net_u16 (GTPU_UDP_PORT);
+
+      /* Fill GTPU info */
+      gtpu1->ver_flags = GTPU_V1_VER | GTPU_PT_GTP | GTPU_S_BIT | GTPU_E_BIT;
+      gtpu1->type = GTPU_TYPE_ERROR_IND;
+      gtpu1->sequence = 0;
+      gtpu1->teid = 0;
+      error.teid = gtpu0->teid; // Net order
+
+      /* Set pointer behind GTPU header to encode ext header UDP port */
+      gtp_len_encoded = sizeof (gtpu_header_t) - sizeof (gtpu1->next_ext_type);
+      vlib_buffer_advance (p0, gtp_len_encoded);
+      ext_header_len = encode_ext_header_udp_port (p0, udp0->src_port);
+
+      /* Set pointer behind GTPU ext header to encode IEs */
+      vlib_buffer_advance (p0, ext_header_len);
+      len_p1 = encode_error_indication (p0, &error, is_ip4);
+      /* GTPU mandatory fields are 8 bytes and are not included into payload */
+      gtpu1->length = clib_host_to_net_u16 (len_p1 + (ext_header_len - 1) + (sizeof (gtpu_header_t) - 8));
+
+      /* Calculate new IP length. */
+      new_len1 = ip4_header_bytes (ip41) + sizeof (udp_header_t) +
+		 gtp_len_encoded + ext_header_len + len_p1;
+
+      /* Update IP header fields and checksum. */
+      sum1 = ip41->checksum;
+
+      sum1 = ip_csum_update (sum1, ip41->ttl, host_config_ttl,
+			     ip4_header_t, ttl);
+      ip41->ttl = host_config_ttl;
+
+      new_ip_len1 = clib_host_to_net_u16 (new_len1);
+      sum1 = ip_csum_update (sum1, ip41->length, new_ip_len1,
+			     ip4_header_t, length);
+      ip41->length = new_ip_len1;
+      ip41->checksum = ip_csum_fold (sum1);
+      ip41->fragment_id = clib_net_to_host_u16 (1);
+
+      /* UDP length. */
+      udp1->length = clib_host_to_net_u16 (sizeof (udp_header_t) +
+					   gtp_len_encoded +
+					   len_p1 + ext_header_len);
+      /* UDP checksum. */
+      udp1->checksum = 0;
+      udp1->checksum = ip4_tcp_udp_compute_checksum (vm, p0, ip41);
+      if (udp1->checksum == 0)
+        udp1->checksum = 0xffff;
+
+      p0->flags |= VNET_BUFFER_F_LOCALLY_ORIGINATED;
+      p0->flags |= VLIB_BUFFER_IS_TRACED;
+
+      vlib_buffer_advance (p0, -(uword) (sizeof (ip4_header_t) + sizeof (udp_header_t) + gtp_len_encoded + ext_header_len));
+
+      /* Enqueue to IP Lookup */
+      upf_ip_lookup_tx (bi, is_ip4);
+    }
+  else
+    {
+      ip6_header_t *ip60, *ip61;
+      udp_header_t *udp0, *udp1;
+      gtpu_header_t *gtpu0, *gtpu1;
+      int bogus = 0;
+
+      /* For ip46-lookup, set up FIB */
+      fib_index1 = vec_elt (i6m->fib_index_by_sw_if_index,
+                                vnet_buffer (b0)->sw_if_index[VLIB_RX]);
+      vnet_buffer (p0)->sw_if_index[VLIB_TX] = fib_index1;
+
+      /* Set buffer borders to include headers for now */
+      p0->current_length += sizeof (ip6_header_t) + sizeof (udp_header_t) + sizeof (gtpu_header_t);
+
+      vlib_buffer_reset (b0);
+      vlib_buffer_advance (b0, vnet_buffer (b0)->l4_hdr_offset);
+      gtpu0 = vlib_buffer_get_current (b0);
+
+      vlib_buffer_advance (b0, -(uword) (sizeof (ip6_header_t) + sizeof (udp_header_t)));
+      ip60 = vlib_buffer_get_current (b0);
+
+      udp0 = ip6_next_header (ip60);
+
+      ip61 = vlib_buffer_get_current (p0);
+      vlib_buffer_advance (p0, sizeof (ip6_header_t));
+      udp1 = vlib_buffer_get_current (p0);
+      vlib_buffer_advance (p0, sizeof (udp_header_t));
+      gtpu1 = vlib_buffer_get_current (p0);
+      p0->trace_handle = b0->trace_handle;
+
+      /* Reuse IP settings of original packet */
+      memcpy (ip61, ip60, sizeof (ip6_header_t));
+
+      /* Swap addresses, save src addr to be encoded */
+      ip61->dst_address = ip60->src_address;
+      ip61->src_address = ip60->dst_address;
+      error.addr.ip6 = ip60->src_address;
+
+      /* Swap udp ports*/
+      udp1->src_port = udp0->dst_port;
+      udp1->dst_port = clib_host_to_net_u16 (GTPU_UDP_PORT);
+
+      /* Fill GTPU info */
+      gtpu1->ver_flags = GTPU_V1_VER | GTPU_PT_GTP | GTPU_S_BIT | GTPU_E_BIT;
+      gtpu1->type = GTPU_TYPE_ERROR_IND;
+      gtpu1->sequence = 0;
+      error.teid = gtpu0->teid; // Net order
+
+      /* Set pointer behind GTPU header to encode ext header UDP port */
+      gtp_len_encoded = sizeof (gtpu_header_t) - sizeof (gtpu1->next_ext_type);
+      vlib_buffer_advance (p0, gtp_len_encoded);
+      ext_header_len = encode_ext_header_udp_port (p0, udp0->src_port);
+
+      /* Set pointer behind GTPU ext header to encode IEs */
+      vlib_buffer_advance (p0, ext_header_len);
+      len_p1 = encode_error_indication (p0, &error, is_ip4);
+      gtpu1->length = clib_host_to_net_u16 (len_p1 + (ext_header_len - 1) + (sizeof (gtpu_header_t) - 8));
+
+      // Update checksums and length params for IP and UDP
+      /* Calculate new IP length. */
+      new_len1 = sizeof (udp_header_t) + gtp_len_encoded + len_p1 + ext_header_len;
+      ip61->payload_length = clib_host_to_net_u16 (new_len1);
+      /* UDP length. */
+      udp1->length = ip61->payload_length;
+      /* UDP checksum. */
+      udp1->checksum = 0;
+      udp1->checksum = ip6_tcp_udp_icmp_compute_checksum (vm, p0, ip61, &bogus);
+      if (udp1->checksum == 0)
+        udp1->checksum = 0xffff;
+
+      p0->flags |= VNET_BUFFER_F_LOCALLY_ORIGINATED;
+      p0->flags |= VLIB_BUFFER_IS_TRACED;
+
+      vlib_buffer_advance (p0, -(uword) (sizeof (ip6_header_t) + sizeof (udp_header_t) + gtp_len_encoded + ext_header_len));
+
+      /* Enqueue to IP Lookup */
+      upf_ip_lookup_tx (bi, is_ip4);
+    }
+}
+
 #ifndef CLIB_MARCH_VARIANT
 u32
 upf_gtpu_end_marker (u32 fib_index, u32 dpoi_index, u8 * rewrite, int is_ip4)

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -1764,7 +1764,7 @@ build_urr_link_map (upf_session_t * sx)
   }
 }
 
-static void
+void
 upf_ip_lookup_tx (u32 bi, int is_ip4)
 {
   vlib_main_t *vm = vlib_get_main ();


### PR DESCRIPTION
When UPG receives a G-PDU for which no corresponding GTP-U tunnel
exists, it must discard the G-PDU and return a GTP-U Error Indication
to the sending node.
Integration test helps to capture and verify error indication packet and it's IEs.