### PR TITLE
[CENNSO-971] ipfix: fix frame leak

### DIFF
--- a/upf/upf_ipfix.c
+++ b/upf/upf_ipfix.c
@@ -226,6 +226,22 @@ upf_ipfix_data_callback (flow_report_main_t *frm, ipfix_exporter_t *exp,
   vlib_buffer_t *b = upf_ipfix_get_buffer (vm, context);
   if (b)
     upf_ipfix_export_send (vm, b, context, now);
+
+  /*
+   * The following is a workaround for a VPP bug fixed in this commit
+   * https://github.com/FDio/vpp/commit/eaa83c0439c13b76525224267c23d0cf52a6668b
+   *
+   * When migrating to newer VPP versions (22.10+), this workaround
+   * will no longer compile and should be removed, as the leak is
+   * fixed in 22.10 and later versions
+   */
+  if (!f->n_vectors)
+    {
+      vlib_node_runtime_t *rt = vlib_node_get_runtime (vm, node_index);
+      vlib_frame_free (vm, rt, f);
+      return 0;
+    }
+
   return f;
 }
 


### PR DESCRIPTION
There's a bug in VPP 22.02 code which is fixed in this upstream commit (present in VPP 22.10):
https://github.com/FDio/vpp/commit/eaa83c0439c13b76525224267c23d0cf52a6668b

It's logistically simpler to add a trivial workaround in UPG-VPP code than backporting the patch, though. The workaround code will no longer compile when migrating to newer VPP (22.10+) and should then be removed.