### PR TITLE
ipfix: add ipfix_report_interval field to NWI

### DIFF
--- a/test/e2e/binapi/upf/upf.ba.go
+++ b/test/e2e/binapi/upf/upf.ba.go
@@ -28,7 +28,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "upf"
 	APIVersion = "2.0.0"
-	VersionCrc = 0x855eb6f7
+	VersionCrc = 0xc56bea88
 )
 
 // UpfIpfixRecordFlags defines enum 'upf_ipfix_record_flags'.
@@ -676,6 +676,7 @@ type UpfNwiAddDel struct {
 	IP6TableID            uint32           `binapi:"u32,name=ip6_table_id" json:"ip6_table_id,omitempty"`
 	IpfixPolicy           []byte           `binapi:"u8[64],name=ipfix_policy" json:"ipfix_policy,omitempty"`
 	IpfixCollectorIP      ip_types.Address `binapi:"address,name=ipfix_collector_ip" json:"ipfix_collector_ip,omitempty"`
+	IpfixReportInterval   uint32           `binapi:"u32,name=ipfix_report_interval" json:"ipfix_report_interval,omitempty"`
 	ObservationDomainID   uint32           `binapi:"u32,name=observation_domain_id" json:"observation_domain_id,omitempty"`
 	ObservationDomainName []byte           `binapi:"u8[256],name=observation_domain_name" json:"observation_domain_name,omitempty"`
 	ObservationPointID    uint64           `binapi:"u64,name=observation_point_id" json:"observation_point_id,omitempty"`
@@ -685,7 +686,7 @@ type UpfNwiAddDel struct {
 
 func (m *UpfNwiAddDel) Reset()               { *m = UpfNwiAddDel{} }
 func (*UpfNwiAddDel) GetMessageName() string { return "upf_nwi_add_del" }
-func (*UpfNwiAddDel) GetCrcString() string   { return "0d3a4bda" }
+func (*UpfNwiAddDel) GetCrcString() string   { return "07485c64" }
 func (*UpfNwiAddDel) GetMessageType() api.MessageType {
 	return api.RequestMessage
 }
@@ -700,6 +701,7 @@ func (m *UpfNwiAddDel) Size() (size int) {
 	size += 1 * 64         // m.IpfixPolicy
 	size += 1              // m.IpfixCollectorIP.Af
 	size += 1 * 16         // m.IpfixCollectorIP.Un
+	size += 4              // m.IpfixReportInterval
 	size += 4              // m.ObservationDomainID
 	size += 1 * 256        // m.ObservationDomainName
 	size += 8              // m.ObservationPointID
@@ -718,6 +720,7 @@ func (m *UpfNwiAddDel) Marshal(b []byte) ([]byte, error) {
 	buf.EncodeBytes(m.IpfixPolicy, 64)
 	buf.EncodeUint8(uint8(m.IpfixCollectorIP.Af))
 	buf.EncodeBytes(m.IpfixCollectorIP.Un.XXX_UnionData[:], 16)
+	buf.EncodeUint32(m.IpfixReportInterval)
 	buf.EncodeUint32(m.ObservationDomainID)
 	buf.EncodeBytes(m.ObservationDomainName, 256)
 	buf.EncodeUint64(m.ObservationPointID)
@@ -734,6 +737,7 @@ func (m *UpfNwiAddDel) Unmarshal(b []byte) error {
 	copy(m.IpfixPolicy, buf.DecodeBytes(len(m.IpfixPolicy)))
 	m.IpfixCollectorIP.Af = ip_types.AddressFamily(buf.DecodeUint8())
 	copy(m.IpfixCollectorIP.Un.XXX_UnionData[:], buf.DecodeBytes(16))
+	m.IpfixReportInterval = buf.DecodeUint32()
 	m.ObservationDomainID = buf.DecodeUint32()
 	m.ObservationDomainName = make([]byte, 256)
 	copy(m.ObservationDomainName, buf.DecodeBytes(len(m.ObservationDomainName)))
@@ -1842,7 +1846,7 @@ func file_upf_binapi_init() {
 	api.RegisterMessage((*UpfApplicationsDump)(nil), "upf_applications_dump_51077d14")
 	api.RegisterMessage((*UpfNatPoolDetails)(nil), "upf_nat_pool_details_536a8c46")
 	api.RegisterMessage((*UpfNatPoolDump)(nil), "upf_nat_pool_dump_51077d14")
-	api.RegisterMessage((*UpfNwiAddDel)(nil), "upf_nwi_add_del_0d3a4bda")
+	api.RegisterMessage((*UpfNwiAddDel)(nil), "upf_nwi_add_del_07485c64")
 	api.RegisterMessage((*UpfNwiAddDelReply)(nil), "upf_nwi_add_del_reply_e8d4e804")
 	api.RegisterMessage((*UpfNwiDetails)(nil), "upf_nwi_details_e676456e")
 	api.RegisterMessage((*UpfNwiDump)(nil), "upf_nwi_dump_51077d14")

--- a/test/e2e/ipfix_e2e.go
+++ b/test/e2e/ipfix_e2e.go
@@ -243,7 +243,6 @@ func describeIPFIX(title string, mode framework.UPGMode, ipMode framework.UPGIPM
 			v.withIPFIXHandler()
 			ginkgo.It("records forwarding policy name in VRFname", func() {
 				v.verifyIPFIX(ipfixVerifierCfg{
-					// NOTE: no farTemplate
 					trafficCfg:             smallVolumeHTTPConfig(nil),
 					protocol:               layers.IPProtocolTCP,
 					expectedTrafficPort:    80,
@@ -252,6 +251,27 @@ func describeIPFIX(title string, mode framework.UPGMode, ipMode framework.UPGIPM
 					expectedReverseVRFName: "altIP",
 				})
 				v.verifyIPFIXDestRecords()
+			})
+		})
+
+		ginkgo.Context("reporting interval", func() {
+			f := framework.NewDefaultFramework(mode, ipMode)
+			v := &ipfixVerifier{f: f}
+			v.withNWIIPFIXPolicy("dest")
+			v.withIPFIXHandler()
+			v.withReportingInterval(7)
+			ginkgo.It("can be set via NWI", func() {
+				trafficCfg := smallVolumeHTTPConfig(nil)
+				// Make sure the flow lasts long enough to measure the intervals
+				trafficCfg.ChunkCount = 50
+				trafficCfg.ChunkDelay = 500 * time.Millisecond
+				v.verifyIPFIX(ipfixVerifierCfg{
+					trafficCfg:          trafficCfg,
+					protocol:            layers.IPProtocolTCP,
+					expectedTrafficPort: 80,
+				})
+				v.verifyIPFIXDestRecords()
+				v.verifyReportingInterval(7)
 			})
 		})
 	})
@@ -352,6 +372,12 @@ func (v *ipfixVerifier) withIPFIXHandler() {
 func (v *ipfixVerifier) withNWIIPFIXPolicy(name string) {
 	v.modifySGi(func(nwiCfg *vpp.NWIConfig) {
 		nwiCfg.IPFIXPolicy = name
+	})
+}
+
+func (v *ipfixVerifier) withReportingInterval(seconds int) {
+	v.modifySGi(func(nwiCfg *vpp.NWIConfig) {
+		nwiCfg.IPFIXReportingInterval = seconds
 	})
 }
 
@@ -650,4 +676,29 @@ func (v *ipfixVerifier) verifyIPFIXDestRecords() {
 
 	gomega.Expect(ulOctets).To(gomega.Equal(*v.ms.Reports[1][0].UplinkVolume), "uplink volume")
 	gomega.Expect(dlOctets).To(gomega.Equal(*v.ms.Reports[1][0].DownlinkVolume), "downlink volume")
+}
+
+func (v *ipfixVerifier) verifyReportingInterval(expectedSeconds int) {
+	var ingressTimes, egressTimes []time.Time
+	for _, r := range v.recs {
+		dir := r["flowDirection"].(uint8)
+		ts := r["ts"].(time.Time)
+		if dir == 0 {
+			ingressTimes = append(ingressTimes, ts)
+		} else {
+			framework.ExpectEqual(dir, uint8(1))
+			egressTimes = append(egressTimes, ts)
+		}
+	}
+	atLeastMs := uint64(expectedSeconds) * 1000
+	verifyIntervals(ingressTimes, atLeastMs)
+	verifyIntervals(egressTimes, atLeastMs)
+}
+
+func verifyIntervals(times []time.Time, atLeastMs uint64) {
+	gomega.Expect(len(times)).To(gomega.BeNumerically(">", 3))
+	for n := 1; n < len(times); n++ {
+		deltaT := times[n].Sub(times[n-1]).Milliseconds()
+		gomega.Expect(deltaT).To(gomega.BeNumerically(">=", atLeastMs-200))
+	}
 }

--- a/test/e2e/ipfix_handler.go
+++ b/test/e2e/ipfix_handler.go
@@ -66,14 +66,16 @@ func (h *ipfixHandler) handleIPFIXMessage(msg *entities.Message) {
 			}
 		}
 	} else {
+		now := time.Now()
 		if h.firstReportTS.IsZero() {
-			h.firstReportTS = time.Now()
+			h.firstReportTS = now
 		}
 		fmt.Fprint(&buf, "DATA SET:\n")
 		for i, record := range set.GetRecords() {
 			fmt.Fprintf(&buf, "  DATA RECORD-%d:\n", i)
 			r := map[string]interface{}{
 				"observationDomainId": msg.GetObsDomainID(),
+				"ts":                  now,
 			}
 			for _, ie := range record.GetOrderedElementList() {
 				elem := ie.GetInfoElement()

--- a/test/e2e/vpp/vpp.go
+++ b/test/e2e/vpp/vpp.go
@@ -82,13 +82,14 @@ type VPPNetworkNamespace struct {
 }
 
 type NWIConfig struct {
-	Name                  string
-	Table                 int
-	IPFIXPolicy           string
-	ObservationDomainId   int
-	ObservationDomainName string
-	ObservationPointId    int
-	GetIPFIXCollectorIP   func() net.IP
+	Name                   string
+	Table                  int
+	IPFIXPolicy            string
+	IPFIXReportingInterval int
+	ObservationDomainId    int
+	ObservationDomainName  string
+	ObservationPointId     int
+	GetIPFIXCollectorIP    func() net.IP
 }
 
 type IPFIXExporterConfig struct {
@@ -626,6 +627,7 @@ func (vi *VPPInstance) setupNWIs() error {
 			Nwi:                 util.EncodeFQDN(nwiCfg.Name),
 			IP4TableID:          uint32(nwiCfg.Table),
 			IP6TableID:          uint32(nwiCfg.Table),
+			IpfixReportInterval: uint32(nwiCfg.IPFIXReportingInterval),
 			ObservationDomainID: uint32(nwiCfg.ObservationDomainId),
 			ObservationPointID:  uint64(nwiCfg.ObservationPointId),
 			Add:                 1,

--- a/upf/upf.api
+++ b/upf/upf.api
@@ -237,6 +237,7 @@ autoreply define upf_nwi_add_del {
   u32 ip6_table_id;
   u8 ipfix_policy[64];
   vl_api_address_t ipfix_collector_ip;
+  u32 ipfix_report_interval;
   u32 observation_domain_id;
   u8 observation_domain_name[256];
   u64 observation_point_id;

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -862,6 +862,7 @@ typedef struct
 
   upf_ipfix_policy_t ipfix_policy;
   ip_address_t ipfix_collector_ip;
+  u32 ipfix_report_interval;
 
   u32 observation_domain_id;
   u64 observation_point_id;
@@ -1062,6 +1063,7 @@ void vnet_upf_pfcp_set_polling (vlib_main_t * vm, u8 polling);
 int vnet_upf_nwi_add_del (u8 * name, u32 ip4_table_id, u32 ip6_table_id,
 			  upf_ipfix_policy_t ipfix_policy,
 			  ip_address_t * ipfix_collector_ip,
+			  u32 ipfix_report_interval,
 			  u32 observation_domain_id,
 			  u8 * observation_domain_name,
 			  u64 observation_point_id, u8 add);

--- a/upf/upf_api.c
+++ b/upf/upf_api.c
@@ -494,6 +494,7 @@ vl_api_upf_nwi_add_del_t_handler (vl_api_upf_nwi_add_del_t * mp)
   upf_ipfix_policy_t ipfix_policy = UPF_IPFIX_POLICY_NONE;
   int rv = 0;
   ip_address_t ipfix_collector_ip;
+  u32 ipfix_report_interval;
   u32 observation_domain_id;
   u8 *observation_domain_name = 0;
   u64 observation_point_id;
@@ -543,6 +544,7 @@ vl_api_upf_nwi_add_del_t_handler (vl_api_upf_nwi_add_del_t * mp)
   ipfix_collector_ip.version =
     ip46_address_is_ip4 (&ipfix_collector_ip.ip) ? AF_IP4 : AF_IP6;
 
+  ipfix_report_interval = clib_net_to_host_u32 (mp->ipfix_report_interval);
   observation_domain_id = clib_net_to_host_u32 (mp->observation_domain_id);
   if (mp->observation_domain_name[0])
     {
@@ -554,6 +556,7 @@ vl_api_upf_nwi_add_del_t_handler (vl_api_upf_nwi_add_del_t * mp)
 
   rv = vnet_upf_nwi_add_del (nwi_name, ip4_table_id, ip6_table_id,
 			     ipfix_policy, &ipfix_collector_ip,
+			     ipfix_report_interval,
 			     observation_domain_id,
 			     observation_domain_name,
 			     observation_point_id, mp->add);

--- a/upf/upf_cli.c
+++ b/upf/upf_cli.c
@@ -379,6 +379,7 @@ upf_nwi_add_del_command_fn (vlib_main_t * vm,
   u8 add = 1;
   int rv;
   ip_address_t ipfix_collector_ip = ip_address_initializer;
+  u32 ipfix_report_interval = 0;
   u32 observation_domain_id = 1;
   u8 *observation_domain_name = 0;
   u64 observation_point_id = 1;
@@ -406,6 +407,9 @@ upf_nwi_add_del_command_fn (vlib_main_t * vm,
 	;
       else if (unformat (line_input, "ipfix-collector-ip %U",
 			 unformat_ip_address, &ipfix_collector_ip))
+	;
+      else if (unformat (line_input, "ipfix-report-interval %u",
+			 &ipfix_report_interval))
 	;
       else
 	if (unformat
@@ -440,6 +444,7 @@ upf_nwi_add_del_command_fn (vlib_main_t * vm,
 
   rv = vnet_upf_nwi_add_del (name, table_id, table_id, ipfix_policy,
 			     &ipfix_collector_ip,
+			     ipfix_report_interval,
 			     observation_domain_id,
 			     observation_domain_name,
 			     observation_point_id, add);
@@ -474,9 +479,13 @@ VLIB_CLI_COMMAND (upf_nwi_add_del_command, static) =
 {
   .path = "upf nwi",
   .short_help =
-  "upf nwi name <name> [table <table-id>] [vrf <vrf-id>] [ipfix-policy <name>] "
-  "[ipfix-collector-ip <ip>] [observation-domain-id <id>] "
-  "[observation-domain-name <name>] [observation-point-id <id>] "
+  "upf nwi name <name> [table <table-id>] [vrf <vrf-id>] "
+  "[ipfix-policy <name>] "
+  "[ipfix-collector-ip <ip>] "
+  "[ipfix-report-interval <secs>] "
+  "[observation-domain-id <id>] "
+  "[observation-domain-name <name>] "
+  "[observation-point-id <id>] "
   "[del]",
   .function = upf_nwi_add_del_command_fn,
 };

--- a/upf/upf_ipfix.h
+++ b/upf/upf_ipfix.h
@@ -14,9 +14,6 @@
 
 #include "flowtable.h"
 
-/* Default timers in seconds */
-#define UPF_IPFIX_TIMER_ACTIVE   (5) // FIXME: use different value
-
 #define FLOW_MAXIMUM_EXPORT_ENTRIES	(1024)
 
 typedef struct {
@@ -82,6 +79,8 @@ typedef struct
   upf_ipfix_info_key_t key;
   /** Context index */
   u32 context_index;
+  /** Report interval in seconds */
+  u32 report_interval;
   /** IPFIX field: ingressVRFID */
   u32 ingress_vrf_id;
   /** IPFIX field: egressVRFID */
@@ -113,8 +112,6 @@ typedef struct
   upf_ipfix_policy_t policy;
 
   u32 vlib_time_0;
-
-  u32 active_timer;
 
   bool initialized;
   bool disabled;

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -120,6 +120,7 @@ static int
 vnet_upf_create_nwi_if (u8 * name, u32 ip4_table_id, u32 ip6_table_id,
 			upf_ipfix_policy_t ipfix_policy,
 			ip_address_t * ipfix_collector_ip,
+			u32 ipfix_report_interval,
 			u32 observation_domain_id,
 			u8 * observation_domain_name,
 			u64 observation_point_id, u32 * sw_if_idx)
@@ -226,6 +227,7 @@ vnet_upf_create_nwi_if (u8 * name, u32 ip4_table_id, u32 ip6_table_id,
 
   hash_set_mem (gtm->nwi_index_by_name, nwi->name, if_index);
 
+  nwi->ipfix_report_interval = ipfix_report_interval;
   nwi->observation_domain_id = observation_domain_id;
   nwi->observation_domain_name = vec_dup (observation_domain_name);
   nwi->observation_point_id = observation_point_id;
@@ -274,6 +276,7 @@ int
 vnet_upf_nwi_add_del (u8 * name, u32 ip4_table_id, u32 ip6_table_id,
 		      upf_ipfix_policy_t ipfix_policy,
 		      ip_address_t * ipfix_collector_ip,
+		      u32 ipfix_report_interval,
 		      u32 observation_domain_id,
 		      u8 * observation_domain_name,
 		      u64 observation_point_id, u8 add)
@@ -281,6 +284,7 @@ vnet_upf_nwi_add_del (u8 * name, u32 ip4_table_id, u32 ip6_table_id,
   return (add) ?
     vnet_upf_create_nwi_if (name, ip4_table_id, ip6_table_id,
 			    ipfix_policy, ipfix_collector_ip,
+			    ipfix_report_interval,
 			    observation_domain_id,
 			    observation_domain_name,
 			    observation_point_id,


### PR DESCRIPTION
The field specifies minimum per-flow IPFIX reporting interval in
seconds. If the field is set to 0 or ~0, the default value of 5
seconds is used. It's possible to set the value both through the
binapi and CLI.

This PR is stacked on top of #255. This PR must be merged first.