### PR TITLE
remove support for pre 3GPP Rel.16 PFCP and UPF features

### DIFF
--- a/upf/test/test_upf.py
+++ b/upf/test/test_upf.py
@@ -118,7 +118,6 @@ class IPv4Mixin(object):
             "upf nwi name cp vrf 0",
             "upf nwi name epc vrf 100",
             "upf nwi name sgi vrf 200",
-            "upf specification release 16",
             "upf node-id fqdn upg",
             "upf pfcp endpoint ip %s vrf 0" % cls.if_cp.local_ip4,
             "ip route add 0.0.0.0/0 table 200 via %s %s" %
@@ -263,7 +262,6 @@ class IPv6Mixin(object):
             "upf nwi name cp vrf 0",
             "upf nwi name epc vrf 100",
             "upf nwi name sgi vrf 200",
-            "upf specification release 16",
             "upf node-id ip6 %s" % cls.if_cp.local_ip6,
             "upf pfcp endpoint ip %s vrf 0" % cls.if_cp.local_ip6,
             "ip route add ::/0 table 200 via %s %s" %

--- a/upf/upf.c
+++ b/upf/upf.c
@@ -566,7 +566,6 @@ upf_init (vlib_main_t * vm)
 
   sm->vnet_main = vnet_get_main ();
   sm->vlib_main = vm;
-  sm->pfcp_spec_version = 15;
   sm->rand_base = random_default_seed ();
   sm->log_class = vlib_log_register_class ("upf", 0);
 

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -1015,8 +1015,6 @@ typedef struct
   /* adf apps vector */
   upf_adf_app_t *upf_apps;
 
-  //TODO: Change to UPF flags?
-  u32 pfcp_spec_version;
   u32 rand_base;
 
   pfcp_node_id_t node_id;

--- a/upf/upf_cli.c
+++ b/upf/upf_cli.c
@@ -786,58 +786,6 @@ VLIB_CLI_COMMAND (upf_tdf_ul_enable_command, static) = {
 /* *INDENT-ON* */
 
 static clib_error_t *
-upf_spec_release_command_fn (vlib_main_t * vm,
-			     unformat_input_t * main_input,
-			     vlib_cli_command_t * cmd)
-{
-  unformat_input_t _line_input, *line_input = &_line_input;
-  upf_main_t *gtm = &upf_main;
-  u32 spec_version = 0;
-
-  if (!unformat_user (main_input, unformat_line_input, line_input))
-    return 0;
-
-  while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
-    {
-      if (unformat (line_input, "release %u", &spec_version))
-	break;
-      else
-	return 0;
-    }
-
-  gtm->pfcp_spec_version = spec_version;
-  return NULL;
-}
-
-/* *INDENT-OFF* */
-VLIB_CLI_COMMAND (upf_spec_release_command, static) = {
-    .path = "upf specification",
-    .short_help = "upf specification release [MAJOR.MINOR.PATCH]",
-    .function = upf_spec_release_command_fn,
-};
-/* *INDENT-ON* */
-
-static clib_error_t *
-upf_show_spec_release_command_fn (vlib_main_t * vm,
-				  unformat_input_t * main_input,
-				  vlib_cli_command_t * cmd)
-{
-  upf_main_t *gtm = &upf_main;
-  vlib_cli_output (vm, "PFCP version: %u", gtm->pfcp_spec_version);
-  return NULL;
-}
-
-/* *INDENT-OFF* */
-VLIB_CLI_COMMAND (upf_show_spec_release_command, static) =
-{
-  .path = "show upf specification release",
-  .short_help =
-  "show upf specification release",
-  .function = upf_show_spec_release_command_fn,
-};
-/* *INDENT-ON* */
-
-static clib_error_t *
 upf_node_id_command_fn (vlib_main_t * vm,
 			unformat_input_t * main_input,
 			vlib_cli_command_t * cmd)

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -2830,18 +2830,15 @@ format_pfcp_session (u8 * s, va_list * args)
 	      vlib_time_now (gtm->vlib_main) - sx->last_ul_traffic,
 	      rules->inactivity_timer.handle);
 
-  if (gtm->pfcp_spec_version == 16)
+  u16 idx = 1;
+  s = format (s, "  TEID assignment per choose ID\n");
+  for (idx = 0; idx < 256 /* U8_MAX limits value of CHID */ ; idx++)
     {
-      u16 idx = 1;
-      s = format (s, "  TEID assignment per choose ID\n");
-      for (idx = 0; idx < 256 /* U8_MAX limits value of CHID */ ; idx++)
-	{
-	  u32 teid = *sparse_vec_elt_at_index (sx->teid_by_chid, idx);
-	  if (teid)
-	    s = format (s, "    %3u: %u (0x%08x)\n", idx, teid, teid);
+      u32 teid = *sparse_vec_elt_at_index (sx->teid_by_chid, idx);
+      if (teid)
+	s = format (s, "    %3u: %u (0x%08x)\n", idx, teid, teid);
 
-	  idx += 1;
-	}
+      idx += 1;
     }
 
   vec_foreach (pdr, rules->pdr)


### PR DESCRIPTION
The PFCP User Plane IP Resource Information IE has been removed in 3GPP Release 16 and UP based TEID assignment is mandatory since that release as well.

User Plane IP Resource Information where never really useful, therefore dropping it helps us simplifying the code without losing anything.

UP based TEID assignment (FTUP feature flag) is mandatory if multiple SMFs want to control the same UPF. This is also an important feature (which part of why it become mandatory in 3GPP Rel. 16).