### PR TITLE
Remove VTIME out of measurement methods

### DIFF
--- a/test/e2e/framework/sessionconfig.go
+++ b/test/e2e/framework/sessionconfig.go
@@ -280,13 +280,17 @@ func (cfg SessionConfig) DeleteFARs() []*ie.IE {
 
 func (cfg SessionConfig) CreateOrUpdateURR(id uint32, update bool) *ie.IE {
 	triggers := uint16(0)
+	measurementMethodDURAT := 1
 	mk := ie.NewCreateURR
 	if update {
 		mk = ie.NewUpdateURR
 	}
+	if cfg.VTime != 0 {
+		measurementMethodDURAT = 0
+	}
 	urr := mk(ie.NewURRID(id),
 		// VOLUM=1 DURAT=1
-		ie.NewMeasurementMethod(0, 1, 1))
+		ie.NewMeasurementMethod(0, 1, measurementMethodDURAT))
 	if !cfg.MonitoringTime.IsZero() {
 		urr.Add(ie.NewMonitoringTime(cfg.MonitoringTime))
 	}

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -1989,14 +1989,14 @@ pfcp_update_apply (upf_session_t * sx)
 						  !!(urr->triggers &
 						     REPORTING_TRIGGER_TIME_QUOTA));
 	  }
-	if (urr->update_flags & PFCP_URR_UPDATE_QUOTA_VALIDITY_TIME)
-	  {
-	    urr->quota_validity_time.base = now;
-	    upf_pfcp_session_start_stop_urr_time (si,
-						  &urr->quota_validity_time,
-						  !!(urr->triggers &
-						     REPORTING_TRIGGER_QUOTA_VALIDITY_TIME));
-	  }
+      }
+    if (urr->update_flags & PFCP_URR_UPDATE_QUOTA_VALIDITY_TIME)
+      {
+	urr->quota_validity_time.base = now;
+	upf_pfcp_session_start_stop_urr_time (si,
+					      &urr->quota_validity_time,
+					      !!(urr->triggers &
+						 REPORTING_TRIGGER_QUOTA_VALIDITY_TIME));
       }
   }
 


### PR DESCRIPTION
TS 29.244 Clause 5.2.2.2: VTIME should be invoked regardlessly to chosen measurement methods.
This fix moves Quota Validity timer out of measurement period checking.