### PR TITLE
[CENNSO-1276] feat: add metric 'upf_timers_missed'

### DIFF
--- a/upf/upf.h
+++ b/upf/upf.h
@@ -581,7 +581,8 @@ typedef enum
   UPF_FLOWS_NOT_STITCHED_TCP_OPS_TIMESTAMP = 5,
   UPF_FLOWS_NOT_STITCHED_TCP_OPS_SACK_PERMIT = 6,
   UPF_FLOWS_STITCHED_DIRTY_FIFOS = 7,
-  UPF_N_COUNTERS = 8,
+  UPF_TIMERS_MISSED = 8,
+  UPF_N_COUNTERS = 9,
 } upf_counters_type_t;
 
 #define foreach_upf_counter_name   \
@@ -592,6 +593,7 @@ typedef enum
   _(FLOWS_NOT_STITCHED_MSS_MISMATCH, mss_mismatch, upf) \
   _(FLOWS_NOT_STITCHED_TCP_OPS_TIMESTAMP, tcp_ops_tstamp, upf) \
   _(FLOWS_NOT_STITCHED_TCP_OPS_SACK_PERMIT, tcp_ops_sack_permit, upf) \
+  _(TIMERS_MISSED, timers_missed, upf) \
   _(FLOWS_STITCHED_DIRTY_FIFOS, stitched_dirty_fifos, upf)
 
 /* TODO: measure if more optimize cache line aware layout

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -593,8 +593,8 @@ typedef enum
   _(FLOWS_NOT_STITCHED_MSS_MISMATCH, mss_mismatch, upf) \
   _(FLOWS_NOT_STITCHED_TCP_OPS_TIMESTAMP, tcp_ops_tstamp, upf) \
   _(FLOWS_NOT_STITCHED_TCP_OPS_SACK_PERMIT, tcp_ops_sack_permit, upf) \
-  _(TIMERS_MISSED, timers_missed, upf) \
-  _(FLOWS_STITCHED_DIRTY_FIFOS, stitched_dirty_fifos, upf)
+  _(FLOWS_STITCHED_DIRTY_FIFOS, stitched_dirty_fifos, upf) \
+  _(TIMERS_MISSED, timers_missed, upf)
 
 /* TODO: measure if more optimize cache line aware layout
  *       of the counters and quotas has any performance impcat */

--- a/upf/upf_pfcp_server.c
+++ b/upf/upf_pfcp_server.c
@@ -1006,6 +1006,9 @@ upf_pfcp_session_urr_timer (upf_session_t * sx, f64 now)
 	  clib_warning("WARNING: timer late by %.4f seconds: "#V, \
 		      (NOW) - (V).expected);			  \
         }                                                         \
+          vlib_increment_simple_counter (                         \
+            &gtm->upf_simple_counters[UPF_TIMERS_MISSED],         \
+	    vlib_get_thread_index (), 0, 1);                      \
     } while (0)
 
 #define URR_COND_TIME(t, time)			\

--- a/upf/upf_pfcp_server.c
+++ b/upf/upf_pfcp_server.c
@@ -996,11 +996,16 @@ upf_pfcp_session_urr_timer (upf_session_t * sx, f64 now)
 #define urr_check(V, NOW)				\
     (((V).base != 0) && ((V).period != 0) &&		\
      ((V).expected != 0) && (V).expected < (NOW))
-#define urr_check_late(V, NOW)					\
-    do { 							\
-      if ((V).expected < (NOW) - LATE_TIMER_WARNING_THRESHOLD)	\
-	clib_warning("WARNING: timer late by %.4f seconds: "#V, \
-		     (NOW) - (V).expected);			\
+#define urr_check_late(V, NOW)					  \
+    do { 							  \
+      if ((V).expected < (NOW) - LATE_TIMER_WARNING_THRESHOLD)    \
+        {	                                                  \
+          vlib_increment_simple_counter (                         \
+            &gtm->upf_simple_counters[UPF_TIMERS_MISSED],         \
+	    vlib_get_thread_index (), 0, 1);                      \
+	  clib_warning("WARNING: timer late by %.4f seconds: "#V, \
+		      (NOW) - (V).expected);			  \
+        }                                                         \
     } while (0)
 
 #define URR_COND_TIME(t, time)			\

--- a/upf/upf_pfcp_server.c
+++ b/upf/upf_pfcp_server.c
@@ -1006,9 +1006,6 @@ upf_pfcp_session_urr_timer (upf_session_t * sx, f64 now)
 	  clib_warning("WARNING: timer late by %.4f seconds: "#V, \
 		      (NOW) - (V).expected);			  \
         }                                                         \
-          vlib_increment_simple_counter (                         \
-            &gtm->upf_simple_counters[UPF_TIMERS_MISSED],         \
-	    vlib_get_thread_index (), 0, 1);                      \
     } while (0)
 
 #define URR_COND_TIME(t, time)			\


### PR DESCRIPTION
this commit adds the metric 'upf_timers_missed' to make the issue visible without relying to scraping logs.