### PR TITLE
[VPP-Base] Update VPP-Base to support vpp interface rename

### DIFF
--- a/vpp.spec
+++ b/vpp.spec
@@ -1,1 +1,1 @@
-VPP_IMAGE_BASE=registry.cennso.com/upg/vpp-base:22.02-rc1-b354d6863
+VPP_IMAGE_BASE=registry.cennso.com/upg/vpp-base:22.02-rc1-b800bed94


### PR DESCRIPTION
New VPP-base version contains a fix for "set interface name" CLI
or binapi call that also renames statistic counters is statseg.