### PR TITLE
[CENNSO-688] Fix excess heartbeat requests after reassociation

### DIFF
--- a/test/e2e/pfcp/multitimer.go
+++ b/test/e2e/pfcp/multitimer.go
@@ -1,0 +1,55 @@
+package pfcp
+
+import (
+	"sync"
+	"time"
+)
+
+type MultiTimer struct {
+	timers     map[int]*time.Timer
+	channel    chan int
+	channelMtx sync.Mutex
+	timersMtx  sync.Mutex
+}
+
+func (mt *MultiTimer) StartTimer(id int, duration time.Duration) {
+	mt.timersMtx.Lock()
+	defer mt.timersMtx.Unlock()
+
+	if mt.timers == nil {
+		mt.timers = make(map[int]*time.Timer)
+	}
+
+	if timer, ok := mt.timers[id]; ok {
+		timer.Stop()
+	}
+
+	timer := time.AfterFunc(duration, func() {
+		mt.Channel() <- id
+		mt.timersMtx.Lock()
+		defer mt.timersMtx.Unlock()
+		delete(mt.timers, id)
+	})
+	mt.timers[id] = timer
+}
+
+func (mt *MultiTimer) StopTimer(id int) {
+	mt.timersMtx.Lock()
+	defer mt.timersMtx.Unlock()
+
+	if timer, ok := mt.timers[id]; ok {
+		timer.Stop()
+		delete(mt.timers, id)
+	}
+}
+
+func (mt *MultiTimer) Channel() chan int {
+	mt.channelMtx.Lock()
+	defer mt.channelMtx.Unlock()
+
+	if mt.channel == nil {
+		mt.channel = make(chan int)
+	}
+
+	return mt.channel
+}

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -465,6 +465,8 @@ pfcp_release_association (upf_node_assoc_t * n)
      format_node_id, &n->node_id, format_ip46_address, &n->lcl_addr,
      IP46_TYPE_ANY, format_ip46_address, &n->rmt_addr, IP46_TYPE_ANY);
 
+  upf_pfcp_server_stop_heartbeat_timer (n);
+
   switch (n->node_id.type)
     {
     case NID_IPv4:

--- a/upf/upf_pfcp_server.h
+++ b/upf/upf_pfcp_server.h
@@ -146,6 +146,7 @@ void upf_pfcp_session_start_stop_urr_time (u32 si, urr_time_t * t,
 
 u32 upf_pfcp_server_start_timer (u8 type, u32 id, u32 seconds);
 void upf_pfcp_server_stop_msg_timer (pfcp_msg_t * msg);
+void upf_pfcp_server_stop_heartbeat_timer (upf_node_assoc_t * n);
 void upf_pfcp_server_deferred_free_msgs_by_node (u32 node);
 
 int upf_pfcp_send_request (upf_session_t * sx, pfcp_decoded_msg_t * dmsg);


### PR DESCRIPTION
When a PFCP association is released and later reestablished, or
established towards another SMF/PGW-C, the old heartbeat timer was not
being stopped, causing excess heartbeat requests to be sent by the UPG.
