### PR TITLE
[CENNSO-102] Fix UE IP Address Pool Identity IE handling code

### DIFF
--- a/hack/run-integration-tests-internal.sh
+++ b/hack/run-integration-tests-internal.sh
@@ -12,6 +12,6 @@ make -C /vpp-src/test VPP_BIN=/usr/bin/vpp \
      WS_ROOT=/vpp-src \
      BR=/vpp-src/build-root \
      TEST_DIR=/tmp \
-     TEST=test_upf V=2 \
+     TEST="${TEST:-test_upf}" V=2 \
      EXTERN_TESTS=/src/upf/test \
      RND_SEED=$(python3 -c 'import time; print(time.time())')

--- a/upf/pfcp.c
+++ b/upf/pfcp.c
@@ -4647,7 +4647,7 @@ decode_ue_ip_address_pool_identity (u8 * data, u16 length, void *p)
   if (length < id_len)
     return PFCP_CAUSE_INVALID_LENGTH;
 
-  get_vec (v, id_len, data);
+  get_vec (*v, id_len, data);
 
   return 0;
 }
@@ -4655,7 +4655,8 @@ decode_ue_ip_address_pool_identity (u8 * data, u16 length, void *p)
 static int
 encode_ue_ip_address_pool_identity (void *p, u8 ** vec)
 {
-  pfcp_ue_ip_address_pool_identity_t **v = p;
+  pfcp_ue_ip_address_pool_identity_t *v =
+    (pfcp_ue_ip_address_pool_identity_t *) p;
 
   put_u16 (*vec, vec_len (*v));
   vec_append (*vec, *v);

--- a/upf/test/association_setup_response_ue_ip_address_pool_identity.txt
+++ b/upf/test/association_setup_response_ue_ip_address_pool_identity.txt
@@ -1,0 +1,11 @@
+PFCP: seq 3683, Association Setup Response (6).
+Node ID: lgw-ref1-upg-volvo-lane-a-upg-a1
+Cause: 1
+Recovery Time Stamp: 2023/01/27 18:30:19:000
+UP Function Features: BUCP:0,DDND:0,DLBD:0,TRST:0,FTUP:1,PFDM:0,HEEU:0,TREU:0,EMPU:1,PDIU:0,UDBC:0,QUOAC:0,TRACE:0,FRRT:0,PFDE:0,EPFAR:0,DPDRA:0,ADPDP:0,UEIP:0,SSET:0,MNOP:0,MTE:0,BUNDL:0,GCOM:0,MPAS:0,RTTL:0,VTIME:1,NORP:0,IPTV:0,IP6PL:0,TSCU:0,MPTCP:0,ATSSS-LL:0,QFQM:0,GPQM:0
+UE IP Address Pool Information
+  UE IP address Pool Identity: pool-test
+  Network Instance: test
+  BBF NAT Port Block: pool-test
+TP: Build Identifier: vpp v22.02.0-15~gc4a276389 built by root on buildkitsandbox at 2022-11-18T14:00:10
+

--- a/upf/test/test_upf.py
+++ b/upf/test/test_upf.py
@@ -5,6 +5,7 @@ import os
 import os.path
 from unittest import skip
 from random import getrandbits
+from scapy.compat import hex_bytes
 from scapy.utils import hexdump
 from scapy.contrib.pfcp import CauseValues, IE_ApplyAction, IE_Cause, \
     IE_CreateFAR, IE_CreatePDR, IE_CreateURR, IE_DestinationInterface, \
@@ -1774,6 +1775,11 @@ class TestPFCPReencode(framework.VppTestCase):
         req = PFCP(version=1, seq=3, seid=5577006791947779410) / \
             PFCPSessionDeletionResponse(IE_list=[ IE_Cause(cause=1) ] + report_ies)
         self.verify_reencode("session_deletion_response", req)
+
+        # FIXME: scapy doesn't support "UE IP address Pool Information"
+        # and "BBF NAT Port Block" IEs in this request
+        req = hex_bytes("200600ce000e6300003c002202206c67772d726566312d7570672d766f6c766f2d6c616e652d612d7570672d6131001300010100600004e77e96bb002b0006100100040000800000060de90000004000e9002700b1000b0009706f6f6c2d746573740016000504746573748012000b0de9706f6f6c2d746573748002005448f9767070207632322e30322e302d31357e67633461323736333839206275696c7420627920726f6f74206f6e206275696c646b697473616e64626f7820617420323032322d31312d31385431343a30303a3130")
+        self.verify_reencode("association_setup_response_ue_ip_address_pool_identity", req)
 
 # TODO: send session report response
 # TODO: check for heartbeat requests from UPF


### PR DESCRIPTION
This fixes crashes due to heap corruption in UE IP Address Pool Identity IE encoding and decoding functions.
Also, integration test script is fixed so just one of the test cases can be run instead of the whole test_upf.