### PR TITLE
Add UPG_BUILDENV_EXTRA_DIR env var for the dockerized buildenv

### DIFF
--- a/hack/buildenv.sh
+++ b/hack/buildenv.sh
@@ -17,6 +17,7 @@ cd "$(dirname "${BASH_SOURCE}")/.."
 : ${BUILD_TYPE:=debug}
 : ${DEV_IMAGE:=${VPP_IMAGE_BASE}_dev_${BUILD_TYPE}}
 : ${VPP_SRC:=}
+: ${UPG_BUILDENV_EXTRA_DIR:=}
 
 if [[ ${GITHUB_RUN_ID:-} ]]; then
   # avoid overlong pod names (must be <= 63 chars including the -0 suffix)
@@ -40,6 +41,10 @@ function docker_buildenv {
   done
   if [[ -t 0 ]]; then
     opts+=(-it)
+  fi
+
+  if [[ ${UPG_BUILDENV_EXTRA_DIR:=} ]]; then
+    opts+=(-v "${UPG_BUILDENV_EXTRA_DIR}:${UPG_BUILDENV_EXTRA_DIR}")
   fi
 
   if [[ ${VPP_SRC} ]]; then


### PR DESCRIPTION
This helps with using custom versions of Go libraries for the tests