### PR TITLE
e2e: fix artifacts log message

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -239,7 +239,7 @@ func (f *Framework) AfterEach() {
 			for _, filename := range matches {
 				os.Remove(filename)
 			}
-			logrus.WithField("testDir", targetDir).Info("test artifacts for the failed testcase")
+			logrus.WithField("testDir", targetDir).Info("test artifacts for the testcase")
 		} else if f.VPPCfg.BaseDir != "" {
 			ExpectNoError(os.RemoveAll(f.VPPCfg.BaseDir))
 		}


### PR DESCRIPTION
When E2E_KEEP_ALL_ARTIFACTS is set, artifacts are stored for the
successful test cases too, so "test artifacts for the failed testcase"
was misleading