### PR TITLE
ipfix: add natEvent field to the 'default' template

### DIFF
--- a/upf/flowtable.h
+++ b/upf/flowtable.h
@@ -133,6 +133,7 @@ typedef struct flow_entry
   u8 spliced_dirty:1;
   u8 dont_splice:1;
   u8 app_detection_done:1;
+  u8 exported:1;
   u16 tcp_state;
   u32 ps_index;
 

--- a/upf/upf_ipfix.h
+++ b/upf/upf_ipfix.h
@@ -136,7 +136,8 @@ typedef u32 (*upf_ipfix_value_func_t) (vlib_buffer_t * to_b,
 				       flow_direction_t direction,
 				       u16 offset,
 				       upf_session_t *sx,
-				       upf_ipfix_info_t *info);
+				       upf_ipfix_info_t *info,
+				       bool last);
 
 typedef struct
 {

--- a/upf/upf_ipfix_templates.c
+++ b/upf/upf_ipfix_templates.c
@@ -31,12 +31,13 @@
 #include "upf_ipfix_templates.h"
 #include "upf_pfcp.h"
 
-#define IPFIX_TEMPLATE_DEFAULT_IPV4(F)		\
-  IPFIX_FIELD_SOURCE_IPV4_ADDRESS(F)		\
-  IPFIX_FIELD_DESTINATION_IPV4_ADDRESS(F)	\
-  IPFIX_FIELD_PROTOCOL_IDENTIFIER(F)		\
-  IPFIX_FIELD_POST_NAT_SOURCE_IPV4_ADDRESS(F)	\
-  IPFIX_FIELD_POST_NAPT_SOURCE_TRANSPORT_PORT(F)
+#define IPFIX_TEMPLATE_DEFAULT_IPV4(F)			\
+  IPFIX_FIELD_SOURCE_IPV4_ADDRESS(F)			\
+  IPFIX_FIELD_DESTINATION_IPV4_ADDRESS(F)		\
+  IPFIX_FIELD_PROTOCOL_IDENTIFIER(F)			\
+  IPFIX_FIELD_POST_NAT_SOURCE_IPV4_ADDRESS(F)		\
+  IPFIX_FIELD_POST_NAPT_SOURCE_TRANSPORT_PORT(F)	\
+  IPFIX_FIELD_NAT_EVENT(F)
 
 #define IPFIX_TEMPLATE_DEFAULT_IPV6(F)		\
   IPFIX_FIELD_SOURCE_IPV6_ADDRESS(F)		\
@@ -71,7 +72,9 @@ upf_ipfix_template_default_ip4_values (vlib_buffer_t * to_b,
 				       flow_entry_t * f,
 				       flow_direction_t direction,
 				       u16 offset,
-				       upf_session_t *sx)
+				       upf_session_t *sx,
+				       upf_ipfix_info_t *info,
+				       bool last)
 {
   IPFIX_TEMPLATE_VALUES (IPFIX_TEMPLATE_DEFAULT_IPV4,
 			 IPFIX_TEMPLATE_DEFAULT_COMMON);
@@ -82,7 +85,9 @@ upf_ipfix_template_default_ip6_values (vlib_buffer_t * to_b,
 				       flow_entry_t * f,
 				       flow_direction_t direction,
 				       u16 offset,
-				       upf_session_t *sx)
+				       upf_session_t *sx,
+				       upf_ipfix_info_t *info,
+				       bool last)
 {
   IPFIX_TEMPLATE_VALUES (IPFIX_TEMPLATE_DEFAULT_IPV6,
 			 IPFIX_TEMPLATE_DEFAULT_COMMON);
@@ -125,7 +130,8 @@ upf_ipfix_template_dest_ip4_values (vlib_buffer_t * to_b,
 				    flow_direction_t direction,
 				    u16 offset,
 				    upf_session_t *sx,
-				    upf_ipfix_info_t *info)
+				    upf_ipfix_info_t *info,
+				    bool last)
 {
   IPFIX_TEMPLATE_VALUES (IPFIX_TEMPLATE_DEST_IPV4,
 			 IPFIX_TEMPLATE_DEST_COMMON);
@@ -137,7 +143,8 @@ upf_ipfix_template_dest_ip6_values (vlib_buffer_t * to_b,
 				    flow_direction_t direction,
 				    u16 offset,
 				    upf_session_t *sx,
-				    upf_ipfix_info_t *info)
+				    upf_ipfix_info_t *info,
+				    bool last)
 {
   IPFIX_TEMPLATE_VALUES (IPFIX_TEMPLATE_DEST_IPV6,
 			 IPFIX_TEMPLATE_DEST_COMMON);

--- a/upf/upf_ipfix_templates.h
+++ b/upf/upf_ipfix_templates.h
@@ -47,6 +47,9 @@
     offset += n;					\
   } while (0)
 
+#define IPFIX_VALUE_U8_COND(v, n, c)	\
+  to_b->data[offset++] = (c) ? (v) : 0
+
 #define IPFIX_VALUE_U16(v, n, c)				\
   do {								\
     u16 tmp = clib_host_to_net_u16 (v);				\
@@ -244,6 +247,15 @@
     IPFIX_VALUE_U64,						\
     info->observation_point_id,					\
     sizeof(u64), 1)
+
+#define UPF_NAT_EVENT_NAT44_SESSION_CREATE 4
+#define UPF_NAT_EVENT_NAT44_SESSION_DELETE 5
+#define IPFIX_FIELD_NAT_EVENT(F)				\
+  F(natEvent, 1,						\
+    IPFIX_VALUE_U8_COND,					\
+    !f->exported ? UPF_NAT_EVENT_NAT44_SESSION_CREATE :		\
+    last ? UPF_NAT_EVENT_NAT44_SESSION_DELETE : 0,		\
+    sizeof (u8), 1)
 
 #define IPFIX_FIELD(fieldName, specLen, valCopy, v, n, c)	\
   do {								\


### PR DESCRIPTION
At the moment, natEvent field is set to NAT44 Session Create (4) in
the first report for a particular flow, and to NAT44 Session
Delete (5) in the last report for that flow. In the reports in
between, it is set to 0.

Stacked on top of #252 (merge this one before #252)