### PR TITLE
[E2E] CG-NAT E2E Verification

### DIFF
--- a/test/e2e/framework/upgmode.go
+++ b/test/e2e/framework/upgmode.go
@@ -240,6 +240,11 @@ func tdfVPPConfigIPv4() vpp.VPPConfig {
 						Dst: MustParseIPNet("10.1.0.0/16"),
 						Gw:  MustParseIP("10.0.1.2"),
 					},
+					{
+						// Used for NAT verification
+						Dst: MustParseIPNet("144.0.0.0/24"),
+						Gw:  MustParseIP("10.0.1.2"),
+					},
 				},
 			},
 		},

--- a/test/e2e/traffic/http.go
+++ b/test/e2e/traffic/http.go
@@ -150,6 +150,7 @@ func (hs *HTTPServer) Start(ctx context.Context, ns *network.NetNS) error {
 			w.Header().Set("Content-Type", "application/octet-stream")
 			fileSize := hs.cfg.ChunkCount * hs.cfg.ChunkSize
 			w.Header().Set("Content-Length", strconv.Itoa(fileSize))
+			hs.rec.RecordClientAddr(r.RemoteAddr)
 			for i := 0; i < hs.cfg.ChunkCount; i++ {
 				_, err := w.Write(chunk)
 				if err != nil {

--- a/test/e2e/traffic/trafficgen.go
+++ b/test/e2e/traffic/trafficgen.go
@@ -43,6 +43,7 @@ type TrafficRec interface {
 	RecordStats(stats TrafficStats)
 	Verify() error
 	Stats() TrafficStats
+	RecordClientAddr(addr string)
 }
 
 type TrafficServer interface {

--- a/test/e2e/traffic/trafficrec.go
+++ b/test/e2e/traffic/trafficrec.go
@@ -34,6 +34,7 @@ type SimpleTrafficRec struct {
 	sync.Mutex
 	errors []string
 	stats  TrafficStats
+	clientAddr  string
 }
 
 var _ TrafficRec = &SimpleTrafficRec{}
@@ -57,6 +58,18 @@ func (tr *SimpleTrafficRec) RecordStats(stats TrafficStats) {
 	tr.stats.ClientReceived += stats.ClientReceived
 	tr.stats.ServerSent += stats.ServerSent
 	tr.stats.ServerReceived += stats.ServerReceived
+}
+
+func (tr *SimpleTrafficRec) RecordClientAddr (addr string) {
+	tr.Lock()
+	defer tr.Unlock()
+    tr.clientAddr = addr
+}
+
+func (tr *SimpleTrafficRec) ClientAddr () string {
+	tr.Lock()
+	defer tr.Unlock()
+	return tr.clientAddr
 }
 
 func (tr *SimpleTrafficRec) verifyUnlocked() error {


### PR DESCRIPTION
Single HTTP session test to verify CG-NAT traslation.
Dedicated BBF IEs implemented locally as part of sessionconfig package.
This commit might be the beginning of complex CG-NAT verification, however further implementation of BBF IEs is required.
NOTE: NAT feature enablement should be changed when base image of VPP will be bumped to 22.02