### PR TITLE
Add association logging and fix use-after-free

### DIFF
--- a/test/e2e/vpp/vppstartup.go
+++ b/test/e2e/vpp/vppstartup.go
@@ -79,6 +79,10 @@ flowtable {
   log2-size 10
 }
 
+logging {
+  class upf { level info syslog-level info }
+}
+
 {{- if .InterruptMode }}
 upf {
   pfcp-server-mode interrupt

--- a/upf/upf.c
+++ b/upf/upf.c
@@ -568,6 +568,7 @@ upf_init (vlib_main_t * vm)
   sm->vlib_main = vm;
   sm->pfcp_spec_version = 15;
   sm->rand_base = random_default_seed ();
+  sm->log_class = vlib_log_register_class ("upf", 0);
 
   if ((error = vlib_call_init_function (vm, upf_proxy_main_init)))
     return error;

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -41,6 +41,7 @@
 #include <vnet/policer/policer.h>
 #include <vnet/session/session_types.h>
 #include <vlib/vlib.h>
+#include <vlib/log.h>
 
 #include "pfcp.h"
 #include "flowtable.h"
@@ -1026,6 +1027,8 @@ typedef struct
   uword *ue_ip_pool_index_by_identity;
 
   policer_t *pfcp_policers;
+
+  vlib_log_class_t log_class;
 } upf_main_t;
 
 extern const fib_node_vft_t upf_vft;

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -53,8 +53,6 @@
   do { } while (0)
 #endif
 
-#define upf_pfcp_associnfo(...) vlib_log_info
-
 upf_main_t upf_main;
 qos_pol_cfg_params_st pfcp_rate_cfg_main;
 
@@ -447,7 +445,8 @@ pfcp_new_association (session_handle_t session_handle,
 				 vlib_get_thread_index (), 0, 1);
 
   upf_pfcp_associnfo
