### PR TITLE
e2e: fix duplicate VPP processes during IPFIX tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,7 +30,7 @@ env:
   # But don't forget to comment it back for a finished PR!
   # E2E_FOCUS: "TDF.*IPv4.*no proxy.*counts plain HTTP traffic"
 
-  E2E_PARALLEL_NODES: "6"
+  E2E_PARALLEL_NODES: "10"
 
 jobs:
   build:

--- a/test/e2e/ipfix_e2e.go
+++ b/test/e2e/ipfix_e2e.go
@@ -30,9 +30,8 @@ import (
 	"github.com/travelping/upg-vpp/test/e2e/vpp"
 )
 
-func describeIPFIX(mode framework.UPGMode, ipMode framework.UPGIPMode) {
-	ginkgo.Context("[ipfix]", func() {
-
+func describeIPFIX(title string, mode framework.UPGMode, ipMode framework.UPGIPMode) {
+	ginkgo.Context(title+" [ipfix]", func() {
 		ginkgo.Context("[FAR-based]", func() {
 			f := framework.NewDefaultFramework(mode, ipMode)
 			v := &ipfixVerifier{f: f}

--- a/test/e2e/upg_e2e.go
+++ b/test/e2e/upg_e2e.go
@@ -145,8 +145,8 @@ func describeMode(title string, mode framework.UPGMode, ipMode framework.UPGIPMo
 				describeNAT(f)
 			}
 		}
-		describeIPFIX(mode, ipMode)
 	})
+	describeIPFIX(title, mode, ipMode)
 }
 
 func describeMeasurement(f *framework.Framework) {


### PR DESCRIPTION
This was causing excess memory consumption during E2E test runs,
as well as making PCAP artifacts useless for these test cases
Also, set E2E_PARALLEL_NODES back to 10 for the CI.