### PR TITLE
[E2E] Move go-pfcp out from fork to upstream wmnsk/go-pfcp

### DIFF
--- a/test/e2e/framework/sessionconfig.go
+++ b/test/e2e/framework/sessionconfig.go
@@ -80,6 +80,7 @@ func (cfg SessionConfig) outerHeaderRemoval() *ie.IE {
 	return ie.NewOuterHeaderRemoval(pfcp.OuterHeaderRemoval_GTPUUDPIPV6, 0)
 }
 
+
 func (cfg SessionConfig) forwardFAR(farID uint32) *ie.IE {
 	var fwParams []*ie.IE
 	switch cfg.Mode {
@@ -141,10 +142,10 @@ func (cfg SessionConfig) reverseFAR(farID uint32) *ie.IE {
 func (cfg SessionConfig) ueIPAddress(flags uint8) *ie.IE {
 	ip4 := cfg.UEIP.To4()
 	if ip4 != nil {
-		return ie.NewUEIPAddress(flags|pfcp.UEIPAddress_V4, ip4.String(), "", 0)
+		return ie.NewUEIPAddress(flags|pfcp.UEIPAddress_V4, ip4.String(), "", 0, 0)
 	}
 
-	return ie.NewUEIPAddress(flags|pfcp.UEIPAddress_V6, "", cfg.UEIP.String(), 0)
+	return ie.NewUEIPAddress(flags|pfcp.UEIPAddress_V6, "", cfg.UEIP.String(), 0, 0)
 }
 
 func (cfg SessionConfig) forwardPDR(pdrID uint16, farID, urrID, precedence uint32, appID string, sdfFilter string) *ie.IE {
@@ -339,9 +340,12 @@ func (cfg SessionConfig) DeletePDRs() []*ie.IE {
 
 func fteid(teid uint32, ip net.IP) *ie.IE {
 	ip4 := ip.To4()
+	var flags uint8
 	if ip4 != nil {
-		return ie.NewFTEID(teid, ip4, nil, nil)
+		flags |= 0x01
+		return ie.NewFTEID(flags, teid, ip4, nil, 0)
 	}
 
-	return ie.NewFTEID(teid, nil, ip, nil) // IPv6
+	flags |= 0x02
+	return ie.NewFTEID(flags, teid, nil, ip, 0) // IPv6
 }

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -2,7 +2,7 @@ module github.com/travelping/upg-vpp/test/e2e
 
 go 1.13
 
-replace github.com/wmnsk/go-pfcp => github.com/ivan4th/go-pfcp v0.0.7-0.20201007115118-38811fc30094
+//replace github.com/wmnsk/go-pfcp => github.com/ivan4th/go-pfcp v0.0.7-0.20201007115118-38811fc30094
 
 // TODO: https://github.com/go-ping/ping/pull/116
 replace github.com/go-ping/ping => github.com/ivan4th/ping v0.0.0-20201105224649-bfa92e2c3093
@@ -22,7 +22,7 @@ require (
 	github.com/vishvananda/netlink v1.1.0
 	github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae
 	github.com/wmnsk/go-gtp v0.7.13
-	github.com/wmnsk/go-pfcp v0.0.6
+	github.com/wmnsk/go-pfcp v0.0.15
 	golang.org/x/sys v0.0.0-20201024232916-9f70ab9862d5
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -53,13 +53,12 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gopacket v1.1.18 h1:lum7VRA9kdlvBi7/v2p7/zcbkduHaCH/SVVyurs7OpY=
 github.com/google/gopacket v1.1.18/go.mod h1:UdDNZ1OO62aGYVnPhxT1U6aI7ukYtA/kB8vaU0diBUM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/ivan4th/go-pfcp v0.0.7-0.20201007115118-38811fc30094 h1:D7taG9Wg2rQCGZuegAKJzOy1RjKvYRWdX+QIOKv0XIY=
-github.com/ivan4th/go-pfcp v0.0.7-0.20201007115118-38811fc30094/go.mod h1:Hwc6b/KmDF6tGa5hwhP5UGfKgwnL2CICFs3PgFz5cRE=
 github.com/ivan4th/ping v0.0.0-20201105224649-bfa92e2c3093 h1:owqw3ykbmKwUvDsIdiZLtS3D1Mt5YfJ7qCZyYcbwO3E=
 github.com/ivan4th/ping v0.0.0-20201105224649-bfa92e2c3093/go.mod h1:35JbSyV/BYqHwwRA6Zr1uVDm1637YlNOU61wI797NPI=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
@@ -119,6 +118,8 @@ github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae h1:4hwBBUfQCFe3C
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/wmnsk/go-gtp v0.7.13 h1:4YO+iVs6lKMybiKyqyK9v7gxjxUdACwzz1LJyseOWZ8=
 github.com/wmnsk/go-gtp v0.7.13/go.mod h1:0F3ihcC+RgmBqgW7a4Il2ovQ5jJjLDDU1bUcfqFHly0=
+github.com/wmnsk/go-pfcp v0.0.15 h1:+drK6VKzYXDS/waV7oK58lHYHPXAAJR76QrVWhVJF0s=
+github.com/wmnsk/go-pfcp v0.0.15/go.mod h1:vAimwm1IQ2Lu3OtuWmGl52YBZu9kHjPxtFRTlSJ/bdU=
 golang.org/x/crypto v0.0.0-20181009213950-7c1a557ab941/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -170,8 +171,9 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/test/e2e/pfcp/pfcp.go
+++ b/test/e2e/pfcp/pfcp.go
@@ -1097,9 +1097,9 @@ func (pc *PFCPConnection) pipelineRequests(
 func (pc *PFCPConnection) sessionEstablishmentRequest(spec SessionOpSpec) message.Message {
 	var fseid *ie.IE
 	if pc.cfg.CNodeIP.To4() == nil {
-		fseid = ie.NewFSEID(uint64(spec.SEID), nil, pc.cfg.CNodeIP, nil)
+		fseid = ie.NewFSEID(uint64(spec.SEID), nil, pc.cfg.CNodeIP)
 	} else {
-		fseid = ie.NewFSEID(uint64(spec.SEID), pc.cfg.CNodeIP.To4(), nil, nil)
+		fseid = ie.NewFSEID(uint64(spec.SEID), pc.cfg.CNodeIP.To4(), nil)
 	}
 
 	ies := append(spec.IEs, fseid, ie.NewNodeID("", "", pc.cfg.NodeID))


### PR DESCRIPTION
Bump to latest go-pfcp v0.0.15 to include proper fixes already merged to upstream.