### PR TITLE
[CENNSO-1051] Removed python2 from dependencies

### DIFF
--- a/vpp.spec
+++ b/vpp.spec
@@ -1,1 +1,1 @@
-VPP_IMAGE_BASE=quay.io/travelping/fpp-vpp:22.02.0-18-bb837ec44
+VPP_IMAGE_BASE=quay.io/travelping/fpp-vpp:v22.02.7

--- a/vpp.spec
+++ b/vpp.spec
@@ -1,1 +1,1 @@
-VPP_IMAGE_BASE=quay.io/travelping/fpp-vpp:22.10.0-28-401c8cddf
+VPP_IMAGE_BASE=quay.io/travelping/fpp-vpp:22.02.0-18-4ca9d84e4

--- a/vpp.spec
+++ b/vpp.spec
@@ -1,1 +1,1 @@
-VPP_IMAGE_BASE=quay.io/travelping/fpp-vpp:v22.02.6
+VPP_IMAGE_BASE=quay.io/travelping/fpp-vpp:22.10.0-28-401c8cddf

--- a/vpp.spec
+++ b/vpp.spec
@@ -1,1 +1,1 @@
-VPP_IMAGE_BASE=quay.io/travelping/fpp-vpp:22.02.0-18-4ca9d84e4
+VPP_IMAGE_BASE=quay.io/travelping/fpp-vpp:22.02.0-18-bb837ec44


### PR DESCRIPTION
This fixes CVE-2022-37454 for images