### PR TITLE
[CENNSO-120] Fix skipping classification in upf-gtpu[46]-input (no PFCP_CLASSIFY)

### DIFF
--- a/test/e2e/framework/sessionconfig.go
+++ b/test/e2e/framework/sessionconfig.go
@@ -51,6 +51,7 @@ type SessionConfig struct {
 	NatPoolName        string
 	IMSI               string
 	IPFIXTemplate      string
+	SkipSDFFilter      bool
 }
 
 const (
@@ -232,7 +233,7 @@ func (cfg SessionConfig) forwardPDR(pdrID uint16, farID, urrID, precedence uint3
 		panic("bad UPGMode")
 	}
 
-	if appID == "" {
+	if appID == "" && !cfg.SkipSDFFilter {
 		if sdfFilter == "" {
 			sdfFilter = "permit out ip from any to assigned"
 		}
@@ -274,7 +275,7 @@ func (cfg SessionConfig) reversePDR(pdrID uint16, farID, urrID, precedence uint3
 			ie.NewSourceInterface(ie.SrcInterfaceCore))
 	}
 
-	if appID == "" {
+	if appID == "" && !cfg.SkipSDFFilter {
 		if sdfFilter == "" {
 			sdfFilter = "permit out ip from any to assigned"
 		}

--- a/test/e2e/upg_e2e.go
+++ b/test/e2e/upg_e2e.go
@@ -1686,6 +1686,9 @@ func describeGTPProxy(title string, ipMode framework.UPGIPMode) {
 				ProxyCoreTEID:   framework.ProxyCoreTEID,
 				ProxyAccessIP:   f.VPPCfg.GetVPPAddress("access").IP,
 				ProxyCoreIP:     f.VPPCfg.GetVPPAddress("core").IP,
+				// Make sure PFCP_CLASSIFY is not set for the session.
+				// That's an important edge case
+				SkipSDFFilter: true,
 			}
 			var err error
 			seid, err = f.PFCP.EstablishSession(f.Context, 0, cfg.SessionIEs()...)


### PR DESCRIPTION
If a session that does GTPU decap doesn't have a UE IP or any ACL
rules, upf-ip[46]-node func was crashing while trying to update the flow
stats.

The problem was introduced while implementing IPFIX.