### PR TITLE
e2e: add E2E_FAIL_FAST option

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -26,6 +26,7 @@ cd "$(dirname "${BASH_SOURCE}")/.."
 : "${E2E_VPP_NOT_INSTALLED:=}"
 : "${E2E_NO_GDB:=}"
 : "${E2E_GDBSERVER:=}"
+: "${E2E_FAIL_FAST:=}"
 : "${BUILD_TYPE:=debug}"
 
 if [[ ! ${E2E_POLLING_MODE} ]]; then
@@ -103,6 +104,10 @@ fi
 
 if [[ ${E2E_FLAKE_ATTEMPTS} ]]; then
   ginkgo_args+=(--flakeAttempts ${E2E_FLAKE_ATTEMPTS})
+fi
+
+if [[ ${E2E_FAIL_FAST} ]]; then
+  ginkgo_args+=(--failFast)
 fi
 
 ginkgo_args+=(--)

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -40,6 +40,7 @@ The make commands accept following variables:
 * `E2E_GDBSERVER`: run VPP under gdbserver. After VPP is started, you need to copy-paste
   the `gdb ...` command from test output into your console and type `cont` there (and press Enter)
   to continue running the test
+* `E2E_FAIL_FAST`: stop running tests after the first failure
 
 An example with multiple flags:
 


### PR DESCRIPTION
With this option, E2E test run terminates upon the first failure.
Handy when many breaking changes are done, so full E2E test suite is expected
to break on some (unknown) point, so as not to wait for all tests to complete.