### PR TITLE
Configurable PFCP Heartbeat parameters

### DIFF
--- a/test/e2e/binapi/upf/upf.ba.go
+++ b/test/e2e/binapi/upf/upf.ba.go
@@ -5,7 +5,7 @@
 // Contents:
 //   2 enums
 //   1 struct
-//  40 messages
+//  44 messages
 //
 package upf
 
@@ -28,7 +28,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "upf"
 	APIVersion = "2.0.0"
-	VersionCrc = 0x93ebcf8d
+	VersionCrc = 0xcdb93693
 )
 
 // UpfIpfixRecordFlags defines enum 'upf_ipfix_record_flags'.
@@ -1107,6 +1107,140 @@ func (m *UpfPfcpFormatReply) Unmarshal(b []byte) error {
 	return nil
 }
 
+// UpfPfcpHeartbeatsGet defines message 'upf_pfcp_heartbeats_get'.
+type UpfPfcpHeartbeatsGet struct{}
+
+func (m *UpfPfcpHeartbeatsGet) Reset()               { *m = UpfPfcpHeartbeatsGet{} }
+func (*UpfPfcpHeartbeatsGet) GetMessageName() string { return "upf_pfcp_heartbeats_get" }
+func (*UpfPfcpHeartbeatsGet) GetCrcString() string   { return "51077d14" }
+func (*UpfPfcpHeartbeatsGet) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *UpfPfcpHeartbeatsGet) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	return size
+}
+func (m *UpfPfcpHeartbeatsGet) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	return buf.Bytes(), nil
+}
+func (m *UpfPfcpHeartbeatsGet) Unmarshal(b []byte) error {
+	return nil
+}
+
+// UpfPfcpHeartbeatsGetReply defines message 'upf_pfcp_heartbeats_get_reply'.
+type UpfPfcpHeartbeatsGetReply struct {
+	Timeout uint32 `binapi:"u32,name=timeout" json:"timeout,omitempty"`
+	Retries uint32 `binapi:"u32,name=retries" json:"retries,omitempty"`
+}
+
+func (m *UpfPfcpHeartbeatsGetReply) Reset()               { *m = UpfPfcpHeartbeatsGetReply{} }
+func (*UpfPfcpHeartbeatsGetReply) GetMessageName() string { return "upf_pfcp_heartbeats_get_reply" }
+func (*UpfPfcpHeartbeatsGetReply) GetCrcString() string   { return "f5eafa3d" }
+func (*UpfPfcpHeartbeatsGetReply) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *UpfPfcpHeartbeatsGetReply) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Timeout
+	size += 4 // m.Retries
+	return size
+}
+func (m *UpfPfcpHeartbeatsGetReply) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeUint32(m.Timeout)
+	buf.EncodeUint32(m.Retries)
+	return buf.Bytes(), nil
+}
+func (m *UpfPfcpHeartbeatsGetReply) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Timeout = buf.DecodeUint32()
+	m.Retries = buf.DecodeUint32()
+	return nil
+}
+
+// UpfPfcpHeartbeatsSet defines message 'upf_pfcp_heartbeats_set'.
+type UpfPfcpHeartbeatsSet struct {
+	Timeout uint32 `binapi:"u32,name=timeout" json:"timeout,omitempty"`
+	Retries uint32 `binapi:"u32,name=retries" json:"retries,omitempty"`
+}
+
+func (m *UpfPfcpHeartbeatsSet) Reset()               { *m = UpfPfcpHeartbeatsSet{} }
+func (*UpfPfcpHeartbeatsSet) GetMessageName() string { return "upf_pfcp_heartbeats_set" }
+func (*UpfPfcpHeartbeatsSet) GetCrcString() string   { return "f5eafa3d" }
+func (*UpfPfcpHeartbeatsSet) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *UpfPfcpHeartbeatsSet) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Timeout
+	size += 4 // m.Retries
+	return size
+}
+func (m *UpfPfcpHeartbeatsSet) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeUint32(m.Timeout)
+	buf.EncodeUint32(m.Retries)
+	return buf.Bytes(), nil
+}
+func (m *UpfPfcpHeartbeatsSet) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Timeout = buf.DecodeUint32()
+	m.Retries = buf.DecodeUint32()
+	return nil
+}
+
+// UpfPfcpHeartbeatsSetReply defines message 'upf_pfcp_heartbeats_set_reply'.
+type UpfPfcpHeartbeatsSetReply struct {
+	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
+}
+
+func (m *UpfPfcpHeartbeatsSetReply) Reset()               { *m = UpfPfcpHeartbeatsSetReply{} }
+func (*UpfPfcpHeartbeatsSetReply) GetMessageName() string { return "upf_pfcp_heartbeats_set_reply" }
+func (*UpfPfcpHeartbeatsSetReply) GetCrcString() string   { return "e8d4e804" }
+func (*UpfPfcpHeartbeatsSetReply) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *UpfPfcpHeartbeatsSetReply) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Retval
+	return size
+}
+func (m *UpfPfcpHeartbeatsSetReply) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.Retval)
+	return buf.Bytes(), nil
+}
+func (m *UpfPfcpHeartbeatsSetReply) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Retval = buf.DecodeInt32()
+	return nil
+}
+
 // UpfPfcpPolicerSet defines message 'upf_pfcp_policer_set'.
 type UpfPfcpPolicerSet struct {
 	CirPps uint32 `binapi:"u32,name=cir_pps" json:"cir_pps,omitempty"`
@@ -1873,6 +2007,10 @@ func file_upf_binapi_init() {
 	api.RegisterMessage((*UpfPfcpEndpointDump)(nil), "upf_pfcp_endpoint_dump_51077d14")
 	api.RegisterMessage((*UpfPfcpFormat)(nil), "upf_pfcp_format_d522d6e1")
 	api.RegisterMessage((*UpfPfcpFormatReply)(nil), "upf_pfcp_format_reply_8706f872")
+	api.RegisterMessage((*UpfPfcpHeartbeatsGet)(nil), "upf_pfcp_heartbeats_get_51077d14")
+	api.RegisterMessage((*UpfPfcpHeartbeatsGetReply)(nil), "upf_pfcp_heartbeats_get_reply_f5eafa3d")
+	api.RegisterMessage((*UpfPfcpHeartbeatsSet)(nil), "upf_pfcp_heartbeats_set_f5eafa3d")
+	api.RegisterMessage((*UpfPfcpHeartbeatsSetReply)(nil), "upf_pfcp_heartbeats_set_reply_e8d4e804")
 	api.RegisterMessage((*UpfPfcpPolicerSet)(nil), "upf_pfcp_policer_set_8d0512f3")
 	api.RegisterMessage((*UpfPfcpPolicerSetReply)(nil), "upf_pfcp_policer_set_reply_e8d4e804")
 	api.RegisterMessage((*UpfPfcpPolicerShow)(nil), "upf_pfcp_policer_show_51077d14")
@@ -1918,6 +2056,10 @@ func AllMessages() []api.Message {
 		(*UpfPfcpEndpointDump)(nil),
 		(*UpfPfcpFormat)(nil),
 		(*UpfPfcpFormatReply)(nil),
+		(*UpfPfcpHeartbeatsGet)(nil),
+		(*UpfPfcpHeartbeatsGetReply)(nil),
+		(*UpfPfcpHeartbeatsSet)(nil),
+		(*UpfPfcpHeartbeatsSetReply)(nil),
 		(*UpfPfcpPolicerSet)(nil),
 		(*UpfPfcpPolicerSetReply)(nil),
 		(*UpfPfcpPolicerShow)(nil),

--- a/test/e2e/binapi/upf/upf_rpc.ba.go
+++ b/test/e2e/binapi/upf/upf_rpc.ba.go
@@ -25,6 +25,8 @@ type RPCService interface {
 	UpfPfcpEndpointAddDel(ctx context.Context, in *UpfPfcpEndpointAddDel) (*UpfPfcpEndpointAddDelReply, error)
 	UpfPfcpEndpointDump(ctx context.Context, in *UpfPfcpEndpointDump) (RPCService_UpfPfcpEndpointDumpClient, error)
 	UpfPfcpFormat(ctx context.Context, in *UpfPfcpFormat) (*UpfPfcpFormatReply, error)
+	UpfPfcpHeartbeatsGet(ctx context.Context, in *UpfPfcpHeartbeatsGet) (*UpfPfcpHeartbeatsGetReply, error)
+	UpfPfcpHeartbeatsSet(ctx context.Context, in *UpfPfcpHeartbeatsSet) (*UpfPfcpHeartbeatsSetReply, error)
 	UpfPfcpPolicerSet(ctx context.Context, in *UpfPfcpPolicerSet) (*UpfPfcpPolicerSetReply, error)
 	UpfPfcpPolicerShow(ctx context.Context, in *UpfPfcpPolicerShow) (*UpfPfcpPolicerShowReply, error)
 	UpfPfcpReencode(ctx context.Context, in *UpfPfcpReencode) (*UpfPfcpReencodeReply, error)
@@ -314,6 +316,24 @@ func (c *serviceClient_UpfPfcpEndpointDumpClient) Recv() (*UpfPfcpEndpointDetail
 
 func (c *serviceClient) UpfPfcpFormat(ctx context.Context, in *UpfPfcpFormat) (*UpfPfcpFormatReply, error) {
 	out := new(UpfPfcpFormatReply)
+	err := c.conn.Invoke(ctx, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, api.RetvalToVPPApiError(out.Retval)
+}
+
+func (c *serviceClient) UpfPfcpHeartbeatsGet(ctx context.Context, in *UpfPfcpHeartbeatsGet) (*UpfPfcpHeartbeatsGetReply, error) {
+	out := new(UpfPfcpHeartbeatsGetReply)
+	err := c.conn.Invoke(ctx, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *serviceClient) UpfPfcpHeartbeatsSet(ctx context.Context, in *UpfPfcpHeartbeatsSet) (*UpfPfcpHeartbeatsSetReply, error) {
+	out := new(UpfPfcpHeartbeatsSetReply)
 	err := c.conn.Invoke(ctx, in, out)
 	if err != nil {
 		return nil, err

--- a/test/e2e/upg_e2e.go
+++ b/test/e2e/upg_e2e.go
@@ -730,6 +730,29 @@ var _ = ginkgo.Describe("UPG Binary API", func() {
 			gomega.Expect(showReply.FifoSize).To(gomega.BeEquivalentTo(512)) // KB
 			gomega.Expect(showReply.PreallocFifos).To(gomega.BeEquivalentTo(0))
 		})
+		ginkgo.It("configures PFCP heartbeats", func() {
+			hbConfig := &upf.UpfPfcpHeartbeatsSet{
+				Retries: 5,
+				Timeout: 10,
+			}
+			reply := &upf.UpfPfcpHeartbeatsSetReply{}
+			err := f.VPP.ApiChannel.SendRequest(hbConfig).ReceiveReply(reply)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			hbConfigStr, err := f.VPP.Ctl("show upf heartbeat-config")
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(hbConfigStr).To(gomega.ContainSubstring("Timeout: 10"))
+			gomega.Expect(hbConfigStr).To(gomega.ContainSubstring("Retries: 5"))
+
+			_, err = f.VPP.Ctl("upf pfcp heartbeat-config timeout 5 retries 15")
+			gomega.Expect(err).To(gomega.BeNil())
+			hbGetRequest := &upf.UpfPfcpHeartbeatsGet{}
+			hbGetReply := &upf.UpfPfcpHeartbeatsGetReply{}
+			err =  f.VPP.ApiChannel.SendRequest(hbGetRequest).ReceiveReply(hbGetReply)
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(hbGetReply.Timeout).To(gomega.Equal(uint32(5)))
+			gomega.Expect(hbGetReply.Retries).To(gomega.Equal(uint32(15)))
+		})
 	})
 })
 

--- a/upf/upf.api
+++ b/upf/upf.api
@@ -324,3 +324,22 @@ define upf_pfcp_policer_show_reply {
   u32 cir_pps;
   u32 cb_ms;
 };
+
+autoreply define upf_pfcp_heartbeats_set {
+  u32 client_index;
+  u32 context;
+  u32 timeout;
+  u32 retries;
+};
+
+define upf_pfcp_heartbeats_get {
+  u32 client_index;
+  u32 context;
+};
+
+define upf_pfcp_heartbeats_get_reply {
+  u32 client_index;
+  u32 context;
+  u32 timeout;
+  u32 retries;
+};

--- a/upf/upf.c
+++ b/upf/upf.c
@@ -380,6 +380,21 @@ vnet_upf_node_id_set (const pfcp_node_id_t * node_id)
   return VNET_API_ERROR_INVALID_ARGUMENT;
 }
 
+int
+vnet_upf_pfcp_heartbeat_config (u32 timeout, u32 retries)
+{
+  pfcp_server_main_t *psm = &pfcp_server_main;
+
+  if (!timeout || timeout > PFCP_MAX_HB_INTERVAL
+      || retries > PFCP_MAX_HB_RETRIES)
+    return -1;
+
+  psm->hb_cfg.timeout = timeout;
+  psm->hb_cfg.retries = retries;
+
+  return 0;
+}
+
 #if 0
 // TODO
 static int

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -1082,6 +1082,8 @@ int vnet_upf_tdf_ul_table_add_del (u32 vrf, fib_protocol_t fproto,
 
 int vnet_upf_node_id_set (const pfcp_node_id_t * node_id);
 
+int vnet_upf_pfcp_heartbeat_config (u32 timeout, u32 retires);
+
 void upf_session_dpo_add_or_lock (dpo_proto_t dproto, upf_session_t * sx,
 				  dpo_id_t * dpo);
 

--- a/upf/upf_api.c
+++ b/upf/upf_api.c
@@ -845,6 +845,54 @@ vl_api_upf_pfcp_policer_show_t_handler (vl_api_upf_pfcp_policer_show_t * mp)
   vl_api_send_msg (reg, (u8 *) rmp);
 }
 
+/* API message handler */
+static void
+vl_api_upf_pfcp_heartbeats_set_t_handler (vl_api_upf_pfcp_heartbeats_set_t *
+					  mp)
+{
+  vl_api_upf_pfcp_heartbeats_set_reply_t *rmp = NULL;
+  upf_main_t *sm = &upf_main;
+  u32 timeout, retries;
+  int rv = 0;
+
+  retries = clib_net_to_host_u32 (mp->retries);
+  timeout = clib_net_to_host_u32 (mp->timeout);
+
+  rv = vnet_upf_pfcp_heartbeat_config (timeout, retries);
+
+  REPLY_MACRO (VL_API_UPF_PFCP_HEARTBEATS_SET_REPLY);
+}
+
+/* API message handler */
+static void
+vl_api_upf_pfcp_heartbeats_get_t_handler (vl_api_upf_pfcp_heartbeats_get_t *
+					  mp)
+{
+  vl_api_upf_pfcp_heartbeats_get_reply_t *rmp = NULL;
+  upf_main_t *sm = &upf_main;
+  pfcp_server_main_t *psm = &pfcp_server_main;
+  vl_api_registration_t *reg;
+
+  reg = vl_api_client_index_to_registration (mp->client_index);
+  if (!reg)
+    {
+      return;
+    }
+
+  rmp = vl_msg_api_alloc (sizeof (*rmp));
+  clib_memset (rmp, 0, sizeof (*rmp));
+
+  rmp->_vl_msg_id =
+    htons (VL_API_UPF_PFCP_HEARTBEATS_GET_REPLY + sm->msg_id_base);
+  rmp->context = mp->context;
+
+  rmp->timeout = clib_host_to_net_u32 (psm->hb_cfg.timeout);
+  rmp->retries = clib_host_to_net_u32 (psm->hb_cfg.retries);
+
+  vl_api_send_msg (reg, (u8 *) rmp);
+}
+
+
 #include <upf/upf.api.c>
 
 static clib_error_t *

--- a/upf/upf_cli.c
+++ b/upf/upf_cli.c
@@ -1646,6 +1646,66 @@ VLIB_CLI_COMMAND (upf_add_policy_command, static) =
 };
 /* *INDENT-ON* */
 
+static clib_error_t *
+upf_pfcp_heartbeat_config_command_fn (vlib_main_t * vm,
+				      unformat_input_t * main_input,
+				      vlib_cli_command_t * cmd)
+{
+  unformat_input_t _line_input, *line_input = &_line_input;
+  upf_main_t *gtm = &upf_main;
+  clib_error_t *error = NULL;
+  u32 timeout = ~0;
+  u32 retries = ~0;
+  int rv = 0;
+
+  if (!unformat_user (main_input, unformat_line_input, line_input))
+    return 0;
+
+  while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
+    {
+      if (unformat (line_input, "timeout %u", &timeout))
+	;
+      else if (unformat (line_input, "retries %u", &retries));
+      else
+	return (clib_error_return (0, "unknown input '%U'",
+				   format_unformat_error, line_input));
+    }
+
+  rv = vnet_upf_pfcp_heartbeat_config (timeout, retries);
+  if (rv)
+    error = clib_return_error ("Invalid parameters");
+  return error;
+}
+
+/* *INDENT-OFF* */
+VLIB_CLI_COMMAND (upf_pfcp_heartbeat_config_command, static) = {
+    .path = "upf pfcp heartbeat-config",
+    .short_help = "upf pfcp heartbeat-config timeout <sec> retries <count>",
+    .function = upf_pfcp_heartbeat_config_command_fn,
+};
+/* *INDENT-ON* */
+
+static clib_error_t *
+upf_show_pfcp_heartbeat_config_command_fn (vlib_main_t * vm,
+					   unformat_input_t * main_input,
+					   vlib_cli_command_t * cmd)
+{
+  pfcp_server_main_t *psm = &pfcp_server_main;
+  vlib_cli_output (vm, "Timeout: %u Retries: %u", psm->hb_cfg.timeout,
+		   psm->hb_cfg.retries);
+  return NULL;
+}
+
+/* *INDENT-OFF* */
+VLIB_CLI_COMMAND (upf_show_pfcp_heartbeat_config_command, static) =
+{
+  .path = "show upf heartbeat-config",
+  .short_help =
+  "show upf heartbeat-config",
+  .function = upf_show_pfcp_heartbeat_config_command_fn,
+};
+/* *INDENT-ON* */
+
 /*
  * fd.io coding-style-patch-verification: ON
  *

--- a/upf/upf_pfcp_api.c
+++ b/upf/upf_pfcp_api.c
@@ -266,6 +266,7 @@ static int
 handle_heartbeat_response (pfcp_msg_t * msg, pfcp_decoded_msg_t * dmsg)
 {
   upf_main_t *gtm = &upf_main;
+  pfcp_server_main_t *psm = &pfcp_server_main;
   upf_node_assoc_t *n;
   pfcp_recovery_time_stamp_t ts =
     dmsg->simple_response.response.recovery_time_stamp;
@@ -294,7 +295,7 @@ handle_heartbeat_response (pfcp_msg_t * msg, pfcp_decoded_msg_t * dmsg)
     {
       upf_debug ("restarting HB timer\n");
       n->heartbeat_handle = upf_pfcp_server_start_timer
-	(PFCP_SERVER_HB_TIMER, n - gtm->nodes, PFCP_HB_INTERVAL);
+	(PFCP_SERVER_HB_TIMER, n - gtm->nodes, psm->hb_cfg.timeout);
     }
 
   return 0;
@@ -394,7 +395,7 @@ handle_association_setup_request (pfcp_msg_t * msg, pfcp_decoded_msg_t * dmsg)
   if (r == 0)
     {
       n->heartbeat_handle = upf_pfcp_server_start_timer
-	(PFCP_SERVER_HB_TIMER, n - gtm->nodes, PFCP_HB_INTERVAL);
+	(PFCP_SERVER_HB_TIMER, n - gtm->nodes, psm->hb_cfg.timeout);
 
       resp->cause = PFCP_CAUSE_REQUEST_ACCEPTED;
     }

--- a/upf/upf_pfcp_server.c
+++ b/upf/upf_pfcp_server.c
@@ -402,7 +402,14 @@ request_t1_expired (u32 seq_no)
 static void
 upf_pfcp_server_send_request (pfcp_msg_t * msg)
 {
-  enqueue_request (msg, 3, 10);
+  pfcp_server_main_t *psm = &pfcp_server_main;
+
+  if (pfcp_msg_type (msg->data) == PFCP_HEARTBEAT_REQUEST)
+    enqueue_request (msg, psm->hb_cfg.retries, psm->hb_cfg.timeout);
+  else
+    enqueue_request (msg, PFCP_DEFAULT_REQUEST_RETRIES,
+		     PFCP_DEFAULT_REQUEST_INTERVAL);
+
   upf_pfcp_send_data (msg);
 }
 
@@ -1421,6 +1428,10 @@ clib_error_t *pfcp_server_main_init (vlib_main_t * vm)
 
   upf_debug ("PFCP: start_time: %p, %d, %x.", psm, psm->start_time,
 	     psm->start_time);
+
+  psm->hb_cfg.retries = PFCP_DEFAULT_REQUEST_RETRIES;
+  psm->hb_cfg.timeout = PFCP_DEFAULT_REQUEST_INTERVAL;
+
   return 0;
 }
 

--- a/upf/upf_pfcp_server.h
+++ b/upf/upf_pfcp_server.h
@@ -22,7 +22,10 @@
 #include "pfcp.h"
 #include <vppinfra/tw_timer_1t_3w_1024sl_ov.h>
 
-#define PFCP_HB_INTERVAL 10
+#define PFCP_DEFAULT_REQUEST_INTERVAL 10
+#define PFCP_DEFAULT_REQUEST_RETRIES 3
+#define PFCP_MAX_HB_INTERVAL 120
+#define PFCP_MAX_HB_RETRIES 30
 #define PFCP_SERVER_HB_TIMER 0
 #define PFCP_SERVER_T1       1
 #define PFCP_SERVER_RESPONSE 2
@@ -35,6 +38,12 @@ typedef enum
   EVENT_TX,
   EVENT_URR,
 } pfcp_process_event_t;
+
+typedef struct
+{
+  u8 retries;
+  u8 timeout;
+} pfcp_hb_config_t;
 
 typedef struct
 {
@@ -98,6 +107,8 @@ typedef struct
   u32 *msg_pool_free;
   uword *request_q;
   mhash_t response_q;
+
+  pfcp_hb_config_t hb_cfg;
 
   vlib_frame_t *ip_lookup_tx_frames[2];
 

--- a/upf/upf_test.c
+++ b/upf/upf_test.c
@@ -170,6 +170,12 @@ api_upf_pfcp_policer_set (vat_main_t * vam)
   return -1;
 }
 
+static int
+api_upf_pfcp_heartbeats_set (vat_main_t * vam)
+{
+  return -1;
+}
+
 #include <upf/upf.api_test.c>
 
 /*


### PR DESCRIPTION
Use binapi or CLI to configure PFCP Heartbeat interval (timeout)
and number of retries to be sent before association drop.