### PR TITLE
Fix setting of buffer offload flags

### DIFF
--- a/upf/upf_forward.c
+++ b/upf/upf_forward.c
@@ -207,9 +207,10 @@ upf_forward (vlib_main_t * vm, vlib_node_runtime_t * node,
 		{
 		  if (is_ip4)
 		    {
-		      b->flags &= ~(VNET_BUFFER_OFFLOAD_F_TCP_CKSUM |
-				    VNET_BUFFER_OFFLOAD_F_UDP_CKSUM |
-				    VNET_BUFFER_OFFLOAD_F_IP_CKSUM);
+		      vnet_buffer_offload_flags_clear
+			(b, (VNET_BUFFER_OFFLOAD_F_TCP_CKSUM |
+			     VNET_BUFFER_OFFLOAD_F_UDP_CKSUM |
+			     VNET_BUFFER_OFFLOAD_F_IP_CKSUM));
 		      upf_nwi_if_and_fib_index
 			(gtm, FIB_PROTOCOL_IP4, far->forward.nwi_index,
 			 &vnet_buffer (b)->sw_if_index[VLIB_RX],
@@ -217,8 +218,9 @@ upf_forward (vlib_main_t * vm, vlib_node_runtime_t * node,
 		    }
 		  else
 		    {
-		      b->flags &= ~(VNET_BUFFER_OFFLOAD_F_TCP_CKSUM |
-				    VNET_BUFFER_OFFLOAD_F_UDP_CKSUM);
+		      vnet_buffer_offload_flags_clear
+			(b, (VNET_BUFFER_OFFLOAD_F_TCP_CKSUM |
+			     VNET_BUFFER_OFFLOAD_F_UDP_CKSUM));
 		      upf_nwi_if_and_fib_index
 			(gtm, FIB_PROTOCOL_IP6, far->forward.nwi_index,
 			 &vnet_buffer (b)->sw_if_index[VLIB_RX],

--- a/upf/upf_gtpu_encap.c
+++ b/upf/upf_gtpu_encap.c
@@ -425,8 +425,8 @@ upf_encap_inline (vlib_main_t * vm,
   upf_peer_t *peer0 = NULL, *peer1 = NULL, *peer2 = NULL, *peer3 = NULL;
 
   u32 const csum_mask =
-	  ~(VNET_BUFFER_OFFLOAD_F_TCP_CKSUM | VNET_BUFFER_OFFLOAD_F_UDP_CKSUM |
-	    (is_ip4 ? VNET_BUFFER_OFFLOAD_F_IP_CKSUM : 0));
+	  (VNET_BUFFER_OFFLOAD_F_TCP_CKSUM | VNET_BUFFER_OFFLOAD_F_UDP_CKSUM |
+	   (is_ip4 ? VNET_BUFFER_OFFLOAD_F_IP_CKSUM : 0));
 
   from = vlib_frame_vector_args (from_frame);
   n_left_from = from_frame->n_vectors;
@@ -811,10 +811,10 @@ upf_encap_inline (vlib_main_t * vm,
 	    }
 
 	  /* clear the checksum offload flags */
-	  b0->flags &= csum_mask;
-	  b1->flags &= csum_mask;
-	  b2->flags &= csum_mask;
-	  b3->flags &= csum_mask;
+	  vnet_buffer_offload_flags_clear(b0, csum_mask);
+	  vnet_buffer_offload_flags_clear(b1, csum_mask);
+	  vnet_buffer_offload_flags_clear(b2, csum_mask);
+	  vnet_buffer_offload_flags_clear(b3, csum_mask);
 
 	  pkts_encapsulated += 4;
 
@@ -994,7 +994,7 @@ upf_encap_inline (vlib_main_t * vm,
 	    }
 
 	  /* clear the checksum offload flags */
-	  b0->flags &= csum_mask;
+	  vnet_buffer_offload_flags_clear(b0, csum_mask);
 
 	  pkts_encapsulated++;
 

--- a/upf/upf_proxy_output.c
+++ b/upf/upf_proxy_output.c
@@ -306,9 +306,10 @@ upf_proxy_output (vlib_main_t * vm, vlib_node_runtime_t * node,
 		ip6_tcp_udp_icmp_compute_checksum (vm, b, ip6, &bogus);
 	    }
 
-	  b->flags &= ~VNET_BUFFER_OFFLOAD_F_TCP_CKSUM;
-	  b->flags &= ~VNET_BUFFER_OFFLOAD_F_UDP_CKSUM;
-	  b->flags &= ~VNET_BUFFER_OFFLOAD_F_IP_CKSUM;
+	  vnet_buffer_offload_flags_clear
+	    (b, (VNET_BUFFER_OFFLOAD_F_TCP_CKSUM |
+		 VNET_BUFFER_OFFLOAD_F_UDP_CKSUM |
+		 VNET_BUFFER_OFFLOAD_F_IP_CKSUM));
 
 	  next = ft_next_map_next[flow_next (flow, direction)];
 	  if (next == UPF_PROXY_OUTPUT_NEXT_PROCESS)

--- a/upf/upf_session_dpo.c
+++ b/upf/upf_session_dpo.c
@@ -356,7 +356,8 @@ ip4_ttl_and_checksum_check (vlib_buffer_t * b, ip4_header_t * ip, u16 * next,
 
   /* Verify checksum. */
   ASSERT ((ip->checksum == ip4_header_checksum (ip)) ||
-	  (b->flags & VNET_BUFFER_OFFLOAD_F_IP_CKSUM));
+	  ((b->flags & VNET_BUFFER_F_OFFLOAD) &&
+	   (vnet_buffer (b)->oflags & VNET_BUFFER_OFFLOAD_F_IP_CKSUM)));
 }
 
 /* end of copy from ip4_forward.c */

--- a/upf/upf_tcp_forward.c
+++ b/upf/upf_tcp_forward.c
@@ -309,9 +309,10 @@ upf_tcp_forward (vlib_main_t * vm, vlib_node_runtime_t * node,
 		ip6_tcp_udp_icmp_compute_checksum (vm, b, ip6, &bogus);
 	    }
 
-	  b->flags &= ~VNET_BUFFER_OFFLOAD_F_TCP_CKSUM;
-	  b->flags &= ~VNET_BUFFER_OFFLOAD_F_UDP_CKSUM;
-	  b->flags &= ~VNET_BUFFER_OFFLOAD_F_IP_CKSUM;
+	  vnet_buffer_offload_flags_clear
+	    (b, (VNET_BUFFER_OFFLOAD_F_TCP_CKSUM |
+		 VNET_BUFFER_OFFLOAD_F_UDP_CKSUM |
+		 VNET_BUFFER_OFFLOAD_F_IP_CKSUM));
 
 	stats:
 	  len = vlib_buffer_length_in_chain (vm, b);


### PR DESCRIPTION
Rather than in b->flags, the offload flags are really stored in `vnet_buffer (b)->oflags' and `vnet_buffer_offload_flags_clear' should be used to set them.