### PR TITLE
ipfix: fix context handling

### DIFF
--- a/test/e2e/ipfix_handler.go
+++ b/test/e2e/ipfix_handler.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"net"
+	"sort"
 	"sync"
 	"time"
 
@@ -130,15 +131,21 @@ func (h *ipfixHandler) handleIPFIXMessage(msg *entities.Message) {
 	framework.Logf("IPFIX:\n%s", buf.String())
 }
 
-func (h *ipfixHandler) haveTemplateIDs(ids ...uint16) bool {
+func (h *ipfixHandler) getTemplateIDs() []int {
 	h.Lock()
 	defer h.Unlock()
-	for _, id := range ids {
-		if !h.ids[id] {
-			return false
-		}
+
+	if len(h.ids) == 0 {
+		return nil
 	}
-	return true
+
+	r := make([]int, 0, len(h.ids))
+	for id := range h.ids {
+		r = append(r, int(id))
+	}
+	sort.Ints(r)
+
+	return r
 }
 
 func (h *ipfixHandler) stop() {

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -867,6 +867,8 @@ typedef struct
   u32 observation_domain_id;
   u64 observation_point_id;
   u8 *observation_domain_name;
+
+  u32 *ipfix_context_indices;
 } upf_nwi_t;
 
 typedef struct

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -245,6 +245,7 @@ vnet_upf_delete_nwi_if (u8 * name)
   upf_main_t *gtm = &upf_main;
   upf_nwi_t *nwi;
   uword *p;
+  u32 *ipfix_ctx_index;
 
   p = hash_get_mem (gtm->nwi_index_by_name, name);
   if (!p)
@@ -267,6 +268,12 @@ vnet_upf_delete_nwi_if (u8 * name)
   hash_unset_mem (gtm->nwi_index_by_name, nwi->name);
   vec_free (nwi->observation_domain_name);
   vec_free (nwi->name);
+
+  vec_foreach (ipfix_ctx_index, nwi->ipfix_context_indices)
+  {
+    upf_unref_ipfix_context_by_index (ipfix_ctx_index);
+  }
+
   pool_put (gtm->nwis, nwi);
 
   return 0;


### PR DESCRIPTION
Don't drop IPFIX contexts when there are no flows, retain them
while the NWI is still present.
Don't crash upon bad IPFIX collector IP spec.