### PR TITLE
Fix and improve 'show upf session'

### DIFF
--- a/upf/flowtable.h
+++ b/upf/flowtable.h
@@ -306,8 +306,6 @@ clib_error_t *flowtable_lifetime_update (flowtable_timeout_type_t type,
 clib_error_t *flowtable_max_lifetime_update (u16 value);
 clib_error_t *flowtable_init (vlib_main_t * vm);
 
-void foreach_upf_flows (clib_bihash_kv_48_8_t * kvp, void *arg);
-
 static inline u16
 flowtable_lifetime_get (flowtable_timeout_type_t type)
 {


### PR DESCRIPTION
Fix filtering by hex UP SEIDs (`show upf session up seid 0x...`)
Add `show upf session 0x... flows` to show the flows related to the
session.
Limit `show upf session` to displaying 100 sessions by default.
This can be overridden via `show upf session limit N`
(`limit 0` stands for unlimited)