### PR TITLE
Fix TCP RST crash in VPP

### DIFF
--- a/test/e2e/pfcp/pfcp.go
+++ b/test/e2e/pfcp/pfcp.go
@@ -87,6 +87,7 @@ const (
 
 	ReportingTriggers_QUVTI = 0x0080 // Quota Validity Time
 	ReportingTriggers_PERIO = 0x0100 // Periodic Reporting
+	ReportingTriggers_VOLQU = 0x0001 // Volume Quota
 
 	maxRequestAttempts = 10
 

--- a/upf/upf_proxy_input.c
+++ b/upf/upf_proxy_input.c
@@ -398,6 +398,8 @@ upf_proxy_input (vlib_main_t * vm, vlib_node_runtime_t * node,
 		     upf_buffer_opaque (b)->gtpu.is_reverse,
 		     flow->is_reverse);
 
+	  vnet_buffer (b)->ip.rx_sw_if_index = vnet_buffer (b)->sw_if_index[VLIB_RX];
+
 	  ftc = &flow_tc (flow, direction);
 
 	  if (flow->is_spliced)

--- a/vpp.spec
+++ b/vpp.spec
@@ -1,1 +1,1 @@
-VPP_IMAGE_BASE=registry.cennso.com/upg/vpp-base:22.02-rc1-b800bed94
+VPP_IMAGE_BASE=registry.cennso.com/upg/vpp-base:22.02-rc1-f5360739d


### PR DESCRIPTION
Fix including following changes:
- bump VPP base image to include fix for NAT-ED code checksum assertion for TCP RST packet
- Set up `rx_sw_if_index` in `upf-proxy-input` to allow VPP TCP stack properly set up output interface index for RST packet
- Create E2E test to verify that Volume quota exhaust and adjusted redirect rules for session won't lead UPG to crash