### PR TITLE
Remove related flows together with PFCP sessions

### DIFF
--- a/test/e2e/upg_e2e.go
+++ b/test/e2e/upg_e2e.go
@@ -153,6 +153,7 @@ func describeMeasurement(f *framework.Framework) {
 	ginkgo.Describe("session measurement", func() {
 		var ms *pfcp.PFCPMeasurement
 		var seid pfcp.SEID
+		var flowStr string
 
 		sessionContext := func(desc string, cfg framework.SessionConfig, body func()) {
 			ginkgo.Context(desc, func() {
@@ -165,7 +166,10 @@ func describeMeasurement(f *framework.Framework) {
 		}
 
 		verify := func(cfg traffic.TrafficConfig) {
+			var err error
 			runTrafficGen(f, cfg, &traffic.PreciseTrafficRec{})
+			flowStr, err = f.VPP.Ctl("show upf flows")
+			framework.ExpectNoError(err, "show upf flows")
 			ms = deleteSession(f, seid, true)
 		}
 
@@ -291,8 +295,6 @@ func describeMeasurement(f *framework.Framework) {
 					}
 					verify(&bypassTrafficCfg)
 					// the flow should not be proxied
-					flowStr, err := f.VPP.Ctl("show upf flows")
-					framework.ExpectNoError(err)
 					gomega.Expect(flowStr).To(gomega.ContainSubstring("proxy 0"))
 					gomega.Expect(flowStr).NotTo(gomega.ContainSubstring("proxy 1"))
 				})
@@ -302,8 +304,6 @@ func describeMeasurement(f *framework.Framework) {
 					verifyNonAppMeasurement(f, ms, layers.IPProtocolTCP, nil)
 
 					// the flow should be proxied
-					flowStr, err := f.VPP.Ctl("show upf flows")
-					framework.ExpectNoError(err)
 					gomega.Expect(flowStr).NotTo(gomega.ContainSubstring("proxy 0"))
 					gomega.Expect(flowStr).To(gomega.ContainSubstring("proxy 1"))
 				})
@@ -315,8 +315,6 @@ func describeMeasurement(f *framework.Framework) {
 					verifyAppMeasurement(f, ms, layers.IPProtocolTCP, nil)
 
 					// the flow should be proxied
-					flowStr, err := f.VPP.Ctl("show upf flows")
-					framework.ExpectNoError(err)
 					gomega.Expect(flowStr).NotTo(gomega.ContainSubstring("proxy 0"))
 					gomega.Expect(flowStr).To(gomega.ContainSubstring("proxy 1"))
 				})

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -796,6 +796,9 @@ typedef struct
 
   pfcp_user_id_t user_id;
 
+  /* per-session flow list linkage */
+  u32 first_flow_index;
+
   u16 generation;
 } upf_session_t;
 
@@ -960,7 +963,7 @@ typedef struct
   /* vector of encap tunnel instances */
   upf_session_t *sessions;
 
-  /* lookup tunnel by key */
+  /* lookup session by id */
   uword *session_by_id;		/* keyed session id */
 
   /* lookup tunnel by TEID */

--- a/upf/upf_flow_node.c
+++ b/upf/upf_flow_node.c
@@ -226,12 +226,29 @@ upf_flow_process (vlib_main_t * vm, vlib_node_runtime_t * node,
 	    flowtable_entry_lookup_create (fm, fmt, &kv0,
 					   timestamp, current_time,
 					   is_reverse0, sx0->generation,
-					   &created0);
+					   sx0->first_flow_index, &created0);
+	  if (created0)
+	    {
+	      ASSERT (flowtable_get_flow
+		      (fm,
+		       flow_idx0)->next_session_flow_index ==
+		      sx0->first_flow_index);
+	      sx0->first_flow_index = flow_idx0;
+	    }
+
 	  flow_idx1 =
 	    flowtable_entry_lookup_create (fm, fmt, &kv1,
 					   timestamp, current_time,
-					   is_reverse1, sx0->generation,
-					   &created1);
+					   is_reverse1, sx1->generation,
+					   sx1->first_flow_index, &created1);
+	  if (created1)
+	    {
+	      ASSERT (flowtable_get_flow
+		      (fm,
+		       flow_idx1)->next_session_flow_index ==
+		      sx1->first_flow_index);
+	      sx1->first_flow_index = flow_idx1;
+	    }
 
 	  if (PREDICT_FALSE (~0 == flow_idx0 || ~0 == flow_idx1))
 	    {
@@ -364,7 +381,15 @@ upf_flow_process (vlib_main_t * vm, vlib_node_runtime_t * node,
 	    flowtable_entry_lookup_create (fm, fmt, &kv,
 					   timestamp, current_time,
 					   is_reverse, sx0->generation,
-					   &created);
+					   sx0->first_flow_index, &created);
+	  if (created)
+	    {
+	      ASSERT (flowtable_get_flow
+		      (fm,
+		       flow_idx)->next_session_flow_index ==
+		      sx0->first_flow_index);
+	      sx0->first_flow_index = flow_idx;
+	    }
 
 	  if (PREDICT_FALSE (~0 == flow_idx))
 	    {

--- a/upf/upf_pfcp.h
+++ b/upf/upf_pfcp.h
@@ -33,6 +33,8 @@ upf_session_t *pfcp_create_session (upf_node_assoc_t * assoc,
 void pfcp_update_session (upf_session_t * sx);
 void pfcp_disable_session (upf_session_t * sx);
 void pfcp_free_session (upf_session_t * sx);
+int session_flow_unlink_handler (flowtable_main_t * fm, flow_entry_t * flow,
+				 flow_direction_t direction, u32 now);
 
 #define pfcp_rule_vector_fns(t)						\
 upf_##t##_t * pfcp_get_##t##_by_id(struct rules *,			\

--- a/upf/upf_proxy.h
+++ b/upf/upf_proxy.h
@@ -154,6 +154,8 @@ proxy_session_lookup_by_index (u32 session_index, u32 thread_index)
   return 0;
 }
 
+void upf_kill_connection_hard (tcp_connection_t * tc);
+
 tcp_connection_t *upf_tcp_lookup_connection (u32 fib_index, vlib_buffer_t * b,
 					     u8 thread_index, u8 is_ip4,
 					     u8 is_reverse);

--- a/upf/upf_proxy_accept.c
+++ b/upf/upf_proxy_accept.c
@@ -240,13 +240,8 @@ upf_proxy_accept_inline (vlib_main_t * vm, vlib_node_runtime_t * node,
       upf_debug ("flow_id: 0x%08x", flow_id);
       flow = pool_elt_at_index (fm->flows, flow_id);
       ASSERT (flow);
-      if (pool_is_free (gtm->sessions, gtm->sessions + flow->session_index))
-	{
-	  clib_warning ("The flow has sidx %d that refers to a dead session",
-			flow->session_index);
-	  error = UPF_PROXY_ERROR_INVALID_FLOW;
-	  goto done;
-	}
+      ASSERT (!pool_is_free
+	      (gtm->sessions, gtm->sessions + flow->session_index));
 
       /* make sure connection_index is invalid */
       vnet_buffer (b)->tcp.connection_index = ~0;

--- a/upf/upf_proxy_output.c
+++ b/upf/upf_proxy_output.c
@@ -315,12 +315,15 @@ upf_proxy_output (vlib_main_t * vm, vlib_node_runtime_t * node,
 	    {
 	      upf_pdr_t *pdr;
 
-	      if (!pool_is_free_index (gtm->sessions, flow->session_index))
-		{
-		  sx = pool_elt_at_index (gtm->sessions, flow->session_index);
-		  if (sx->generation != flow->generation)
-		    sx = NULL;
-		}
+	      sx = pool_elt_at_index (gtm->sessions, flow->session_index);
+	      /*
+	       * Edge case: session modified after this buffer left
+	       * upf-ip[46]-flow-process node but before it entered
+	       * this node.
+	       * FIXME: this shouldn't actually happen.
+	       */
+	      if (sx->generation != flow->generation)
+		sx = NULL;
 
 	      ASSERT (flow_pdr_id (flow, direction) != ~0);
 	      active = sx ? pfcp_get_rules (sx, PFCP_ACTIVE) : NULL;


### PR DESCRIPTION
This is needed to avoid losing IPFIX reports for the flows that still
exist when a PFCP session is deleted.
As part of the change, flowtable hooks are replaced with flowtable
events which are more flexible (multiple handlers per event).
Possible inconsistencies related to flows that don't correspond to any
active session are now being avoided.