### PR TITLE
Fix crash in session delete (sparse_vec_free)

### DIFF
--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -1162,7 +1162,7 @@ pfcp_free_session (upf_session_t * sx)
   for (size_t i = 0; i < ARRAY_LEN (sx->rules); i++)
     pfcp_free_rules (sx, i);
 
-  sparse_vec_free (sx->teid_by_chid);
+  sparse_vec_free (*sx->teid_by_chid);
 
   if (sx->nat_addr)
     upf_delete_nat_binding (sx);


### PR DESCRIPTION
I am facing several issues when the PFCP session is removed for a given UE, usually vpp/upg is left on a deadlock state and can't be used anymore. Debugging this further the culprit is in the call to `sparse_vec_free`. I guess the vec pointer has to be deferenced. Similar code flow exists on other parts of vpp (e.g. https://github.com/FDio/vpp/blob/9bc72ac8de6dcc74aa82fa6c3223e9f93b2dc3c2/src/vnet/udp/udp.c#L491-L510)
Runtime testing this change and the deadlock is gone

regards