### PR TITLE
FPP-VPP: update to release 22.02.2

### DIFF
--- a/vpp.spec
+++ b/vpp.spec
@@ -1,1 +1,1 @@
-VPP_IMAGE_BASE=quay.io/travelping/fpp-vpp:v22.02.1
+VPP_IMAGE_BASE=quay.io/travelping/fpp-vpp:v22.02.2


### PR DESCRIPTION
New release of FPP-VPP provides new feature of logging:
- Log if NAT can't allocate port for given binding to make a translation
- Log if NAT flows table is full
- Set NAT logs rate limit to 1 message per second.