### PR TITLE
[Stable][Backport]GTPU Error indication

### DIFF
--- a/upf/upf.h
+++ b/upf/upf.h
@@ -185,9 +185,31 @@ typedef CLIB_PACKED (struct
 #define GTPU_TYPE_END_MARKER  254
 #define GTPU_TYPE_GTPU  255
 
+#define GTPU_UDP_PORT 2152
+
+#define GTPU_EXT_HEADER_UDP_PORT_LENGTH 1
+
+#define GTPU_EXT_HEADER_NEXT_HEADER_NO_MORE 0
+#define GTPU_EXT_HEADER_UDP_PORT 0x40
+
 #define GTPU_IE_RECOVERY 14
+#define GTPU_IE_TEID_I 16
+#define GTPU_IE_GSN_ADDRESS 133
 
 /* *INDENT-OFF* */
+typedef CLIB_PACKED(struct
+{
+  u8 id;
+  u8 data[];
+}) gtpu_tv_ie_t;
+
+typedef CLIB_PACKED(struct
+{
+  u8 id;
+  u16 len;
+  u8 data[];
+}) gtpu_tlv_ie_t;
+
 typedef CLIB_PACKED(struct
 {
   ip4_header_t ip4;            /* 20 bytes */
@@ -992,6 +1014,9 @@ vnet_upf_nat_pool_add_del (u8 * nwi_name, ip4_address_t start_addr,
 			   u8 is_add);
 
 int vnet_upf_ue_ip_pool_add_del (u8 * identity, u8 * nwi_name, int is_add);
+
+void upf_ip_lookup_tx (u32 bi, int is_ip4);
+void upf_gtpu_error_ind (vlib_buffer_t * b0, int is_ip4);
 
 static_always_inline void
 upf_vnet_buffer_l3_hdr_offset_is_current (vlib_buffer_t * b)

--- a/upf/upf_gtpu_decap.c
+++ b/upf/upf_gtpu_decap.c
@@ -259,6 +259,7 @@ upf_gtpu_input (vlib_main_t * vm,
 		       (&gtm->v4_tunnel_by_key, &kv, &value)))
 		    {
 		      error0 = UPF_GTPU_ERROR_NO_SUCH_TUNNEL;
+		      upf_gtpu_error_ind (b0, is_ip4);
 		      next0 = UPF_GTPU_INPUT_NEXT_DROP;
 		      goto trace0;
 		    }
@@ -297,6 +298,7 @@ upf_gtpu_input (vlib_main_t * vm,
 		       (&gtm->v6_tunnel_by_key, &kv, &value)))
 		    {
 		      error0 = UPF_GTPU_ERROR_NO_SUCH_TUNNEL;
+		      upf_gtpu_error_ind (b0, is_ip4);
 		      next0 = UPF_GTPU_INPUT_NEXT_DROP;
 		      goto trace0;
 		    }
@@ -445,6 +447,7 @@ upf_gtpu_input (vlib_main_t * vm,
 		       (&gtm->v4_tunnel_by_key, &kv, &value)))
 		    {
 		      error1 = UPF_GTPU_ERROR_NO_SUCH_TUNNEL;
+		      upf_gtpu_error_ind (b1, is_ip4);
 		      next1 = UPF_GTPU_INPUT_NEXT_DROP;
 		      goto trace1;
 		    }
@@ -483,6 +486,7 @@ upf_gtpu_input (vlib_main_t * vm,
 		       (&gtm->v6_tunnel_by_key, &kv, &value)))
 		    {
 		      error1 = UPF_GTPU_ERROR_NO_SUCH_TUNNEL;
+		      upf_gtpu_error_ind (b1, is_ip4);
 		      next1 = UPF_GTPU_INPUT_NEXT_DROP;
 		      goto trace1;
 		    }
@@ -683,6 +687,7 @@ upf_gtpu_input (vlib_main_t * vm,
 		       (&gtm->v4_tunnel_by_key, &kv, &value)))
 		    {
 		      error0 = UPF_GTPU_ERROR_NO_SUCH_TUNNEL;
+		      upf_gtpu_error_ind (b0, is_ip4);
 		      next0 = UPF_GTPU_INPUT_NEXT_DROP;
 		      goto trace00;
 		    }
@@ -721,6 +726,7 @@ upf_gtpu_input (vlib_main_t * vm,
 		       (&gtm->v6_tunnel_by_key, &kv, &value)))
 		    {
 		      error0 = UPF_GTPU_ERROR_NO_SUCH_TUNNEL;
+		      upf_gtpu_error_ind (b0, is_ip4);
 		      next0 = UPF_GTPU_INPUT_NEXT_DROP;
 		      goto trace00;
 		    }

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -1732,7 +1732,7 @@ build_urr_link_map (upf_session_t * sx)
   }
 }
 
-static void
+void
 upf_ip_lookup_tx (u32 bi, int is_ip4)
 {
   vlib_main_t *vm = vlib_get_main ();


### PR DESCRIPTION
When UPG receives a G-PDU for which no corresponding GTP-U tunnel
exists, it must discard the G-PDU and return a GTP-U Error Indication
to the sending node.