-    ("PFCP Association Established: Node %U, Local IP %U, Remote IP %U\n",
+    (gtm,
+     "PFCP Association established: node %U, local IP %U, remote IP %U\n",
      format_node_id, &n->node_id, format_ip46_address, &n->lcl_addr,
      IP46_TYPE_ANY, format_ip46_address, &n->rmt_addr, IP46_TYPE_ANY);
   return n;
@@ -461,7 +460,8 @@ pfcp_release_association (upf_node_assoc_t * n)
   u32 idx = n->sessions;
 
   upf_pfcp_associnfo
-    ("PFCP Association Released: Node %U , Local IP %U, Remote IP %U\n",
+    (gtm,
+     "PFCP Association released: node %U, local IP %U, remote IP %U\n",
      format_node_id, &n->node_id, format_ip46_address, &n->lcl_addr,
      IP46_TYPE_ANY, format_ip46_address, &n->rmt_addr, IP46_TYPE_ANY);
 

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -53,6 +53,8 @@
   do { } while (0)
 #endif
 
+#define upf_pfcp_associnfo(...) vlib_log_info
+
 upf_main_t upf_main;
 qos_pol_cfg_params_st pfcp_rate_cfg_main;
 
@@ -444,6 +446,10 @@ pfcp_new_association (session_handle_t session_handle,
   vlib_increment_simple_counter (&gtm->upf_simple_counters[UPF_ASSOC_COUNTER],
 				 vlib_get_thread_index (), 0, 1);
 
+  upf_pfcp_associnfo
+    ("PFCP Association Established: Node %U, Local IP %U, Remote IP %U\n",
+     format_node_id, &n->node_id, format_ip46_address, &n->lcl_addr,
+     IP46_TYPE_ANY, format_ip46_address, &n->rmt_addr, IP46_TYPE_ANY);
   return n;
 }
 
@@ -453,6 +459,11 @@ pfcp_release_association (upf_node_assoc_t * n)
   upf_main_t *gtm = &upf_main;
   u32 node_id = n - gtm->nodes;
   u32 idx = n->sessions;
+
+  upf_pfcp_associnfo
+    ("PFCP Association Released: Node %U , Local IP %U, Remote IP %U\n",
+     format_node_id, &n->node_id, format_ip46_address, &n->lcl_addr,
+     IP46_TYPE_ANY, format_ip46_address, &n->rmt_addr, IP46_TYPE_ANY);
 
   switch (n->node_id.type)
     {
@@ -466,8 +477,6 @@ pfcp_release_association (upf_node_assoc_t * n)
       vec_free (n->node_id.fqdn);
       break;
     }
-
-  upf_debug ("pfcp_release_association idx: %u");
 
   while (idx != ~0)
     {

--- a/upf/upf_pfcp.h
+++ b/upf/upf_pfcp.h
@@ -19,6 +19,9 @@
 
 #define MAX_LEN 128
 
+#define upf_pfcp_associnfo(gtm, ...) \
+  vlib_log_info((gtm)->log_class, __VA_ARGS__)
+
 upf_node_assoc_t *pfcp_get_association (pfcp_node_id_t * node_id);
 upf_node_assoc_t *pfcp_new_association (session_handle_t session_handle,
 					ip46_address_t * lcl_addr,

--- a/upf/upf_pfcp_server.c
+++ b/upf/upf_pfcp_server.c
@@ -396,6 +396,7 @@ request_t1_expired (u32 seq_no)
   else
     {
       u8 type = pfcp_msg_type (msg->data);
+      u32 node = msg->node;
 
       upf_debug ("abort...\n");
       // TODO: handle communication breakdown....
@@ -404,9 +405,9 @@ request_t1_expired (u32 seq_no)
       pfcp_msg_pool_put (psm, msg);
 
       if (type == PFCP_HEARTBEAT_REQUEST
-	  && !pool_is_free_index (gtm->nodes, msg->node))
+	  && !pool_is_free_index (gtm->nodes, node))
 	{
-	  upf_node_assoc_t *n = pool_elt_at_index (gtm->nodes, msg->node);
+	  upf_node_assoc_t *n = pool_elt_at_index (gtm->nodes, node);
 
 	  upf_pfcp_associnfo
 	    (gtm,

--- a/upf/upf_pfcp_server.c
+++ b/upf/upf_pfcp_server.c
@@ -56,8 +56,6 @@
   do { } while (0)
 #endif
 
-#define upf_pfcp_associnfo(...) vlib_log_info
-
 static void upf_pfcp_make_response (pfcp_msg_t * resp, pfcp_msg_t * req);
 static void restart_response_timer (pfcp_msg_t * msg);
 
@@ -382,7 +380,8 @@ request_t1_expired (u32 seq_no)
 	{
 	  upf_node_assoc_t *n = pool_elt_at_index (gtm->nodes, msg->node);
 	  upf_pfcp_associnfo
-	    ("PFCP Association Suspicious: Node {%s}, Node IP {%U}, Local IP %U, Remote IP %U\n",
+	    (gtm,
+	     "PFCP Association unstable: node %U, local IP %U, remote IP %U\n",
 	     format_node_id, &n->node_id, format_ip46_address, &n->lcl_addr,
 	     IP46_TYPE_ANY, format_ip46_address, &n->rmt_addr, IP46_TYPE_ANY);
 	}
@@ -410,7 +409,8 @@ request_t1_expired (u32 seq_no)
 	  upf_node_assoc_t *n = pool_elt_at_index (gtm->nodes, msg->node);
 
 	  upf_pfcp_associnfo
-	    ("PFCP Association Lost: Node %U , Local IP %U, Remote IP %U\n",
+	    (gtm,
+	     "PFCP Association lost: node %U, local IP %U, remote IP %U\n",
 	     format_node_id, &n->node_id, format_ip46_address, &n->lcl_addr,
 	     IP46_TYPE_ANY, format_ip46_address, &n->rmt_addr, IP46_TYPE_ANY);
 

--- a/upf/upf_pfcp_server.h
+++ b/upf/upf_pfcp_server.h
@@ -245,6 +245,9 @@ _pfcp_msg_pool_put (pfcp_server_main_t * psm, pfcp_msg_t * m)
   ASSERT (m->is_valid_pool_item);
 
   vec_free (m->data);
+#if CLIB_DEBUG > 0
+  clib_memset (m, 0xfa, sizeof (pfcp_msg_t));
+#endif
   m->is_valid_pool_item = 0;
   vec_add1 (psm->msg_pool_free, m - psm->msg_pool);
 }


### PR DESCRIPTION
This adds some fixes to the changes from #294.
The code is buildable now. Also, the following is needed in `startup.conf` to enable UPG-related logging
(the class is called `upf` for consistency with other UPG aspects):

```
logging {
  class upf { level info syslog-level info }
}
```

As an alternative, logging can be enabled via CLI
```
set logging class upf level info syslog-level info
```

Without additional syslog config, `syslog-level` setting is needed to see the messages printed to the stderr. Otherwise, they will only be visible in `show logging` command output.

Also, a use-after-free issue is fixed in the PFCP server code, and `pfcp_msg_t` data poisoning is added.