### PR TITLE
[CENNSO-150] feat: implement MPAS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,9 +158,9 @@ endif (NOT CMAKE_BUILD_TYPE)
 SET(UPF_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR} CACHE STRING "upf_install_prefix")
 
 if (CMAKE_BUILD_TYPE STREQUAL "Release")
-   set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Wall -march=corei7 -mtune=corei7-avx -O3 -g")
+   set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Wall -march=corei7 -mtune=corei7-avx -O3 -g -Wno-address-of-packed-member -Wno-macro-redefined")
 elseif (CMAKE_BUILD_TYPE STREQUAL "Debug")
-   set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -march=corei7 -mtune=corei7-avx -O0 -g")
+   set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -march=corei7 -mtune=corei7-avx -O0 -g -Wno-address-of-packed-member -Wno-macro-redefined")
    add_definitions(-DCLIB_DEBUG -DVLIB_BUFFER_TRACE_TRAJECTORY -fPIC -fstack-protector-all)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,9 +158,9 @@ endif (NOT CMAKE_BUILD_TYPE)
 SET(UPF_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR} CACHE STRING "upf_install_prefix")
 
 if (CMAKE_BUILD_TYPE STREQUAL "Release")
-   set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Wall -march=corei7 -mtune=corei7-avx -O3 -g -Wno-address-of-packed-member -Wno-macro-redefined")
+   set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Wall -march=corei7 -mtune=corei7-avx -O3 -g")
 elseif (CMAKE_BUILD_TYPE STREQUAL "Debug")
-   set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -march=corei7 -mtune=corei7-avx -O0 -g -Wno-address-of-packed-member -Wno-macro-redefined")
+   set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -march=corei7 -mtune=corei7-avx -O0 -g")
    add_definitions(-DCLIB_DEBUG -DVLIB_BUFFER_TRACE_TRAJECTORY -fPIC -fstack-protector-all)
 endif()
 

--- a/test/e2e/pfcp/pfcp.go
+++ b/test/e2e/pfcp/pfcp.go
@@ -133,6 +133,8 @@ const (
 	timerIDHeartbeatTimeout timerID = iota
 	timerIDRetransmit
 
+	// This is hack to perform and validate CP SEID change on session migration in SMFSet
+	// Session CP SEID will be increased on this value after migration
 	CP_SEID_CHANGE_ON_SMF_MIGRATION SEID = 0x1_0000_000
 )
 
@@ -906,7 +908,7 @@ func (pc *PFCPConnection) sendSessionReportResponse(req *message.SessionReportRe
 		}
 		ses = pc.sessions[SEID(fseidFields.SEID)]
 		if ses != nil {
-			// change seid to test for updated cp seid in upf
+			// update CP SEID to validate change of node
 
 			delete(pc.sessions, SEID(fseidFields.SEID))
 			ses.cp_seid += CP_SEID_CHANGE_ON_SMF_MIGRATION

--- a/test/e2e/pfcp/pfcp.go
+++ b/test/e2e/pfcp/pfcp.go
@@ -349,7 +349,7 @@ var pfcpTransitions = map[pfcpTransitionKey]pfcpTransitionFunc{
 
 		if pc.FITHook.IsFaultInjected(util.FaultSessionForgot) {
 			return pc.sendSessionReportResponseFIT(ev.msg.(*message.SessionReportRequest))
-		} else if pc.FITHook.IsFaultInjected(util.FaultReportResponse) {
+		} else if pc.FITHook.IsFaultInjected(util.FaultNoReportResponse) {
 			return nil
 		} else {
 			return pc.sendSessionReportResponse(ev.msg.(*message.SessionReportRequest))

--- a/test/e2e/pfcp/pfcp.go
+++ b/test/e2e/pfcp/pfcp.go
@@ -43,7 +43,7 @@ type pfcpState string
 type pfcpEventType string
 
 type eventResult struct {
-	seid    SEID
+	cp_seid SEID
 	payload interface{}
 	err     error
 }
@@ -53,10 +53,10 @@ type pfcpEvent struct {
 	eventType    pfcpEventType
 	resultCh     chan eventResult
 	attemptsLeft int
-	// seid is used in the requests that were not sent yet.  It's
+	// cp_seid is used in the requests that were not sent yet.  It's
 	// needed b/c SessionEstablishmentRequest doesn't have the
 	// session's SEID in it
-	seid    SEID
+	cp_seid SEID
 	timerID timerID
 }
 
@@ -132,6 +132,8 @@ const (
 
 	timerIDHeartbeatTimeout timerID = iota
 	timerIDRetransmit
+
+	CP_SEID_CHANGE_ON_SMF_MIGRATION SEID = 0x1_0000_000
 )
 
 var (
@@ -196,8 +198,8 @@ func pfcpSessionResponse(et sessionEventType) pfcpTransitionFunc {
 		if reqEv, err := pc.acceptResponse(ev); err != nil {
 			if reqEv != nil {
 				reqEv.resultCh <- eventResult{
-					seid: reqEv.seid,
-					err:  err,
+					cp_seid: reqEv.cp_seid,
+					err:     err,
 				}
 			}
 			var serverErr *PFCPServerError
@@ -213,7 +215,7 @@ func pfcpSessionResponse(et sessionEventType) pfcpTransitionFunc {
 		} else if reqEv != nil {
 			result, err := pc.sessionEvent(et, ev)
 			reqEv.resultCh <- eventResult{
-				seid:    reqEv.seid,
+				cp_seid: reqEv.cp_seid,
 				payload: result,
 				err:     err,
 			}
@@ -319,7 +321,7 @@ var pfcpTransitions = map[pfcpTransitionKey]pfcpTransitionFunc{
 	},
 
 	{pfcpStateAssociated, pfcpEventActEstablishSession}: func(pc *PFCPConnection, ev pfcpEvent) error {
-		if err := pc.createSession(ev.seid); err != nil {
+		if err := pc.createSession(ev.cp_seid); err != nil {
 			return errors.Wrap(err, "error creating session")
 		}
 		return pc.sendRequest(ev)
@@ -345,6 +347,8 @@ var pfcpTransitions = map[pfcpTransitionKey]pfcpTransitionFunc{
 
 		if pc.FITHook.IsFaultInjected(util.FaultSessionForgot) {
 			return pc.sendSessionReportResponseFIT(ev.msg.(*message.SessionReportRequest))
+		} else if pc.FITHook.IsFaultInjected(util.FaultReportResponse) {
+			return nil
 		} else {
 			return pc.sendSessionReportResponse(ev.msg.(*message.SessionReportRequest))
 		}
@@ -388,6 +392,7 @@ type PFCPConfig struct {
 	MaxInFlight       int
 	InitialSeq        uint32
 	RecoveryTimestamp time.Time
+	SMFSet            string
 	FITHook           *util.FITHook
 }
 
@@ -487,6 +492,14 @@ func (pc *PFCPConnection) ReceivedHBRequestTimes() []time.Time {
 	return r
 }
 
+func (pc *PFCPConnection) ShareSession(conn *PFCPConnection, seid SEID) error {
+	if _, ok := conn.sessions[seid]; !ok {
+		return errors.Errorf("No session %x in %+#v", seid, conn.sessions)
+	}
+	pc.sessions[seid] = conn.sessions[seid]
+	return nil
+}
+
 func (pc *PFCPConnection) setState(newState pfcpState) {
 	pc.state = newState
 }
@@ -541,8 +554,8 @@ func (pc *PFCPConnection) event(event pfcpEvent) error {
 		pc.cleanAndDone()
 		if event.resultCh != nil {
 			event.resultCh <- eventResult{
-				err:  err,
-				seid: event.seid,
+				err:     err,
+				cp_seid: event.cp_seid,
 			}
 		}
 
@@ -635,15 +648,15 @@ LOOP:
 			}
 			// proceed to next iteration to handle the retransmits
 		case ev := <-pc.eventCh:
-			seid := ev.seid
-			if seid == 0 {
-				seid = SEID(ev.msg.SEID())
+			cp_seid := ev.cp_seid
+			if cp_seid == 0 {
+				cp_seid = SEID(ev.msg.SEID())
 			}
 			pc.log.WithFields(logrus.Fields{
 				"eventType":   ev.eventType,
 				"messageType": ev.msg.MessageTypeName(),
 				"seq":         ev.msg.Sequence(),
-				"SEID":        fmt.Sprintf("%016x", seid),
+				"SEID":        fmt.Sprintf("%016x", cp_seid),
 			}).Trace("incoming event")
 			if err = pc.event(ev); err != nil {
 				msgType := "<none>"
@@ -672,8 +685,8 @@ LOOP:
 		case ev := <-pc.eventCh:
 			if ev.resultCh != nil {
 				ev.resultCh <- eventResult{
-					err:  err,
-					seid: ev.seid,
+					err:     err,
+					cp_seid: ev.cp_seid,
 				}
 			}
 		default:
@@ -691,8 +704,8 @@ LOOP:
 		ev := e.(pfcpEvent)
 		if ev.resultCh != nil {
 			ev.resultCh <- eventResult{
-				err:  err,
-				seid: ev.seid,
+				err:     err,
+				cp_seid: ev.cp_seid,
 			}
 		}
 	}
@@ -847,10 +860,16 @@ func (pc *PFCPConnection) acceptResponse(ev pfcpEvent) (*pfcpEvent, error) {
 }
 
 func (pc *PFCPConnection) sendAssociationSetupRequest() error {
-	msg := message.NewAssociationSetupRequest(
-		0,
+	var ies []*ie.IE
+	ies = append(ies,
 		ie.NewRecoveryTimeStamp(pc.timestamp),
-		ie.NewNodeID("", "", pc.cfg.NodeID))
+		ie.NewNodeID("", "", pc.cfg.NodeID),
+	)
+	if pc.cfg.SMFSet != "" {
+		ies = append(ies, ie.NewSMFSetID(pc.cfg.SMFSet))
+	}
+
+	msg := message.NewAssociationSetupRequest(0, ies...)
 	if err := pc.sendRequest(pfcpEvent{
 		msg:          msg,
 		resultCh:     pc.startCh,
@@ -873,7 +892,35 @@ func (pc *PFCPConnection) sendHeartbeatResponse(hr *message.HeartbeatRequest) er
 }
 
 func (pc *PFCPConnection) sendSessionReportResponse(req *message.SessionReportRequest) error {
-	return pc.send(message.NewSessionReportResponse(0, 0, req.SEID(), req.SequenceNumber, 0, ie.NewRecoveryTimeStamp(pc.timestamp)))
+	var ies []*ie.IE
+	var ses *pfcpSession
+	var up_seid SEID
+
+	ies = append(ies, ie.NewCause(ie.CauseRequestAccepted))
+
+	// if migrated from old node
+	if req.OldCPFSEID != nil {
+		fseidFields, err := req.OldCPFSEID.FSEID()
+		if err != nil {
+			return err
+		}
+		ses = pc.sessions[SEID(fseidFields.SEID)]
+		if ses != nil {
+			// change seid to test for updated cp seid in upf
+
+			delete(pc.sessions, SEID(fseidFields.SEID))
+			ses.cp_seid += CP_SEID_CHANGE_ON_SMF_MIGRATION
+			pc.sessions[ses.cp_seid] = ses
+
+			ies = append(ies, pc.NewIEFSEID(ses.cp_seid))
+
+			up_seid = ses.up_seid
+		}
+	} else {
+		up_seid = pc.sessions[SEID(req.SEID())].up_seid
+	}
+	ies = append(ies, ie.NewRecoveryTimeStamp(pc.timestamp))
+	return pc.send(message.NewSessionReportResponse(0, 0, uint64(up_seid), req.SequenceNumber, 0, ies...))
 }
 
 func (pc *PFCPConnection) sendSessionReportResponseFIT(req *message.SessionReportRequest) error {
@@ -894,9 +941,9 @@ func (pc *PFCPConnection) createSession(seid SEID) error {
 		return errors.Errorf("session with SEID 0x%016x already present", seid)
 	}
 	pc.sessions[seid] = &pfcpSession{
-		pc:    pc,
-		seid:  seid,
-		state: sessionStateEstablishing,
+		pc:      pc,
+		cp_seid: seid,
+		state:   sessionStateEstablishing,
 	}
 	return nil
 }
@@ -1142,21 +1189,21 @@ func (pc *PFCPConnection) pipelineRequests(
 			panic("pipelined request over timeout")
 		}
 
-		n, found := m[r.seid]
+		n, found := m[r.cp_seid]
 		if !found {
 			panic("Internal error: unexpected SEID in event response")
 		}
 
 		inFlight--
 		if r.err != nil {
-			errs[n] = errors.Wrapf(r.err, "SEID %016x", r.seid)
+			errs[n] = errors.Wrapf(r.err, "SEID %016x", r.cp_seid)
 		} else {
 			results[n] = r.payload
 		}
 		pc.log.WithFields(logrus.Fields{
 			"cur":      cur,
 			"inFlight": inFlight,
-			"SEID":     fmt.Sprintf("%016x", r.seid),
+			"SEID":     fmt.Sprintf("%016x", r.cp_seid),
 			"err":      r.err,
 			"seq":      reqs[n].Sequence(),
 		}).Trace("response for a pipelined request")
@@ -1165,14 +1212,16 @@ func (pc *PFCPConnection) pipelineRequests(
 	return results, errs
 }
 
-func (pc *PFCPConnection) sessionEstablishmentRequest(spec SessionOpSpec) message.Message {
-	var fseid *ie.IE
+func (pc *PFCPConnection) NewIEFSEID(seid SEID) *ie.IE {
 	if pc.cfg.CNodeIP.To4() == nil {
-		fseid = ie.NewFSEID(uint64(spec.SEID), nil, pc.cfg.CNodeIP)
+		return ie.NewFSEID(uint64(seid), nil, pc.cfg.CNodeIP)
 	} else {
-		fseid = ie.NewFSEID(uint64(spec.SEID), pc.cfg.CNodeIP.To4(), nil)
+		return ie.NewFSEID(uint64(seid), pc.cfg.CNodeIP.To4(), nil)
 	}
+}
 
+func (pc *PFCPConnection) sessionEstablishmentRequest(spec SessionOpSpec) message.Message {
+	fseid := pc.NewIEFSEID(spec.SEID)
 	ies := append(spec.IEs, fseid, ie.NewNodeID("", "", pc.cfg.NodeID))
 	return message.NewSessionEstablishmentRequest(0, 0, 0, 0, 0, ies...)
 }
@@ -1199,7 +1248,7 @@ func (pc *PFCPConnection) enqueueRequest(seid SEID, msg message.Message, resultC
 		msg:          msg,
 		resultCh:     resultCh,
 		attemptsLeft: maxRequestAttempts,
-		seid:         seid,
+		cp_seid:      seid,
 	}
 
 	return nil
@@ -1220,9 +1269,14 @@ type sessionTransitionKey struct {
 }
 
 var sessionTransitions = map[sessionTransitionKey]sessionTransitionFunc{
-	{sessionStateEstablishing, sessionEventEstablished}: sessionToState(sessionStateEstablished),
-	{sessionStateEstablished, sessionEventActDelete}:    sessionToState(sessionStateDeleting),
-	{sessionStateEstablished, sessionEventActModify}:    sessionToState(sessionStateModifying),
+	{sessionStateEstablishing, sessionEventEstablished}: func(s *pfcpSession, ev pfcpEvent) (*PFCPMeasurement, error) {
+		upFSEID, _ := ev.msg.(*message.SessionEstablishmentResponse).UPFSEID.FSEID()
+		s.up_seid = SEID(upFSEID.SEID)
+		s.setState(sessionStateEstablished)
+		return nil, nil
+	},
+	{sessionStateEstablished, sessionEventActDelete}: sessionToState(sessionStateDeleting),
+	{sessionStateEstablished, sessionEventActModify}: sessionToState(sessionStateModifying),
 	{sessionStateModifying, sessionEventModified}: func(s *pfcpSession, ev pfcpEvent) (*PFCPMeasurement, error) {
 		s.setState(sessionStateEstablished)
 		return s.getMeasurement(ev.msg)
@@ -1239,9 +1293,10 @@ var sessionTransitions = map[sessionTransitionKey]sessionTransitionFunc{
 }
 
 type pfcpSession struct {
-	pc    *PFCPConnection
-	seid  SEID
-	state sessionState
+	pc      *PFCPConnection
+	cp_seid SEID
+	up_seid SEID
+	state   sessionState
 }
 
 func (s *pfcpSession) setState(newState sessionState) {
@@ -1249,12 +1304,12 @@ func (s *pfcpSession) setState(newState sessionState) {
 }
 
 func (s *pfcpSession) removeSelf() {
-	s.pc.forgetSessionUnlocked(s.seid)
+	s.pc.forgetSessionUnlocked(s.cp_seid)
 }
 
 func (s *pfcpSession) error(err error) error {
 	s.pc.log.WithFields(logrus.Fields{
-		"SEID":  fmt.Sprintf("%016x", s.seid),
+		"SEID":  fmt.Sprintf("%016x", s.cp_seid),
 		"state": s.state,
 		"error": err,
 	}).Debug("session error")
@@ -1269,13 +1324,13 @@ func (s *pfcpSession) event(et sessionEventType, ev pfcpEvent) (*PFCPMeasurement
 	defer func() {
 		if oldState == s.state {
 			s.pc.log.WithFields(logrus.Fields{
-				"SEID":     fmt.Sprintf("%016x", s.seid),
+				"SEID":     fmt.Sprintf("%016x", s.cp_seid),
 				"oldState": oldState,
 				"event":    et,
 			}).Trace("session state machine event w/o transition")
 		} else {
 			s.pc.log.WithFields(logrus.Fields{
-				"SEID":     fmt.Sprintf("%016x", s.seid),
+				"SEID":     fmt.Sprintf("%016x", s.cp_seid),
 				"oldState": oldState,
 				"event":    et,
 				"newState": s.state,
@@ -1285,7 +1340,7 @@ func (s *pfcpSession) event(et sessionEventType, ev pfcpEvent) (*PFCPMeasurement
 	tk := sessionTransitionKey{state: s.state, event: et}
 	tf, found := sessionTransitions[tk]
 	if !found {
-		return nil, s.error(errors.Errorf("Session %016x: can't handle event %s in state %s", s.seid, et, s.state))
+		return nil, s.error(errors.Errorf("Session %016x: can't handle event %s in state %s", s.cp_seid, et, s.state))
 	}
 
 	result, err := tf(s, ev)

--- a/test/e2e/upg_e2e.go
+++ b/test/e2e/upg_e2e.go
@@ -1387,7 +1387,7 @@ var _ = ginkgo.Describe("Multiple PFCP peers", func() {
 				MeasurementPeriod: 15 * time.Second,
 			}
 
-			// TODO: also check for order of reports
+			// TODO: also possible to check for order of reports
 
 			cp_seid, err := conns[0].EstablishSession(f.Context, 100, sessionCfg.SessionIEs()...)
 			framework.ExpectNoError(err)

--- a/test/e2e/upg_e2e.go
+++ b/test/e2e/upg_e2e.go
@@ -1394,7 +1394,7 @@ var _ = ginkgo.Describe("Multiple PFCP peers", func() {
 
 			// stop new association 0, node should migrate to 1 or 2
 			var fitHook util.FITHook
-			fitHook.EnableFault(util.FaultReportResponse)
+			fitHook.EnableFault(util.FaultNoReportResponse)
 			fitHook.EnableFault(util.FaultIgnoreHeartbeat)
 
 			gomega.Expect(conns[1].ShareSession(conns[0], cp_seid)).To(gomega.Succeed())

--- a/test/e2e/upg_e2e.go
+++ b/test/e2e/upg_e2e.go
@@ -2139,7 +2139,7 @@ var _ = ginkgo.Describe("Multiple PFCP Sessions", func() {
 			f.PFCP.ForgetSession(seid)
 			sessionCfg.UEIP = f.AddUEIP()
 			_, err = f.PFCP.EstablishSession(f.Context, seid, sessionCfg.SessionIEs()...)
-			verifyPFCPError(err, ie.CauseRequestRejected, seid, 0, "Duplicate SEID")
+			verifyPFCPError(err, ie.CauseRequestRejected, seid, 0, "Duplicate F-SEID")
 		})
 	})
 

--- a/test/e2e/util/fit.go
+++ b/test/e2e/util/fit.go
@@ -23,8 +23,8 @@ type FITHook struct {
 }
 
 const (
-	FaultSessionForgot  FaultType = "session_forgot"
-	FaultReportResponse FaultType = "no_report_response"
+	FaultSessionForgot    FaultType = "session_forgot"
+	FaultNoReportResponse FaultType = "no_report_response"
 
 	// IgnoreHeartbeatRequests makes PFCPConnection ignore incoming
 	// PFCP Heartbeat Requests, thus simulating a faulty CP.

--- a/test/e2e/util/fit.go
+++ b/test/e2e/util/fit.go
@@ -23,7 +23,8 @@ type FITHook struct {
 }
 
 const (
-	FaultSessionForgot FaultType = "session_forgot"
+	FaultSessionForgot  FaultType = "session_forgot"
+	FaultReportResponse FaultType = "no_report_response"
 
 	// IgnoreHeartbeatRequests makes PFCPConnection ignore incoming
 	// PFCP Heartbeat Requests, thus simulating a faulty CP.

--- a/upf/flowtable.c
+++ b/upf/flowtable.c
@@ -460,7 +460,7 @@ format_flow_key (u8 * s, va_list * args)
 		 format_ip46_address, &key->ip[FT_ORIGIN], IP46_TYPE_ANY,
 		 clib_net_to_host_u16 (key->port[FT_ORIGIN]),
 		 format_ip46_address, &key->ip[FT_REVERSE], IP46_TYPE_ANY,
-		 clib_net_to_host_u16 (key->port[FT_REVERSE]), key->seid);
+		 clib_net_to_host_u16 (key->port[FT_REVERSE]), key->up_seid);
 }
 
 u8 *

--- a/upf/flowtable.h
+++ b/upf/flowtable.h
@@ -70,7 +70,7 @@ typedef struct
   {
     struct
     {
-      u64 seid;
+      u64 up_seid;
       ip46_address_t ip[FT_ORDER_MAX];
       u16 port[FT_ORDER_MAX];
       u8 proto;
@@ -398,14 +398,14 @@ parse_ip6_packet (ip6_header_t * ip6, uword * is_reverse, flow_key_t * key)
 }
 
 static inline void
-flow_mk_key (u64 seid, u8 * header, u8 is_ip4,
+flow_mk_key (u64 up_seid, u8 * header, u8 is_ip4,
 	     uword * is_reverse, clib_bihash_kv_48_8_t * kv)
 {
   flow_key_t *key = (flow_key_t *) & kv->key;
 
   memset (key, 0, sizeof (*key));
 
-  key->seid = seid;
+  key->up_seid = up_seid;
 
   /* compute 5 tuple key so that 2 half connections
    * get into the same flow */

--- a/upf/llist.h
+++ b/upf/llist.h
@@ -183,6 +183,26 @@ typedef upf_llist_anchor_t NAME ## _anchor_t; \
 
 /* Create methods instead of macros for type verification */
 #define UPF_LLIST_TEMPLATE_DEFINITIONS(NAME, TYPE, ANCHOR) \
+static u8 *__clib_unused \
+format_ ## NAME ## _llist(u8 * s, va_list * args) { \
+  TYPE *pool = va_arg (*args, TYPE*); \
+  upf_llist_t *list = va_arg (*args, upf_llist_t*); \
+  \
+  ASSERT(pool); \
+  u32 i = 0; \
+  s = format (s, "head: %d", list->head); \
+  if (!upf_llist_list_is_empty(list)) { \
+    upf_llist_foreach(el, pool, ANCHOR, list, { \
+      s = format(s, "   element (%x) %d", el, el - pool); \
+      s = format(s, " next %d prev %d", el->ANCHOR.next, el->ANCHOR.prev); \
+      /* s = format(s, "  element (%x) %d next %d prev %d",*/ \
+      /* el, el - pool, el->ANCHOR.next, el->ANCHOR.prev);*/ \
+      if (i++ == 10000) break; \
+    }); \
+  } \
+  \
+  return s; \
+} \
 static inline void __clib_unused \
 NAME ## _init(NAME ## _t *list) { \
   upf_llist_init(list); \
@@ -202,6 +222,7 @@ NAME ## _el_is_part_of_list(TYPE *el) { \
 static void __clib_unused \
 NAME ## _insert_tail(TYPE *pool, NAME ## _t *list, TYPE *el) { \
   upf_llist_insert_tail(pool, ANCHOR, list, el); \
+  /* upf_debug(">>>>>>>>>>>>>>> after insert: %U", format_ ## NAME ## _llist, pool, list); */ \
 } \
 static void __clib_unused \
 NAME ## _remove(TYPE *pool, NAME ## _t *list, TYPE *el) { \

--- a/upf/llist.h
+++ b/upf/llist.h
@@ -4,6 +4,9 @@
 #include "vppinfra/pool.h"
 #include <stdbool.h>
 
+#ifndef __included_upf_llist_h__
+#define __included_upf_llist_h__
+
 /*
 This is analog of vpp dlist, but intrusive version with anchor.
 Also this implementation can create typed helpers.
@@ -183,26 +186,6 @@ typedef upf_llist_anchor_t NAME ## _anchor_t; \
 
 /* Create methods instead of macros for type verification */
 #define UPF_LLIST_TEMPLATE_DEFINITIONS(NAME, TYPE, ANCHOR) \
-static u8 *__clib_unused \
-format_ ## NAME ## _llist(u8 * s, va_list * args) { \
-  TYPE *pool = va_arg (*args, TYPE*); \
-  upf_llist_t *list = va_arg (*args, upf_llist_t*); \
-  \
-  ASSERT(pool); \
-  u32 i = 0; \
-  s = format (s, "head: %d", list->head); \
-  if (!upf_llist_list_is_empty(list)) { \
-    upf_llist_foreach(el, pool, ANCHOR, list, { \
-      s = format(s, "   element (%x) %d", el, el - pool); \
-      s = format(s, " next %d prev %d", el->ANCHOR.next, el->ANCHOR.prev); \
-      /* s = format(s, "  element (%x) %d next %d prev %d",*/ \
-      /* el, el - pool, el->ANCHOR.next, el->ANCHOR.prev);*/ \
-      if (i++ == 10000) break; \
-    }); \
-  } \
-  \
-  return s; \
-} \
 static inline void __clib_unused \
 NAME ## _init(NAME ## _t *list) { \
   upf_llist_init(list); \
@@ -222,9 +205,10 @@ NAME ## _el_is_part_of_list(TYPE *el) { \
 static void __clib_unused \
 NAME ## _insert_tail(TYPE *pool, NAME ## _t *list, TYPE *el) { \
   upf_llist_insert_tail(pool, ANCHOR, list, el); \
-  /* upf_debug(">>>>>>>>>>>>>>> after insert: %U", format_ ## NAME ## _llist, pool, list); */ \
 } \
 static void __clib_unused \
 NAME ## _remove(TYPE *pool, NAME ## _t *list, TYPE *el) { \
   upf_llist_remove(pool, ANCHOR, list, el); \
 }
+
+#endif

--- a/upf/pfcp.c
+++ b/upf/pfcp.c
@@ -4757,10 +4757,10 @@ decode_smf_set_id (u8 * data, u16 length, void *p)
 {
   pfcp_smf_set_id_t *v = p;
 
-  get_u8(data); // skip spare
+  get_u8 (data);		// skip spare
   length--;
 
-  get_vec(v->fqdn, length, data);
+  get_vec (v->fqdn, length, data);
 
   return 0;
 }
@@ -4770,7 +4770,7 @@ encode_smf_set_id (void *p, u8 ** vec)
 {
   pfcp_smf_set_id_t *v = p;
 
-  put_u8 (*vec, 0); // spare
+  put_u8 (*vec, 0);		// spare
   vec_append (*vec, v->fqdn);
 
   return 0;
@@ -4781,7 +4781,7 @@ free_smf_set_id (void *p)
 {
   pfcp_smf_set_id_t *v = p;
 
-  vec_free(v->fqdn);
+  vec_free (v->fqdn);
 }
 
 #define format_quota_validity_time format_u32_ie

--- a/upf/pfcp.c
+++ b/upf/pfcp.c
@@ -7717,6 +7717,10 @@ static struct pfcp_group_ie_def pfcp_session_report_request_group[] =
       .type = PFCP_IE_PFCPSRREQ_FLAGS,
       .offset = offsetof(pfcp_session_report_request_t, pfcpsrreq_flags)
     },
+    [SESSION_REPORT_REQUEST_OLD_CP_F_SEID] = {
+      .type = PFCP_IE_F_SEID,
+      .offset = offsetof(pfcp_session_report_request_t, old_cp_f_seid)
+    },
   };
 
 static struct pfcp_group_ie_def pfcp_session_report_response_group[] =

--- a/upf/pfcp.c
+++ b/upf/pfcp.c
@@ -4744,6 +4744,46 @@ encode_alternative_smf_ip_address (void *p, u8 ** vec)
   return 0;
 }
 
+u8 *
+format_smf_set_id (u8 * s, va_list * args)
+{
+  pfcp_smf_set_id_t *n = va_arg (*args, pfcp_smf_set_id_t *);
+
+  return format (s, "%U", format_dns_labels, n->fqdn);
+}
+
+static int
+decode_smf_set_id (u8 * data, u16 length, void *p)
+{
+  pfcp_smf_set_id_t *v = p;
+
+  get_u8(data); // skip spare
+  length--;
+
+  get_vec(v->fqdn, length, data);
+
+  return 0;
+}
+
+static int
+encode_smf_set_id (void *p, u8 ** vec)
+{
+  pfcp_smf_set_id_t *v = p;
+
+  put_u8 (*vec, 0); // spare
+  vec_append (*vec, v->fqdn);
+
+  return 0;
+}
+
+static void
+free_smf_set_id (void *p)
+{
+  pfcp_smf_set_id_t *v = p;
+
+  vec_free(v->fqdn);
+}
+
 #define format_quota_validity_time format_u32_ie
 #define decode_quota_validity_time decode_u32_ie
 #define encode_quota_validity_time encode_u32_ie
@@ -6956,6 +6996,7 @@ static struct pfcp_ie_def tgpp_specs[] =
     },
     SIMPLE_IE(PFCP_IE_UE_IP_ADDRESS_POOL_IDENTITY, ue_ip_address_pool_identity, "UE IP address Pool Identity"),
     SIMPLE_IE(PFCP_IE_ALTERNATIVE_SMF_IP_ADDRESS, alternative_smf_ip_address, "Alternative SMF IP Address"),
+    SIMPLE_IE_FREE(PFCP_IE_SMF_SET_ID, smf_set_id, "SMF Set ID"),
     SIMPLE_IE(PFCP_IE_QUOTA_VALIDITY_TIME, quota_validity_time, "Quota Validity Time"),
     [PFCP_IE_UE_IP_ADDRESS_POOL_INFORMATION] =
     {
@@ -7127,6 +7168,10 @@ static struct pfcp_group_ie_def pfcp_association_setup_request_group[] =
       .is_array = true,
       .offset = offsetof(pfcp_association_setup_request_t, alternative_smf_ip_address)
     },
+    [ASSOCIATION_SETUP_REQUEST_SMF_SET_ID] = {
+      .type = PFCP_IE_SMF_SET_ID,
+      .offset = offsetof(pfcp_association_setup_request_t, smf_set_id)
+    },
   };
 
 static struct pfcp_group_ie_def pfcp_association_setup_response_group[] =
@@ -7176,6 +7221,10 @@ static struct pfcp_group_ie_def pfcp_association_setup_response_group[] =
       .is_array = true,
       .offset = offsetof(pfcp_association_procedure_response_t, ue_ip_address_pool_information)
     },
+    [ASSOCIATION_PROCEDURE_RESPONSE_SMF_SET_ID] = {
+      .type = PFCP_IE_SMF_SET_ID,
+      .offset = offsetof(pfcp_association_procedure_response_t, smf_set_id)
+    },
   };
 
 static struct pfcp_group_ie_def pfcp_association_update_request_group[] =
@@ -7218,6 +7267,10 @@ static struct pfcp_group_ie_def pfcp_association_update_request_group[] =
       .type = PFCP_IE_ALTERNATIVE_SMF_IP_ADDRESS,
       .is_array = true,
       .offset = offsetof(pfcp_association_update_request_t, alternative_smf_ip_address)
+    },
+    [ASSOCIATION_UPDATE_REQUEST_SMF_SET_ID] = {
+      .type = PFCP_IE_SMF_SET_ID,
+      .offset = offsetof(pfcp_association_update_request_t, smf_set_id)
     },
   };
 

--- a/upf/pfcp.c
+++ b/upf/pfcp.c
@@ -1746,7 +1746,7 @@ format_pfcpsrrsp_flags (u8 * s, va_list * args)
 #define decode_pdr_id decode_u16_ie
 #define encode_pdr_id encode_u16_ie
 
-static u8 *
+u8 *
 format_f_seid (u8 * s, va_list * args)
 {
   pfcp_f_seid_t *n = va_arg (*args, pfcp_f_seid_t *);

--- a/upf/pfcp.h
+++ b/upf/pfcp.h
@@ -2826,6 +2826,7 @@ u8 *format_user_plane_ip_resource_information (u8 * s, va_list * args);
 u8 *format_redirect_information (u8 * s, va_list * args);
 u8 *format_ue_ip_address (u8 * s, va_list * args);
 u8 *format_node_id (u8 * s, va_list * args);
+u8 *format_smf_set_id (u8 * s, va_list * args);
 u8 *format_outer_header_creation (u8 * s, va_list * args);
 uword tbcd_len (u8 * in, uword n_bytes);
 uword decode_tbcd (u8 * in, uword n_bytes, u8 * out, uword n_out);

--- a/upf/pfcp.h
+++ b/upf/pfcp.h
@@ -471,6 +471,10 @@ typedef struct
 
   union
   {
+    /*
+      When set to an IP address, it indicates that the
+      CP/UP function only exposes one IP address for the PFCP Association signalling.
+    */
     ip46_address_t ip;
     u8 *fqdn;
   };
@@ -2826,6 +2830,7 @@ u8 *format_user_plane_ip_resource_information (u8 * s, va_list * args);
 u8 *format_redirect_information (u8 * s, va_list * args);
 u8 *format_ue_ip_address (u8 * s, va_list * args);
 u8 *format_node_id (u8 * s, va_list * args);
+u8 *format_f_seid (u8 * s, va_list * args);
 u8 *format_smf_set_id (u8 * s, va_list * args);
 u8 *format_outer_header_creation (u8 * s, va_list * args);
 uword tbcd_len (u8 * in, uword n_bytes);

--- a/upf/pfcp.h
+++ b/upf/pfcp.h
@@ -2713,7 +2713,8 @@ enum
   SESSION_REPORT_REQUEST_OVERLOAD_CONTROL_INFORMATION,
   SESSION_REPORT_REQUEST_ADDITIONAL_USAGE_REPORTS_INFORMATION,
   SESSION_REPORT_REQUEST_PFCPSRREQ_FLAGS,
-  SESSION_REPORT_REQUEST_LAST = SESSION_REPORT_REQUEST_PFCPSRREQ_FLAGS
+  SESSION_REPORT_REQUEST_OLD_CP_F_SEID,
+  SESSION_REPORT_REQUEST_LAST = SESSION_REPORT_REQUEST_OLD_CP_F_SEID
 };
 
 typedef struct
@@ -2729,6 +2730,7 @@ typedef struct
     pfcp_additional_usage_reports_information_t
     additional_usage_reports_information;
   pfcp_pfcpsrreq_flags_t pfcpsrreq_flags;
+  pfcp_f_seid_t old_cp_f_seid;
 } pfcp_session_report_request_t;
 
 enum

--- a/upf/pfcp.h
+++ b/upf/pfcp.h
@@ -1148,6 +1148,12 @@ typedef struct
   ip6_address_t ip6;
 } pfcp_alternative_smf_ip_address_t;
 
+#define PFCP_IE_SMF_SET_ID				180
+typedef struct
+{
+  u8 *fqdn;
+} pfcp_smf_set_id_t;
+
 #define PFCP_IE_QUOTA_VALIDITY_TIME			181
 typedef u32 pfcp_quota_validity_time_t;
 
@@ -2406,8 +2412,9 @@ enum
   ASSOCIATION_SETUP_REQUEST_UE_IP_ADDRESS_POOL_INFORMATION,
   ASSOCIATION_SETUP_REQUEST_TP_BUILD_ID,
   ASSOCIATION_SETUP_REQUEST_ALTERNATIVE_SMF_IP_ADDRESS,
+  ASSOCIATION_SETUP_REQUEST_SMF_SET_ID,
   ASSOCIATION_SETUP_REQUEST_LAST =
-    ASSOCIATION_SETUP_REQUEST_ALTERNATIVE_SMF_IP_ADDRESS
+    ASSOCIATION_SETUP_REQUEST_SMF_SET_ID
 };
 
 typedef struct
@@ -2423,6 +2430,7 @@ typedef struct
     * user_plane_ip_resource_information;
   pfcp_tp_build_id_t tp_build_id;
   pfcp_alternative_smf_ip_address_t *alternative_smf_ip_address;
+  pfcp_smf_set_id_t smf_set_id;
 } pfcp_association_setup_request_t;
 
 enum
@@ -2437,8 +2445,9 @@ enum
   ASSOCIATION_UPDATE_REQUEST_PFCPAUREQ_FLAGS,
   ASSOCIATION_UPDATE_REQUEST_UE_IP_ADDRESS_POOL_IDENTITY,
   ASSOCIATION_UPDATE_REQUEST_ALTERNATIVE_SMF_IP_ADDRESS,
+  ASSOCIATION_UPDATE_REQUEST_SMF_SET_ID,
   ASSOCIATION_UPDATE_REQUEST_LAST =
-    ASSOCIATION_UPDATE_REQUEST_ALTERNATIVE_SMF_IP_ADDRESS
+    ASSOCIATION_UPDATE_REQUEST_SMF_SET_ID
 };
 
 typedef struct
@@ -2455,6 +2464,7 @@ typedef struct
     * user_plane_ip_resource_information;
   pfcp_pfcpaureq_flags_t pfcpaureq_flags;
   pfcp_alternative_smf_ip_address_t *alternative_smf_ip_address;
+  pfcp_smf_set_id_t smf_set_id;
 } pfcp_association_update_request_t;
 
 enum
@@ -2480,6 +2490,7 @@ enum
   ASSOCIATION_PROCEDURE_RESPONSE_BBF_UP_FUNCTION_FEATURES,
   ASSOCIATION_PROCEDURE_RESPONSE_UE_IP_ADDRESS_POOL_INFORMATION,
   ASSOCIATION_PROCEDURE_RESPONSE_USER_PLANE_IP_RESOURCE_INFORMATION,
+  ASSOCIATION_PROCEDURE_RESPONSE_SMF_SET_ID,
   ASSOCIATION_PROCEDURE_RESPONSE_TP_ERROR_REPORT,
   ASSOCIATION_PROCEDURE_RESPONSE_TP_BUILD_ID,
   ASSOCIATION_PROCEDURE_RESPONSE_LAST =
@@ -2501,6 +2512,7 @@ typedef struct
     * user_plane_ip_resource_information;
   pfcp_bbf_up_function_features_t bbf_up_function_features;
   pfcp_tp_build_id_t tp_build_id;
+  pfcp_smf_set_id_t smf_set_id;
 } pfcp_association_procedure_response_t;
 
 enum

--- a/upf/pfcp.h
+++ b/upf/pfcp.h
@@ -472,9 +472,9 @@ typedef struct
   union
   {
     /*
-      When set to an IP address, it indicates that the
-      CP/UP function only exposes one IP address for the PFCP Association signalling.
-    */
+       When set to an IP address, it indicates that the
+       CP/UP function only exposes one IP address for the PFCP Association signalling.
+     */
     ip46_address_t ip;
     u8 *fqdn;
   };
@@ -2417,8 +2417,7 @@ enum
   ASSOCIATION_SETUP_REQUEST_TP_BUILD_ID,
   ASSOCIATION_SETUP_REQUEST_ALTERNATIVE_SMF_IP_ADDRESS,
   ASSOCIATION_SETUP_REQUEST_SMF_SET_ID,
-  ASSOCIATION_SETUP_REQUEST_LAST =
-    ASSOCIATION_SETUP_REQUEST_SMF_SET_ID
+  ASSOCIATION_SETUP_REQUEST_LAST = ASSOCIATION_SETUP_REQUEST_SMF_SET_ID
 };
 
 typedef struct
@@ -2450,8 +2449,7 @@ enum
   ASSOCIATION_UPDATE_REQUEST_UE_IP_ADDRESS_POOL_IDENTITY,
   ASSOCIATION_UPDATE_REQUEST_ALTERNATIVE_SMF_IP_ADDRESS,
   ASSOCIATION_UPDATE_REQUEST_SMF_SET_ID,
-  ASSOCIATION_UPDATE_REQUEST_LAST =
-    ASSOCIATION_UPDATE_REQUEST_SMF_SET_ID
+  ASSOCIATION_UPDATE_REQUEST_LAST = ASSOCIATION_UPDATE_REQUEST_SMF_SET_ID
 };
 
 typedef struct

--- a/upf/upf.c
+++ b/upf/upf.c
@@ -608,6 +608,8 @@ upf_init (vlib_main_t * vm)
   sm->node_index_by_fqdn =
     hash_create_vec ( /* initial length */ 32, sizeof (u8), sizeof (uword));
   mhash_init (&sm->node_index_by_ip, sizeof (uword), sizeof (ip46_address_t));
+  mhash_init (&sm->mhash_cp_fseid_to_session_idx, sizeof (uword), sizeof (upf_cp_fseid_key_t));
+  mhash_init (&sm->mhash_cached_fseid_idx, sizeof (uword), sizeof (upf_cached_f_seid_key_t));
 
   sm->smf_sets = NULL;
   sm->smf_set_by_fqdn =
@@ -652,9 +654,6 @@ upf_init (vlib_main_t * vm)
 
   sm->ue_ip_pool_index_by_identity =
     hash_create_vec ( /* initial length */ 32, sizeof (u8), sizeof (uword));
-
-  sm->hashmap_cached_fseid_idx =
-    hash_create_mem ( /* initial length */ 32, sizeof (upf_cached_f_seid_key_t), sizeof (uword));
 
   error = flowtable_init (vm);
   if (!error)

--- a/upf/upf.c
+++ b/upf/upf.c
@@ -609,6 +609,10 @@ upf_init (vlib_main_t * vm)
     hash_create_vec ( /* initial length */ 32, sizeof (u8), sizeof (uword));
   mhash_init (&sm->node_index_by_ip, sizeof (uword), sizeof (ip46_address_t));
 
+  sm->smf_sets = NULL;
+  sm->smf_set_by_fqdn =
+    hash_create_vec ( /* initial length */ 32, sizeof(u8), sizeof(uword));
+
 #if 0
   sm->vtep6 = hash_create_mem (0, sizeof (ip6_address_t), sizeof (uword));
 #endif

--- a/upf/upf.c
+++ b/upf/upf.c
@@ -653,6 +653,10 @@ upf_init (vlib_main_t * vm)
   sm->ue_ip_pool_index_by_identity =
     hash_create_vec ( /* initial length */ 32, sizeof (u8), sizeof (uword));
 
+  sm->hashmap_cached_fseid_idx =
+    hash_create_mem ( /* initial length */ 32, sizeof (upf_cached_f_seid_key_t), sizeof (uword));
+
+
   error = flowtable_init (vm);
   if (!error)
     error = upf_ipfix_init (vm);

--- a/upf/upf.c
+++ b/upf/upf.c
@@ -656,7 +656,6 @@ upf_init (vlib_main_t * vm)
   sm->hashmap_cached_fseid_idx =
     hash_create_mem ( /* initial length */ 32, sizeof (upf_cached_f_seid_key_t), sizeof (uword));
 
-
   error = flowtable_init (vm);
   if (!error)
     error = upf_ipfix_init (vm);

--- a/upf/upf.c
+++ b/upf/upf.c
@@ -608,12 +608,14 @@ upf_init (vlib_main_t * vm)
   sm->node_index_by_fqdn =
     hash_create_vec ( /* initial length */ 32, sizeof (u8), sizeof (uword));
   mhash_init (&sm->node_index_by_ip, sizeof (uword), sizeof (ip46_address_t));
-  mhash_init (&sm->mhash_cp_fseid_to_session_idx, sizeof (uword), sizeof (upf_cp_fseid_key_t));
-  mhash_init (&sm->mhash_cached_fseid_idx, sizeof (uword), sizeof (upf_cached_f_seid_key_t));
+  mhash_init (&sm->mhash_cp_fseid_to_session_idx, sizeof (uword),
+	      sizeof (upf_cp_fseid_key_t));
+  mhash_init (&sm->mhash_cached_fseid_idx, sizeof (uword),
+	      sizeof (upf_cached_f_seid_key_t));
 
   sm->smf_sets = NULL;
   sm->smf_set_by_fqdn =
-    hash_create_vec ( /* initial length */ 32, sizeof(u8), sizeof(uword));
+    hash_create_vec ( /* initial length */ 32, sizeof (u8), sizeof (uword));
 
 #if 0
   sm->vtep6 = hash_create_mem (0, sizeof (ip6_address_t), sizeof (uword));

--- a/upf/upf.c
+++ b/upf/upf.c
@@ -863,7 +863,7 @@ vnet_upf_policy_fn (fib_route_path_t * rpaths, u8 * policy_id, u8 action)
 	  pool_get (gtm->upf_forwarding_policies, fp_entry);
 	  fib_node_init (&fp_entry->fib_node, upf_policy_fib_node_type);
 	  fp_entry->policy_id = vec_dup (policy_id);
-	  fp_entry->rpaths = clib_mem_alloc (sizeof (fp_entry->rpaths));
+	  fp_entry->rpaths = clib_mem_alloc (sizeof (*fp_entry->rpaths));
 
 	  fib_path_list_create_and_child_add (fp_entry, rpaths);
 	  hash_set_mem (gtm->forwarding_policy_by_id, fp_entry->policy_id,

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -753,8 +753,12 @@ typedef struct
 
   f64 last_ul_traffic;
 
-  u64 up_seid; // up_seid assigned once
-  u64 cp_seid; // cp_seid can be chaged by SMF
+  /* up_seid assigned once */
+  u64 up_seid;
+
+  /* cp_seid can be chaged by SMF or be invalid
+     should be reflected in current assoc hashmap */
+  u64 cp_seid;
 
   struct
   {
@@ -914,6 +918,10 @@ typedef struct
   u32 idx_in_smf_set_nodes_pool;
 
   u32 policer_idx;
+
+  // We have to track seids of association to not allow seid collision
+  // key: seid u64 value: session index
+  mhash_t hash_cp_seid_to_session_id;
 } upf_node_assoc_t;
 
 typedef struct
@@ -969,6 +977,7 @@ typedef struct
   u32 refcount;
   upf_cached_f_seid_key_t key;
 } upf_cached_f_seid_t;
+
 
 /* bihash buckets are cheap, only 8 bytes per bucket */
 #define UPF_MAPPING_BUCKETS      (64 * 1024)
@@ -1078,7 +1087,7 @@ typedef struct
 
   // cache fseid addresses since they not unique per session
   upf_cached_f_seid_t *cached_fseid_pool;
-  // hashmap key: upf_cached_f_seid_key_t value: index in cached_fseid_pool
+  // key: upf_cached_f_seid_key_t value: index in cached_fseid_pool
   uword *hashmap_cached_fseid_idx;
 
   policer_t *pfcp_policers;

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -752,7 +752,7 @@ typedef struct
     u32 prev;
   } assoc;
 
-  uint32_t flags;
+  uint32_t flags; // TODO: use bitfields instead
 #define UPF_SESSION_LOST_CP         BIT(0) // remote cp peer is down, f_seid is old
 #define UPF_SESSION_UPDATING        BIT(1) // TODO: remove, looks like not used
 
@@ -899,7 +899,7 @@ typedef struct
   u32 heartbeat_handle;
 
   u32 smf_set_idx;
-  u32 idx_in_smf_set_pool;
+  u32 idx_in_smf_set_nodes_pool;
 
   u32 policer_idx;
 } upf_node_assoc_t;
@@ -907,7 +907,7 @@ typedef struct
 typedef struct
 {
   u8 *fqdn;
-  u32 *node_ids; // pool of node ids
+  u32 *node_ids_pool; // pool of node ids
 } upf_smf_set_t;
 
 typedef u8 *regex_t;

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -743,7 +743,6 @@ typedef struct
 
   u64 up_seid; // up_seid assigned once
   u64 cp_seid; // cp_seid can be chaged by SMF
-  ip46_address_t cp_address;
 
   struct
   {
@@ -753,8 +752,8 @@ typedef struct
   } assoc;
 
   uint32_t flags;
-#define UPF_SESSION_NEW_SMF     0x4000 // cp_seid is not valid, since owner node is down
-#define UPF_SESSION_UPDATING    0x8000 // TODO: remove since not used
+#define UPF_SESSION_NEW_SMF     0x4000 // cp_seid is not valid becase cp node is changed
+#define UPF_SESSION_UPDATING    0x8000 // TODO: remove, looks like not used
 
   volatile int active;
 

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -55,8 +55,8 @@
 #include "vnet/ip/ip46_address.h"
 #include "llist.h"
 
-UPF_LLIST_TEMPLATE_TYPES(upf_session_requests_list); // requests in flight for session
-UPF_LLIST_TEMPLATE_TYPES(upf_node_sessions_list); // sessions for node
+UPF_LLIST_TEMPLATE_TYPES (upf_session_requests_list);	// requests in flight for session
+UPF_LLIST_TEMPLATE_TYPES (upf_node_sessions_list);	// sessions for node
 
 /* #define UPF_TRAFFIC_LOG 1 */
 
@@ -766,9 +766,9 @@ typedef struct
     upf_node_sessions_list_anchor_t anchor;
   } assoc;
 
-  uint32_t flags; // TODO: use bitfields instead
-#define UPF_SESSION_LOST_CP         BIT(0) // remote cp peer is down, f_seid is old
-#define UPF_SESSION_UPDATING        BIT(1) // TODO: remove, looks like not used
+  uint32_t flags;		// TODO: use bitfields instead
+#define UPF_SESSION_LOST_CP         BIT(0)	// remote cp peer is down, f_seid is old
+#define UPF_SESSION_UPDATING        BIT(1)	// TODO: remove, looks like not used
 
   volatile int active;
 
@@ -824,7 +824,7 @@ typedef struct
 
   upf_session_requests_list_t requests;
 
-  u16 generation; // increased on session modification request
+  u16 generation;		// increased on session modification request
 } upf_session_t;
 
 
@@ -929,7 +929,7 @@ typedef struct
   u8 *fqdn;
 
   // TODO: use llist instead
-  u32 *node_ids_pool; // pool of node ids
+  u32 *node_ids_pool;		// pool of node ids
 } upf_smf_set_t;
 
 typedef u8 *regex_t;
@@ -1019,7 +1019,7 @@ typedef struct
   upf_session_t *sessions;
 
   /* lookup session by up seid */
-  uword *session_by_up_seid;		/* keyed session id */
+  uword *session_by_up_seid;	/* keyed session id */
 
   /* lookup tunnel by TEID */
   clib_bihash_8_8_t v4_tunnel_by_key;	/* keyed session id */
@@ -1046,7 +1046,7 @@ typedef struct
   /* pool of SMF sets */
   upf_smf_set_t *smf_sets;
   /* lookup SMF sets */
-  uword *smf_set_by_fqdn; // hashmap to smf set id
+  uword *smf_set_by_fqdn;	// hashmap to smf set id
 
   /* upg-related counters */
   vlib_simple_counter_main_t *upf_simple_counters;
@@ -1175,7 +1175,8 @@ void upf_gtpu_error_ind (vlib_buffer_t * b0, int is_ip4);
 
 void upf_pfcp_policers_relalculate (qos_pol_cfg_params_st * cfg);
 
-UPF_LLIST_TEMPLATE_DEFINITIONS(upf_node_sessions_list, upf_session_t, assoc.anchor);
+UPF_LLIST_TEMPLATE_DEFINITIONS (upf_node_sessions_list, upf_session_t,
+				assoc.anchor);
 
 static_always_inline void
 upf_vnet_buffer_l3_hdr_offset_is_current (vlib_buffer_t * b)

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -43,7 +43,7 @@
 #include <vlib/vlib.h>
 #include <vlib/log.h>
 
-#define CLIB_DEBUG 2
+#define CLIB_DEBUG 1
 
 #if CLIB_DEBUG > 1
 #define upf_debug clib_warning

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -735,11 +735,14 @@ typedef struct
   CLIB_CACHE_LINE_ALIGN_MARK (cacheline0);
 
   /* most updated fields first */
+#ifdef UPF_FLOW_SESSION_SPINLOCK
   clib_spinlock_t lock;
+#endif
+
   f64 last_ul_traffic;
 
-  ip46_address_t up_address;
-  u64 cp_seid;
+  u64 up_seid; // up_seid assigned once
+  u64 cp_seid; // cp_seid can be chaged by SMF
   ip46_address_t cp_address;
 
   struct
@@ -750,7 +753,8 @@ typedef struct
   } assoc;
 
   uint32_t flags;
-#define PFCP_UPDATING    0x8000
+#define UPF_SESSION_NEW_SMF     0x4000 // cp_seid is not valid, since owner node is down
+#define UPF_SESSION_UPDATING    0x8000 // TODO: remove since not used
 
   volatile int active;
 
@@ -974,8 +978,8 @@ typedef struct
   /* vector of encap tunnel instances */
   upf_session_t *sessions;
 
-  /* lookup session by id */
-  uword *session_by_id;		/* keyed session id */
+  /* lookup session by up seid */
+  uword *session_by_up_seid;		/* keyed session id */
 
   /* lookup tunnel by TEID */
   clib_bihash_8_8_t v4_tunnel_by_key;	/* keyed session id */

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -913,7 +913,8 @@ typedef struct
   upf_node_sessions_list_t sessions;
   u32 heartbeat_handle;
 
-  struct {
+  struct
+  {
     u32 idx;
     upf_smfset_nodes_list_anchor_t anchor;
   } smf_set;

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -753,10 +753,8 @@ typedef struct
   } assoc;
 
   uint32_t flags;
-#define UPF_SESSION_LOST_CP         BIT(0) // remote peer down, f_seid is old
-#define UPF_SESSION_CP_F_SEID_IPv4  BIT(1) // cp_f_seid_ipv4 field is part of f_seid
-#define UPF_SESSION_CP_F_SEID_IPv6  BIT(2) // cp_f_seid_ipv6 field is part of f_seid
-#define UPF_SESSION_UPDATING        BIT(3) // TODO: remove, looks like not used
+#define UPF_SESSION_LOST_CP         BIT(0) // remote cp peer is down, f_seid is old
+#define UPF_SESSION_UPDATING        BIT(1) // TODO: remove, looks like not used
 
   volatile int active;
 

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -43,8 +43,6 @@
 #include <vlib/vlib.h>
 #include <vlib/log.h>
 
-#define CLIB_DEBUG 1
-
 #if CLIB_DEBUG > 1
 #define upf_debug clib_warning
 #else

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -55,8 +55,8 @@
 #include "vnet/ip/ip46_address.h"
 #include "llist.h"
 
-UPF_LLIST_TEMPLATE_TYPES(upf_session_requests_list) // requests in flight for session
-UPF_LLIST_TEMPLATE_TYPES(upf_node_sessions_list) // sessions for node
+UPF_LLIST_TEMPLATE_TYPES(upf_session_requests_list); // requests in flight for session
+UPF_LLIST_TEMPLATE_TYPES(upf_node_sessions_list); // sessions for node
 
 /* #define UPF_TRAFFIC_LOG 1 */
 

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -891,8 +891,17 @@ typedef struct
   u32 sessions;
   u32 heartbeat_handle;
 
+  u32 smf_set_idx;
+  u32 idx_in_smf_set_pool;
+
   u32 policer_idx;
 } upf_node_assoc_t;
+
+typedef struct
+{
+  u8 *fqdn;
+  u32 *node_ids; // pool of node ids
+} upf_smf_set_t;
 
 typedef u8 *regex_t;
 
@@ -984,11 +993,16 @@ typedef struct
   upf_peer_t *peers;
   clib_bihash_24_8_t peer_index_by_ip;	/* remote GTP-U peer keyed on it's ip addr and vrf */
 
-  /* vector of associated PFCP nodes */
+  /* pool of associated PFCP nodes */
   upf_node_assoc_t *nodes;
   /* lookup PFCP nodes */
   mhash_t node_index_by_ip;
   uword *node_index_by_fqdn;
+
+  /* pool of SMF sets */
+  upf_smf_set_t *smf_sets;
+  /* lookup SMF sets */
+  uword *smf_set_by_fqdn; // hashmap to smf set id
 
   /* upg-related counters */
   vlib_simple_counter_main_t *upf_simple_counters;

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -52,6 +52,8 @@
 UPF_LLIST_TEMPLATE_TYPES (upf_session_requests_list);
 /* sessions for association */
 UPF_LLIST_TEMPLATE_TYPES (upf_node_sessions_list);
+/* associations for smfset */
+UPF_LLIST_TEMPLATE_TYPES (upf_smfset_nodes_list);
 
 /* #define UPF_TRAFFIC_LOG 1 */
 
@@ -911,8 +913,10 @@ typedef struct
   upf_node_sessions_list_t sessions;
   u32 heartbeat_handle;
 
-  u32 smf_set_idx;
-  u32 idx_in_smf_set_nodes_pool;
+  struct {
+    u32 idx;
+    upf_smfset_nodes_list_anchor_t anchor;
+  } smf_set;
 
   u32 policer_idx;
 } upf_node_assoc_t;
@@ -920,9 +924,7 @@ typedef struct
 typedef struct
 {
   u8 *fqdn;
-
-  /* pool of node indexes */
-  u32 *node_ids_pool;
+  upf_smfset_nodes_list_t nodes;
 } upf_smf_set_t;
 
 typedef u8 *regex_t;
@@ -1179,6 +1181,9 @@ void upf_pfcp_policers_relalculate (qos_pol_cfg_params_st * cfg);
 
 UPF_LLIST_TEMPLATE_DEFINITIONS (upf_node_sessions_list, upf_session_t,
 				assoc.anchor);
+
+UPF_LLIST_TEMPLATE_DEFINITIONS (upf_smfset_nodes_list, upf_node_assoc_t,
+				smf_set.anchor);
 
 static_always_inline void
 upf_vnet_buffer_l3_hdr_offset_is_current (vlib_buffer_t * b)

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -55,8 +55,8 @@
 #include "vnet/ip/ip46_address.h"
 #include "llist.h"
 
-UPF_LLIST_TEMPLATE_TYPES(upf_session_requests) // requests in flight for session
-UPF_LLIST_TEMPLATE_TYPES(upf_node_sessions) // sessions for node
+UPF_LLIST_TEMPLATE_TYPES(upf_session_requests_list) // requests in flight for session
+UPF_LLIST_TEMPLATE_TYPES(upf_node_sessions_list) // sessions for node
 
 /* #define UPF_TRAFFIC_LOG 1 */
 
@@ -759,7 +759,7 @@ typedef struct
   struct
   {
     u32 node;
-    upf_node_sessions_anchor_t anchor;
+    upf_node_sessions_list_anchor_t anchor;
   } assoc;
 
   uint32_t flags; // TODO: use bitfields instead
@@ -818,7 +818,7 @@ typedef struct
   // index in hashmap_cached_fseid_idx
   u32 cached_fseid_idx;
 
-  upf_session_requests_llist_t requests;
+  upf_session_requests_list_t requests;
 
   u16 generation; // increased on session modification request
 } upf_session_t;
@@ -907,7 +907,7 @@ typedef struct
   ip46_address_t rmt_addr;
   ip46_address_t lcl_addr;
 
-  upf_node_sessions_llist_t sessions;
+  upf_node_sessions_list_t sessions;
   u32 heartbeat_handle;
 
   u32 smf_set_idx;
@@ -1166,7 +1166,7 @@ void upf_gtpu_error_ind (vlib_buffer_t * b0, int is_ip4);
 
 void upf_pfcp_policers_relalculate (qos_pol_cfg_params_st * cfg);
 
-UPF_LLIST_TEMPLATE_DEFINITIONS(upf_node_sessions, upf_session_t, assoc.anchor);
+UPF_LLIST_TEMPLATE_DEFINITIONS(upf_node_sessions_list, upf_session_t, assoc.anchor);
 
 static_always_inline void
 upf_vnet_buffer_l3_hdr_offset_is_current (vlib_buffer_t * b)

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -752,7 +752,7 @@ typedef struct
   } assoc;
 
   uint32_t flags;
-#define UPF_SESSION_NEW_SMF     0x4000 // cp_seid is not valid becase cp node is changed
+#define UPF_SESSION_LOST_CP     0x0001 // remote peer down, old node stored in old_node_idx
 #define UPF_SESSION_UPDATING    0x8000 // TODO: remove, looks like not used
 
   volatile int active;
@@ -803,6 +803,9 @@ typedef struct
   pfcp_user_id_t user_id;
 
   session_flows_list_t flows;
+
+  // present when this session in process of migrating (UPF_SESSION_LOST_CP)
+  u32 old_node_idx;
 
   u16 generation;
 } upf_session_t;

--- a/upf/upf_app_db.c
+++ b/upf/upf_app_db.c
@@ -300,7 +300,7 @@ upf_adf_app_add_command_fn (vlib_main_t * vm,
 	}
     }
 
-  sess = pfcp_lookup (up_seid);
+  sess = pfcp_lookup_up_seid (up_seid);
   if (sess == NULL)
     {
       error = clib_error_return (0, "could not find a session");
@@ -748,8 +748,7 @@ upf_application_rule_add_del_command_fn (vlib_main_t * vm,
 		{
 		  break;
 		}
-	      else
-		if (unformat
+	      else if (unformat
 		    (line_input, "ipfilter %_%U%_", unformat_ipfilter, &rule))
 		{
 		  break;

--- a/upf/upf_classify.c
+++ b/upf/upf_classify.c
@@ -76,7 +76,7 @@ static upf_classify_next_t upf_classify_flow_next[] = {
 typedef struct
 {
   u32 session_index;
-  u64 cp_seid;
+  u64 up_seid;
   u32 pdr_idx;
   u32 next_index;
   u8 packet_data[64 - 1 * sizeof (u32)];
@@ -93,8 +93,8 @@ format_upf_classify_trace (u8 * s, va_list * args)
 
   s =
     format (s,
-	    "upf_session%d cp-seid 0x%016" PRIx64
-	    " pdr %d, next_index = %d\n%U%U", t->session_index, t->cp_seid,
+	    "upf_session%d up-seid 0x%016" PRIx64
+	    " pdr %d, next_index = %d\n%U%U", t->session_index, t->up_seid,
 	    t->pdr_idx, t->next_index, format_white_space, indent,
 	    format_ip4_header, t->packet_data, sizeof (t->packet_data));
   return s;
@@ -569,7 +569,7 @@ upf_classify_fn (vlib_main_t * vm, vlib_node_runtime_t * node,
 	      upf_classify_trace_t *tr =
 		vlib_add_trace (vm, node, b, sizeof (*tr));
 	      tr->session_index = sidx;
-	      tr->cp_seid = sess->cp_seid;
+	      tr->up_seid = sess->up_seid;
 	      tr->pdr_idx = upf_buffer_opaque (b)->gtpu.pdr_idx;
 	      tr->next_index = next;
 	      clib_memcpy (tr->packet_data, vlib_buffer_get_current (b),

--- a/upf/upf_cli.c
+++ b/upf/upf_cli.c
@@ -1122,7 +1122,7 @@ upf_flows_out_cb (clib_bihash_kv_48_8_t * kvp, void *arg)
   flow_entry_t *flow;
 
   flow = pool_elt_at_index (fm->flows, kvp->value);
-  if (!arg_value->filtered || arg_value->seid == key->seid)
+  if (!arg_value->filtered || arg_value->seid == key->up_seid)
     vlib_cli_output (arg_value->vm, "%U", format_flow, flow);
 
   return arg_value->limit != ~0 && !--arg_value->limit ?
@@ -1200,7 +1200,7 @@ upf_show_session_command_fn (vlib_main_t * vm,
 	.limit = limit
       };
 
-      if (!(sess = pfcp_lookup (up_seid)))
+      if (!(sess = pfcp_lookup_up_seid (up_seid)))
 	{
 	  error = clib_error_return (0, "Sessions 0x%lx not found", up_seid);
 	  goto done;
@@ -1224,7 +1224,7 @@ upf_show_session_command_fn (vlib_main_t * vm,
 
   if (has_up_seid && !has_flows)
     {
-      if (!(sess = pfcp_lookup (up_seid)))
+      if (!(sess = pfcp_lookup_up_seid (up_seid)))
 	{
 	  error = clib_error_return (0, "Sessions %d not found", up_seid);
 	  goto done;

--- a/upf/upf_cli.c
+++ b/upf/upf_cli.c
@@ -1759,7 +1759,7 @@ upf_pfcp_heartbeat_config_command_fn (vlib_main_t * vm,
 
   rv = vnet_upf_pfcp_heartbeat_config (timeout, retries);
   if (rv)
-    error = clib_return_error ("Invalid parameters");
+    error = (clib_error_return (0, "invalid parameters"));
   return error;
 }
 

--- a/upf/upf_flow_node.c
+++ b/upf/upf_flow_node.c
@@ -35,7 +35,7 @@
 typedef struct
 {
   u32 session_index;
-  u64 cp_seid;
+  u64 up_seid;
   flow_key_t key;
   u32 flow_idx;
   u32 sw_if_index;
@@ -53,9 +53,9 @@ format_get_flowinfo (u8 * s, va_list * args)
   u32 indent = format_get_indent (s);
 
   s = format (s,
-	      "upf_session%d cp-seid 0x%016llx\n"
+	      "upf_session%d up-seid 0x%016llx\n"
 	      "%UFlowInfo - sw_if_index %d, next_index = %d\n%U%U\n%U%U\n%U%U",
-	      t->session_index, t->cp_seid,
+	      t->session_index, t->up_seid,
 	      format_white_space, indent,
 	      t->sw_if_index, t->next_index,
 	      format_white_space, indent,
@@ -218,8 +218,8 @@ upf_flow_process (vlib_main_t * vm, vlib_node_runtime_t * node,
 	  active0 = pfcp_get_rules (sx0, PFCP_ACTIVE);
 	  active1 = pfcp_get_rules (sx1, PFCP_ACTIVE);
 
-	  flow_mk_key (sx0->cp_seid, p0, is_ip4, &is_reverse0, &kv0);
-	  flow_mk_key (sx1->cp_seid, p1, is_ip4, &is_reverse1, &kv1);
+	  flow_mk_key (sx0->up_seid, p0, is_ip4, &is_reverse0, &kv0);
+	  flow_mk_key (sx1->up_seid, p1, is_ip4, &is_reverse1, &kv1);
 
 	  /* lookup/create flow */
 	  flow_idx0 =
@@ -297,7 +297,7 @@ upf_flow_process (vlib_main_t * vm, vlib_node_runtime_t * node,
 	      upf_session_t *sess = pool_elt_at_index (gtm->sessions, sidx);
 	      flow_trace_t *t = vlib_add_trace (vm, node, b0, sizeof (*t));
 	      t->session_index = sidx;
-	      t->cp_seid = sess->cp_seid;
+	      t->up_seid = sess->up_seid;
 	      t->sw_if_index = vnet_buffer (b0)->sw_if_index[VLIB_RX];
 	      t->next_index = next0;
 	      clib_memcpy (t->packet_data, vlib_buffer_get_current (b0) +
@@ -310,7 +310,7 @@ upf_flow_process (vlib_main_t * vm, vlib_node_runtime_t * node,
 	      upf_session_t *sess = pool_elt_at_index (gtm->sessions, sidx);
 	      flow_trace_t *t = vlib_add_trace (vm, node, b1, sizeof (*t));
 	      t->session_index = sidx;
-	      t->cp_seid = sess->cp_seid;
+	      t->up_seid = sess->up_seid;
 	      t->sw_if_index = vnet_buffer (b1)->sw_if_index[VLIB_RX];
 	      t->next_index = next1;
 	      clib_memcpy (t->packet_data, vlib_buffer_get_current (b1) +
@@ -372,7 +372,7 @@ upf_flow_process (vlib_main_t * vm, vlib_node_runtime_t * node,
 	  active0 = pfcp_get_rules (sx0, PFCP_ACTIVE);
 
 	  /* lookup/create flow */
-	  flow_mk_key (sx0->cp_seid, p, is_ip4, &is_reverse, &kv);
+	  flow_mk_key (sx0->up_seid, p, is_ip4, &is_reverse, &kv);
 	  flow_idx =
 	    flowtable_entry_lookup_create (fm, fmt, &kv,
 					   timestamp_ns, current_time,
@@ -436,7 +436,7 @@ upf_flow_process (vlib_main_t * vm, vlib_node_runtime_t * node,
 	      upf_session_t *sess = pool_elt_at_index (gtm->sessions, sidx);
 	      flow_trace_t *t = vlib_add_trace (vm, node, b0, sizeof (*t));
 	      t->session_index = sidx;
-	      t->cp_seid = sess->cp_seid;
+	      t->up_seid = sess->up_seid;
 	      memcpy (&t->key, &kv.key, sizeof (t->key));
 	      t->flow_idx = flow - fm->flows;
 	      t->sw_if_index = vnet_buffer (b0)->sw_if_index[VLIB_RX];

--- a/upf/upf_forward.c
+++ b/upf/upf_forward.c
@@ -71,7 +71,7 @@ typedef enum
 typedef struct
 {
   u32 session_index;
-  u64 cp_seid;
+  u64 up_seid;
   u32 pdr_id;
   u32 far_id;
   u8 packet_data[64 - 1 * sizeof (u32)];
@@ -86,8 +86,8 @@ format_upf_forward_trace (u8 * s, va_list * args)
   upf_forward_trace_t *t = va_arg (*args, upf_forward_trace_t *);
   u32 indent = format_get_indent (s);
 
-  s = format (s, "upf_session%d cp-seid 0x%016" PRIx64 " pdr %d far %d\n%U%U",
-	      t->session_index, t->cp_seid, t->pdr_id, t->far_id,
+  s = format (s, "upf_session%d up-seid 0x%016" PRIx64 " pdr %d far %d\n%U%U",
+	      t->session_index, t->up_seid, t->pdr_id, t->far_id,
 	      format_white_space, indent,
 	      format_ip4_header, t->packet_data, sizeof (t->packet_data));
   return s;
@@ -333,7 +333,7 @@ upf_forward (vlib_main_t * vm, vlib_node_runtime_t * node,
 	      upf_forward_trace_t *tr =
 		vlib_add_trace (vm, node, b, sizeof (*tr));
 	      tr->session_index = sidx;
-	      tr->cp_seid = sess->cp_seid;
+	      tr->up_seid = sess->up_seid;
 	      tr->pdr_id = pdr ? pdr->id : ~0;
 	      tr->far_id = far ? far->id : ~0;
 	      clib_memcpy (tr->packet_data, vlib_buffer_get_current (b),

--- a/upf/upf_input.c
+++ b/upf/upf_input.c
@@ -69,7 +69,7 @@ typedef enum
 typedef struct
 {
   u32 session_index;
-  u64 cp_seid;
+  u64 up_seid;
   u32 pdr_id;
   u32 far_id;
   u8 packet_data[64 - 1 * sizeof (u32)];
@@ -84,8 +84,8 @@ format_upf_input_trace (u8 * s, va_list * args)
   upf_input_trace_t *t = va_arg (*args, upf_input_trace_t *);
   u32 indent = format_get_indent (s);
 
-  s = format (s, "upf_session%d cp-seid 0x%016" PRIx64 " pdr %d far %d\n%U%U",
-	      t->session_index, t->cp_seid, t->pdr_id, t->far_id,
+  s = format (s, "upf_session%d up-seid 0x%016" PRIx64 " pdr %d far %d\n%U%U",
+	      t->session_index, t->up_seid, t->pdr_id, t->far_id,
 	      format_white_space, indent,
 	      format_ip4_header, t->packet_data, sizeof (t->packet_data));
   return s;
@@ -253,7 +253,7 @@ upf_input (vlib_main_t * vm, vlib_node_runtime_t * node,
 	      upf_input_trace_t *tr =
 		vlib_add_trace (vm, node, b, sizeof (*tr));
 	      tr->session_index = sidx;
-	      tr->cp_seid = sess->cp_seid;
+	      tr->up_seid = sess->up_seid;
 	      tr->pdr_id = pdr ? pdr->id : ~0;
 	      tr->far_id = far ? far->id : ~0;
 	      clib_memcpy (tr->packet_data, vlib_buffer_get_current (b),

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -425,7 +425,7 @@ pfcp_new_association (session_handle_t session_handle,
 
   pool_get_aligned_zero (gtm->nodes, n, CLIB_CACHE_LINE_BYTES);
   upf_node_sessions_list_init (&n->sessions);
-  upf_smfset_nodes_list_anchor_init(n);
+  upf_smfset_nodes_list_anchor_init (n);
   n->smf_set.idx = ~0;
   n->node_id = *node_id;
   n->session_handle = session_handle;
@@ -561,7 +561,7 @@ pfcp_new_smf_set (u8 * fqdn)
 
   pool_get_zero (gtm->smf_sets, smfs);
   smfs->fqdn = vec_dup (fqdn);
-  upf_smfset_nodes_list_init(&smfs->nodes);
+  upf_smfset_nodes_list_init (&smfs->nodes);
 
   smfs_idx = smfs - gtm->smf_sets;
   hash_set_mem (gtm->smf_set_by_fqdn, smfs->fqdn, smfs_idx);
@@ -593,7 +593,7 @@ pfcp_free_smf_set (upf_smf_set_t * smfs)
 {
   upf_main_t *gtm = &upf_main;
 
-  ASSERT (upf_llist_list_is_empty(&smfs->nodes));
+  ASSERT (upf_llist_list_is_empty (&smfs->nodes));
   vec_free (smfs->fqdn);
 
   pool_put (gtm->smf_sets, smfs);
@@ -610,7 +610,7 @@ pfcp_node_enter_smf_set (upf_node_assoc_t * n, u8 * fqdn)
   uword smfs_idx = pfcp_ensure_smf_set (fqdn);
   upf_smf_set_t *smfs = pool_elt_at_index (gtm->smf_sets, smfs_idx);
 
-  upf_smfset_nodes_list_insert_tail(gtm->nodes, &smfs->nodes, n);
+  upf_smfset_nodes_list_insert_tail (gtm->nodes, &smfs->nodes, n);
   n->smf_set.idx = smfs_idx;
 
   upf_debug ("node %d %U entered set %U", n - gtm->nodes,
@@ -627,10 +627,10 @@ pfcp_node_exit_smf_set (upf_node_assoc_t * n)
 
   upf_smf_set_t *smfs = pool_elt_at_index (gtm->smf_sets, n->smf_set.idx);
 
-  upf_smfset_nodes_list_remove(gtm->nodes, &smfs->nodes, n);
+  upf_smfset_nodes_list_remove (gtm->nodes, &smfs->nodes, n);
   n->smf_set.idx = ~0;
 
-  if (upf_smfset_nodes_list_is_empty(&smfs->nodes))
+  if (upf_smfset_nodes_list_is_empty (&smfs->nodes))
     {
       pfcp_free_smf_set (smfs);
       return NULL;

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -523,7 +523,7 @@ pfcp_release_association (upf_node_assoc_t * n)
         node_assoc_detach_session(sx);
         node_assoc_attach_session(new_node, sx);
 
-        upf_llist_foreach(req, pfcp_server_main.msg_pool, session.anchor, (&sx->requests), {
+        upf_llist_foreach(req, pfcp_server_main.msg_pool, session.anchor, &sx->requests, {
           req->node = new_node_idx;
         });
 
@@ -1269,6 +1269,12 @@ pfcp_disable_session (upf_session_t * sx)
     upf_pfcp_session_stop_urr_time (&urr->traffic_timer, now);
   }
   upf_pfcp_session_stop_up_inactivity_timer (&active->inactivity_timer);
+
+  /* detach all requests */
+  upf_llist_foreach(req, pfcp_server_main.msg_pool, session.anchor, &sx->requests, {
+    upf_session_requests_remove(pfcp_server_main.msg_pool, &sx->requests, req);
+    req->session.idx = ~0;
+  });
 
   vlib_decrement_simple_counter (&gtm->upf_simple_counters
 				 [UPF_SESSIONS_COUNTER],

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -464,7 +464,7 @@ pfcp_release_association (upf_node_assoc_t * n)
 {
   upf_main_t *gtm = &upf_main;
   u32 node_id = n - gtm->nodes;
-  upf_node_sessions_llist_t *sessions = &n->sessions;
+  upf_node_sessions_list_t *sessions = &n->sessions;
   u32 *smf_alt_node_ids = NULL;
 
   upf_pfcp_associnfo
@@ -526,11 +526,7 @@ pfcp_release_association (upf_node_assoc_t * n)
           req->flags.is_migrated_in_smfset = 1;
           req->node = new_node_idx;
         });
-
-        upf_debug("session requests after migration %U",
-          format_upf_session_requests_llist, pfcp_server_main.msg_pool, &sx->requests);
       });
-
     } else {
       // remove sessions
       upf_llist_foreach(sx, gtm->sessions, assoc.anchor, sessions, {
@@ -649,7 +645,7 @@ node_assoc_attach_session (upf_node_assoc_t * n, upf_session_t * sx)
   upf_main_t *gtm = &upf_main;
   sx->assoc.node = n - gtm->nodes;
 
-  upf_node_sessions_insert_tail(gtm->sessions, &n->sessions, sx);
+  upf_node_sessions_list_insert_tail(gtm->sessions, &n->sessions, sx);
 }
 
 static void
@@ -662,7 +658,7 @@ node_assoc_detach_session (upf_session_t * sx)
 
   n = pool_elt_at_index (gtm->nodes, sx->assoc.node);
 
-  upf_node_sessions_remove(gtm->sessions, &n->sessions, sx);
+  upf_node_sessions_list_remove(gtm->sessions, &n->sessions, sx);
   sx->assoc.node = ~0;
 }
 
@@ -752,7 +748,7 @@ pfcp_create_session (upf_node_assoc_t * assoc, pfcp_f_seid_t * cp_f_seid, u64 up
   sx->up_seid = up_seid;
   sx->cached_fseid_idx = ~0;
   sx->assoc.node = ~0;
-  upf_node_sessions_anchor_init(sx);
+  upf_node_sessions_list_anchor_init(sx);
   upf_session_requests_list_init(&sx->requests);
 
   pfcp_session_set_cp_fseid (sx, cp_f_seid);
@@ -1291,7 +1287,7 @@ pfcp_disable_session (upf_session_t * sx)
 
   /* detach all requests */
   upf_llist_foreach(req, pfcp_server_main.msg_pool, session.anchor, &sx->requests, {
-    upf_session_requests_remove(pfcp_server_main.msg_pool, &sx->requests, req);
+    upf_session_requests_list_remove(pfcp_server_main.msg_pool, &sx->requests, req);
     req->session.idx = ~0;
   });
 
@@ -3290,7 +3286,7 @@ format_pfcp_node_association (u8 * s, va_list * args)
   upf_node_assoc_t *node = va_arg (*args, upf_node_assoc_t *);
   u8 verbose = va_arg (*args, int);
   upf_main_t *gtm = &upf_main;
-  upf_node_sessions_llist_t *sessions = &node->sessions;
+  upf_node_sessions_list_t *sessions = &node->sessions;
   u32 i = 0;
 
   s = format (s,

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -709,7 +709,6 @@ pfcp_session_set_fseid(upf_session_t * sx, pfcp_f_seid_t * f_seid)
     cached_f_seid = pool_elt_at_index(gtm->cached_fseid_pool, existing_f_seid[0]);
   } else {
     pool_get_zero(gtm->cached_fseid_pool, cached_f_seid);
-
     cached_f_seid->key = key;
     hash_set_mem(gtm->hashmap_cached_fseid_idx, &key, cached_f_seid - gtm->cached_fseid_pool);
   }
@@ -728,8 +727,7 @@ pfcp_create_session (upf_node_assoc_t * assoc, pfcp_f_seid_t * cp_f_seid, u64 up
 
   vlib_worker_thread_barrier_sync (vm);
 
-  pool_get_aligned (gtm->sessions, sx, CLIB_CACHE_LINE_BYTES);
-  memset (sx, 0, sizeof (*sx));
+  pool_get_aligned_zero (gtm->sessions, sx, CLIB_CACHE_LINE_BYTES);
 
   sx->up_seid = up_seid;
   sx->cp_seid = cp_f_seid->seid;
@@ -753,7 +751,7 @@ pfcp_create_session (upf_node_assoc_t * assoc, pfcp_f_seid_t * cp_f_seid, u64 up
   node_assoc_attach_session (assoc, sx);
   hash_set (gtm->session_by_up_seid, up_seid, sx - gtm->sessions);
 
-  /*Init TEID by choose_id hash lookup table */
+  /* Init TEID by choose_id hash lookup table */
   sx->teid_by_chid =
     sparse_vec_new ( /*elt bytes */ sizeof (u32), /*bits in index */ 8);
 

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -713,10 +713,12 @@ pfcp_session_free_fseid(upf_session_t * sx)
   ASSERT (sx->cached_fseid_idx != ~0);
 
   cached_fseid = pool_elt_at_index(gtm->cached_fseid_pool, sx->cached_fseid_idx);
-  if (cached_fseid->refcount-- == 0) {
+  cached_fseid->refcount -= 1;
+
+  if (cached_fseid->refcount == 0) {
     hash_unset_mem(gtm->hashmap_cached_fseid_idx, &cached_fseid->key);
+    pool_put(gtm->cached_fseid_pool, cached_fseid);
   }
-  pool_put(gtm->cached_fseid_pool, cached_fseid);
   sx->cached_fseid_idx = ~0;
 }
 

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -687,10 +687,10 @@ pfcp_session_free_cp_fseid (upf_session_t * sx)
 
   ASSERT (sx->cached_fseid_idx != ~0);
 
-  upf_cp_fseid_key_t cp_key = {};
+  upf_cp_fseid_key_t cp_key = { };
   cp_key.seid = sx->cp_seid,
-  cp_key.cached_f_seid_id = sx->cached_fseid_idx,
-  mhash_unset(&gtm->mhash_cp_fseid_to_session_idx, &cp_key, NULL);
+    cp_key.cached_f_seid_id = sx->cached_fseid_idx,
+    mhash_unset (&gtm->mhash_cp_fseid_to_session_idx, &cp_key, NULL);
 
   cached_fseid =
     pool_elt_at_index (gtm->cached_fseid_pool, sx->cached_fseid_idx);
@@ -698,8 +698,9 @@ pfcp_session_free_cp_fseid (upf_session_t * sx)
 
   if (cached_fseid->refcount == 0)
     {
-      mhash_unset(&gtm->mhash_cached_fseid_idx, &cached_fseid->key, NULL);
-      ASSERT (mhash_get(&gtm->mhash_cached_fseid_idx, &cached_fseid->key) == NULL);
+      mhash_unset (&gtm->mhash_cached_fseid_idx, &cached_fseid->key, NULL);
+      ASSERT (mhash_get (&gtm->mhash_cached_fseid_idx, &cached_fseid->key) ==
+	      NULL);
       pool_put (gtm->cached_fseid_pool, cached_fseid);
     }
   sx->cached_fseid_idx = ~0;
@@ -715,7 +716,7 @@ pfcp_session_set_cp_fseid (upf_session_t * sx, pfcp_f_seid_t * f_seid)
       pfcp_session_free_cp_fseid (sx);
     }
 
-  upf_cached_f_seid_key_t key = {};
+  upf_cached_f_seid_key_t key = { };
   key.flags = f_seid->flags;
   key.ip4 = f_seid->ip4;
   key.ip6 = f_seid->ip6;
@@ -733,19 +734,20 @@ pfcp_session_set_cp_fseid (upf_session_t * sx, pfcp_f_seid_t * f_seid)
     {
       pool_get_zero (gtm->cached_fseid_pool, cached_f_seid);
       cached_f_seid->key = key;
-      mhash_set(&gtm->mhash_cached_fseid_idx, &key,
-                cached_f_seid - gtm->cached_fseid_pool, NULL);
-      ASSERT(mhash_get(&gtm->mhash_cached_fseid_idx, &key));
+      mhash_set (&gtm->mhash_cached_fseid_idx, &key,
+		 cached_f_seid - gtm->cached_fseid_pool, NULL);
+      ASSERT (mhash_get (&gtm->mhash_cached_fseid_idx, &key));
     }
 
   sx->cached_fseid_idx = cached_f_seid - gtm->cached_fseid_pool;
   sx->cp_seid = f_seid->seid;
   cached_f_seid->refcount += 1;
 
-  upf_cp_fseid_key_t cp_key = {};
+  upf_cp_fseid_key_t cp_key = { };
   cp_key.seid = sx->cp_seid;
   cp_key.cached_f_seid_id = sx->cached_fseid_idx;
-  mhash_set(&gtm->mhash_cp_fseid_to_session_idx, &cp_key, sx - gtm->sessions, NULL);
+  mhash_set (&gtm->mhash_cp_fseid_to_session_idx, &cp_key, sx - gtm->sessions,
+	     NULL);
 }
 
 upf_session_t *
@@ -2402,30 +2404,31 @@ pfcp_lookup_cp_cached_f_seid (u32 cached_f_seid_idx, u64 cp_seid)
 {
   upf_main_t *gtm = &upf_main;
 
-  upf_cp_fseid_key_t fseid_key = {};
+  upf_cp_fseid_key_t fseid_key = { };
   fseid_key.seid = cp_seid;
   fseid_key.cached_f_seid_id = cached_f_seid_idx;
 
   uword *p = mhash_get (&gtm->mhash_cp_fseid_to_session_idx, &fseid_key);
   if (p)
-    return pool_elt_at_index(gtm->sessions, p[0]);
+    return pool_elt_at_index (gtm->sessions, p[0]);
   else
     return NULL;
 }
 
 upf_session_t *
-pfcp_lookup_cp_f_seid (pfcp_f_seid_t *f_seid)
+pfcp_lookup_cp_f_seid (pfcp_f_seid_t * f_seid)
 {
   upf_main_t *gtm = &upf_main;
 
-  upf_cached_f_seid_key_t cached_f_seid_key = {0};
+  upf_cached_f_seid_key_t cached_f_seid_key = { 0 };
   cached_f_seid_key.flags = f_seid->flags;
   cached_f_seid_key.ip4 = f_seid->ip4;
   cached_f_seid_key.ip6 = f_seid->ip6;
 
-  uword *cached_f_seid_idx = mhash_get (&gtm->mhash_cached_fseid_idx, &cached_f_seid_key);
+  uword *cached_f_seid_idx =
+    mhash_get (&gtm->mhash_cached_fseid_idx, &cached_f_seid_key);
   if (cached_f_seid_idx)
-    return pfcp_lookup_cp_cached_f_seid(cached_f_seid_idx[0], f_seid->seid);
+    return pfcp_lookup_cp_cached_f_seid (cached_f_seid_idx[0], f_seid->seid);
   else
     return NULL;
 }
@@ -3035,7 +3038,7 @@ format_pfcp_session (u8 * s, va_list * args)
 
   upf_node_assoc_t *assoc = pool_elt_at_index (gtm->nodes, sx->assoc.node);
 
-  upf_cached_f_seid_key_t f_seid = {};
+  upf_cached_f_seid_key_t f_seid = { };
   if (sx->cached_fseid_idx != ~0)
     {
       upf_cached_f_seid_t *cached =

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -36,10 +36,6 @@
 #include <search.h>
 #include <netinet/ip.h>
 #include <vlib/unix/plugin.h>
-#include "vppinfra/hash.h"
-#include "vppinfra/mhash.h"
-#include "vppinfra/vec_bootstrap.h"
-#include "vppinfra/vector.h"
 
 #include "pfcp.h"
 #include "upf.h"
@@ -712,9 +708,7 @@ pfcp_session_set_cp_fseid (upf_session_t * sx, pfcp_f_seid_t * f_seid)
   upf_main_t *gtm = &upf_main;
 
   if (sx->cached_fseid_idx != ~0)
-    {
       pfcp_session_free_cp_fseid (sx);
-    }
 
   upf_cached_f_seid_key_t key = { };
   key.flags = f_seid->flags;
@@ -1369,9 +1363,7 @@ pfcp_free_session (upf_session_t * sx)
 
   free_user_id (&sx->user_id);
   if (sx->cached_fseid_idx != ~0)
-    {
       pfcp_session_free_cp_fseid (sx);
-    }
 
 #ifdef UPF_FLOW_SESSION_SPINLOCK
   clib_spinlock_free (&sx->lock);

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -605,7 +605,7 @@ pfcp_node_exit_smf_set (upf_node_assoc_t * n) {
   ASSERT (n->smf_set_idx != ~0);
 
   upf_smf_set_t *smfs = pool_elt_at_index(gtm->smf_sets, n->smf_set_idx);
-  pool_put_index(smfs, n->idx_in_smf_set_pool);
+  pool_put_index(smfs->node_ids, n->idx_in_smf_set_pool);
 
   n->idx_in_smf_set_pool = ~0;
   n->smf_set_idx = ~0;

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -708,7 +708,7 @@ pfcp_session_set_cp_fseid (upf_session_t * sx, pfcp_f_seid_t * f_seid)
   upf_main_t *gtm = &upf_main;
 
   if (sx->cached_fseid_idx != ~0)
-      pfcp_session_free_cp_fseid (sx);
+    pfcp_session_free_cp_fseid (sx);
 
   upf_cached_f_seid_key_t key = { };
   key.flags = f_seid->flags;
@@ -1363,7 +1363,7 @@ pfcp_free_session (upf_session_t * sx)
 
   free_user_id (&sx->user_id);
   if (sx->cached_fseid_idx != ~0)
-      pfcp_session_free_cp_fseid (sx);
+    pfcp_session_free_cp_fseid (sx);
 
 #ifdef UPF_FLOW_SESSION_SPINLOCK
   clib_spinlock_free (&sx->lock);

--- a/upf/upf_pfcp.h
+++ b/upf/upf_pfcp.h
@@ -29,6 +29,10 @@ upf_node_assoc_t *pfcp_new_association (session_handle_t session_handle,
 					pfcp_node_id_t * node_id);
 void pfcp_release_association (upf_node_assoc_t * n);
 
+void pfcp_node_enter_smf_set (upf_node_assoc_t * n,
+                              u8 * fqdn);
+u32 *pfcp_node_exit_smf_set (upf_node_assoc_t * n);
+
 upf_session_t *pfcp_create_session (upf_node_assoc_t * assoc,
 				    const ip46_address_t * up_address,
 				    uint64_t cp_seid,

--- a/upf/upf_pfcp.h
+++ b/upf/upf_pfcp.h
@@ -71,6 +71,8 @@ int pfcp_update_apply (upf_session_t * sx);
 void pfcp_update_finish (upf_session_t * sx);
 
 upf_session_t *pfcp_lookup_up_seid (u64 up_seid);
+upf_session_t *pfcp_lookup_cp_cached_f_seid (u32 cached_f_seid_idx, u64 cp_seid);
+upf_session_t *pfcp_lookup_cp_f_seid (pfcp_f_seid_t *f_seid);
 
 static inline struct rules *
 pfcp_get_rules (upf_session_t * sx, int rules)

--- a/upf/upf_pfcp.h
+++ b/upf/upf_pfcp.h
@@ -34,7 +34,7 @@ void pfcp_node_enter_smf_set (upf_node_assoc_t * n,
 u32 *pfcp_node_exit_smf_set (upf_node_assoc_t * n);
 
 upf_session_t *pfcp_create_session (upf_node_assoc_t * assoc,
-				    u64 cp_seid,
+				    pfcp_f_seid_t * cp_f_seid,
                                     u64 up_seid);
 void pfcp_update_session (upf_session_t * sx);
 void pfcp_disable_session (upf_session_t * sx);

--- a/upf/upf_pfcp.h
+++ b/upf/upf_pfcp.h
@@ -34,9 +34,8 @@ void pfcp_node_enter_smf_set (upf_node_assoc_t * n,
 u32 *pfcp_node_exit_smf_set (upf_node_assoc_t * n);
 
 upf_session_t *pfcp_create_session (upf_node_assoc_t * assoc,
-				    const ip46_address_t * up_address,
-				    uint64_t cp_seid,
-				    const ip46_address_t * cp_address);
+				    u64 cp_seid,
+                                    u64 up_seid);
 void pfcp_update_session (upf_session_t * sx);
 void pfcp_disable_session (upf_session_t * sx);
 void pfcp_free_session (upf_session_t * sx);
@@ -69,7 +68,7 @@ void pfcp_send_end_marker (upf_session_t * sx, u16 far_id);
 int pfcp_update_apply (upf_session_t * sx);
 void pfcp_update_finish (upf_session_t * sx);
 
-upf_session_t *pfcp_lookup (uint64_t sess_id);
+upf_session_t *pfcp_lookup_up_seid (u64 up_seid);
 
 static inline struct rules *
 pfcp_get_rules (upf_session_t * sx, int rules)

--- a/upf/upf_pfcp.h
+++ b/upf/upf_pfcp.h
@@ -29,15 +29,13 @@ upf_node_assoc_t *pfcp_new_association (session_handle_t session_handle,
 					pfcp_node_id_t * node_id);
 void pfcp_release_association (upf_node_assoc_t * n);
 
-void pfcp_session_set_cp_fseid(upf_session_t * sx, pfcp_f_seid_t * f_seid);
+void pfcp_session_set_cp_fseid (upf_session_t * sx, pfcp_f_seid_t * f_seid);
 
-void pfcp_node_enter_smf_set (upf_node_assoc_t * n,
-                              u8 * fqdn);
+void pfcp_node_enter_smf_set (upf_node_assoc_t * n, u8 * fqdn);
 u32 *pfcp_node_exit_smf_set (upf_node_assoc_t * n);
 
 upf_session_t *pfcp_create_session (upf_node_assoc_t * assoc,
-				    pfcp_f_seid_t * cp_f_seid,
-                                    u64 up_seid);
+				    pfcp_f_seid_t * cp_f_seid, u64 up_seid);
 void pfcp_update_session (upf_session_t * sx);
 void pfcp_disable_session (upf_session_t * sx);
 void pfcp_free_session (upf_session_t * sx);
@@ -71,8 +69,9 @@ int pfcp_update_apply (upf_session_t * sx);
 void pfcp_update_finish (upf_session_t * sx);
 
 upf_session_t *pfcp_lookup_up_seid (u64 up_seid);
-upf_session_t *pfcp_lookup_cp_cached_f_seid (u32 cached_f_seid_idx, u64 cp_seid);
-upf_session_t *pfcp_lookup_cp_f_seid (pfcp_f_seid_t *f_seid);
+upf_session_t *pfcp_lookup_cp_cached_f_seid (u32 cached_f_seid_idx,
+					     u64 cp_seid);
+upf_session_t *pfcp_lookup_cp_f_seid (pfcp_f_seid_t * f_seid);
 
 static inline struct rules *
 pfcp_get_rules (upf_session_t * sx, int rules)

--- a/upf/upf_pfcp.h
+++ b/upf/upf_pfcp.h
@@ -29,7 +29,7 @@ upf_node_assoc_t *pfcp_new_association (session_handle_t session_handle,
 					pfcp_node_id_t * node_id);
 void pfcp_release_association (upf_node_assoc_t * n);
 
-void pfcp_session_set_fseid(upf_session_t * sx, pfcp_f_seid_t * f_seid);
+void pfcp_session_set_cp_fseid(upf_session_t * sx, pfcp_f_seid_t * f_seid);
 
 void pfcp_node_enter_smf_set (upf_node_assoc_t * n,
                               u8 * fqdn);

--- a/upf/upf_pfcp.h
+++ b/upf/upf_pfcp.h
@@ -29,6 +29,8 @@ upf_node_assoc_t *pfcp_new_association (session_handle_t session_handle,
 					pfcp_node_id_t * node_id);
 void pfcp_release_association (upf_node_assoc_t * n);
 
+void pfcp_session_set_fseid(upf_session_t * sx, pfcp_f_seid_t * f_seid);
+
 void pfcp_node_enter_smf_set (upf_node_assoc_t * n,
                               u8 * fqdn);
 u32 *pfcp_node_exit_smf_set (upf_node_assoc_t * n);

--- a/upf/upf_pfcp_api.c
+++ b/upf/upf_pfcp_api.c
@@ -116,17 +116,11 @@ init_response_up_f_seid (pfcp_f_seid_t * up_f_seid, ip46_address_t * address, bo
     {
       up_f_seid->flags |= IE_F_SEID_IP_ADDRESS_V4;
       up_f_seid->ip4 = address->ip4;
-
-      ip_set (&up_f_seid->ip4, &address->ip4, 1);
-      ip_set (&cp_address, &req->f_seid.ip4, 1);
     }
   else
     {
       up_f_seid->flags |= IE_F_SEID_IP_ADDRESS_V6;
-      up_f_seid->ip6 = addr.ip6;
-
-      ip_set (&up_address, &msg->lcl.address.ip6, 0);
-      ip_set (&cp_address, &req->f_seid.ip6, 0);
+      up_f_seid->ip6 = address->ip6;
     }
 }
 
@@ -2592,23 +2586,17 @@ handle_session_establishment_request (pfcp_msg_t * msg,
   resp->up_f_seid.seid = up_seid;
 
   is_ip4 = ip46_address_is_ip4 (&msg->rmt.address);
-  if (is_ip4)
-    {
-      resp->up_f_seid.flags |= IE_F_SEID_IP_ADDRESS_V4;
-      resp->up_f_seid.ip4 = msg->lcl.address.ip4;
-
-      ip_set (&up_address, &msg->lcl.address.ip4, 1);
-      ip_set (&cp_address, &req->f_seid.ip4, 1);
-    }
-  else
-    {
-      resp->up_f_seid.flags |= IE_F_SEID_IP_ADDRESS_V6;
-      resp->up_f_seid.ip6 = msg->lcl.address.ip6;
-
-      ip_set (&up_address, &msg->lcl.address.ip6, 0);
-      ip_set (&cp_address, &req->f_seid.ip6, 0);
-    }
   init_response_up_f_seid(&resp->up_f_seid, &msg->lcl.address, is_ip4);
+  ip_set (&up_address, &msg->lcl.address.ip4, is_ip4);
+  ip_set (&cp_address, &req->f_seid.ip4, is_ip4);
+
+  upf_debug ("CP F-SEID: 0x%016" PRIx64 " @ %U %U\n"
+	     "UP F-SEID: 0x%016" PRIx64 " @ %U\n",
+             req->f_seid.seid,
+	     format_ip4_address, &req->f_seid.ip4,
+             format_ip6_address, &req->f_seid.ip6,
+	     up_seid,
+             format_ip46_address, &up_address, IP46_TYPE_ANY);
 
   sess = pfcp_create_session (assoc, &req->f_seid, up_seid);
 

--- a/upf/upf_pfcp_api.c
+++ b/upf/upf_pfcp_api.c
@@ -52,7 +52,6 @@
 
 #include <vlib/unix/plugin.h>
 
-#define CLIB_DEBUG 2
 #if CLIB_DEBUG > 1
 #define upf_debug clib_warning
 #else
@@ -2979,6 +2978,7 @@ handle_session_report_response (pfcp_msg_t * msg, pfcp_decoded_msg_t * dmsg)
   else if (resp->response.cause == PFCP_CAUSE_REQUEST_ACCEPTED)
     {
       upf_session_t *sess;
+
       sess = pool_elt_at_index (gtm->sessions, msg->session_index);
       upf_debug("session report response session flags 0x%x", sess->flags);
       if (sess->flags & UPF_SESSION_LOST_CP)

--- a/upf/upf_pfcp_api.c
+++ b/upf/upf_pfcp_api.c
@@ -370,9 +370,13 @@ handle_association_setup_request (pfcp_msg_t * msg, pfcp_decoded_msg_t * dmsg)
 			  &req->request.node_id);
   n->recovery_time_stamp = req->recovery_time_stamp;
 
+  if (ISSET_BIT (req->grp.fields, ASSOCIATION_SETUP_REQUEST_SMF_SET_ID))
+    pfcp_node_enter_smf_set(n, req->smf_set_id.fqdn);
+
   UPF_SET_BIT (resp->grp.fields,
 	       ASSOCIATION_PROCEDURE_RESPONSE_UP_FUNCTION_FEATURES);
   resp->up_function_features |= F_UPFF_EMPU;
+  resp->up_function_features |= F_UPFF_MPAS;
   if (gtm->pfcp_spec_version >= 16)
     {
       resp->up_function_features |= F_UPFF_VTIME;

--- a/upf/upf_pfcp_api.c
+++ b/upf/upf_pfcp_api.c
@@ -40,21 +40,22 @@
 #include <vnet/fib/fib_path_list.h>
 
 #include "pfcp.h"
-#include "upf/upf.h"
+#include "upf.h"
 #include "upf_pfcp.h"
 #include "upf_pfcp_server.h"
 #include "upf_pfcp_api.h"
 #include "upf_app_db.h"
 #include "upf_ipfilter.h"
 #include "upf_ipfix.h"
-#include "vnet/ip/format.h"
-#include "vppinfra/clib.h"
-#include "vppinfra/error.h"
-#include "vppinfra/mhash.h"
-#include "vppinfra/pool.h"
-#include "vppinfra/time.h"
 
 #include <vlib/unix/plugin.h>
+
+#if CLIB_DEBUG > 1
+#define upf_debug clib_warning
+#else
+#define upf_debug(...)                         \
+  do { } while (0)
+#endif
 
 #define API_VERSION      1
 #define TRAFFIC_TIMER_PERIOD 60
@@ -482,6 +483,7 @@ handle_node_report_response (pfcp_msg_t * msg, pfcp_decoded_msg_t * dmsg)
   return -1;
 }
 
+/* this methods used for cases when incoming message decode is failed */
 static void
 send_simple_response (pfcp_msg_t * req, u8 type,
 		      pfcp_cause_t cause, pfcp_offending_ie_t * err)
@@ -489,7 +491,6 @@ send_simple_response (pfcp_msg_t * req, u8 type,
   pfcp_server_main_t *psm = &pfcp_server_main;
   pfcp_decoded_msg_t resp_dmsg = {
     .type = type,
-    .seid = 0,
   };
   pfcp_simple_response_t *resp = &resp_dmsg.simple_response;
 

--- a/upf/upf_pfcp_api.c
+++ b/upf/upf_pfcp_api.c
@@ -2965,7 +2965,7 @@ handle_session_report_response (pfcp_msg_t * msg, pfcp_decoded_msg_t * dmsg)
 
       /* since this is a response, and some time passed since the request
          make sure that session index still matches the original session */
-      if (sess->cp_seid != msg->seid)
+      if (sess->up_seid != msg->seid)
 	{
 	  upf_debug ("PFCP Session seid not matching (deleted already?).\n");
 	  return -1;

--- a/upf/upf_pfcp_server.c
+++ b/upf/upf_pfcp_server.c
@@ -30,12 +30,9 @@
 
 #include <vppinfra/bihash_template.c>
 
-#include "upf/pfcp.h"
-#include "upf/upf.h"
 #include "upf_pfcp.h"
 #include "upf_pfcp_api.h"
 #include "upf_pfcp_server.h"
-#include "vppinfra/pool.h"
 
 #define RESPONSE_TIMEOUT 30
 

--- a/upf/upf_pfcp_server.c
+++ b/upf/upf_pfcp_server.c
@@ -479,10 +479,10 @@ enqueue_request (pfcp_msg_t * msg, u32 n1, u32 t1)
 
   hash_set (psm->request_q, msg->seq_no, id);
   if (msg->session.idx != ~0) {
-    upf_session_requests_anchor_init(msg);
+    upf_session_requests_list_anchor_init(msg);
     upf_session_t *sx = pool_elt_at_index(upf_main.sessions, msg->session.idx);
 
-    upf_session_requests_insert_tail(psm->msg_pool, &sx->requests, msg);
+    upf_session_requests_list_insert_tail(psm->msg_pool, &sx->requests, msg);
   }
 
   msg->timer =
@@ -594,7 +594,7 @@ upf_pfcp_server_stop_request (pfcp_msg_t * req)
 
   if (req->session.idx != ~0) {
     upf_session_t *sx = pool_elt_at_index (gtm->sessions, req->session.idx);
-    upf_session_requests_remove(psm->msg_pool, &sx->requests, req);
+    upf_session_requests_list_remove(psm->msg_pool, &sx->requests, req);
     req->session.idx = ~0;
   }
   upf_pfcp_server_stop_msg_timer(req);

--- a/upf/upf_pfcp_server.c
+++ b/upf/upf_pfcp_server.c
@@ -510,7 +510,7 @@ request_t1_expired (u32 seq_no)
 
   upf_debug ("Msg Seq No: %u, %p, n1 %u\n", req->seq_no, req, req->n1);
 
-  // make sure to resent reports to new peer if smfset peer is changed
+  /* make sure to resent reports to new peer if smfset peer is changed */
   if (req->flags.is_migrated_in_smfset &&
       req->session.idx != ~0 &&
       pfcp_msg_type(req->data) == PFCP_SESSION_REPORT_REQUEST) {
@@ -519,12 +519,13 @@ request_t1_expired (u32 seq_no)
     pfcp_decoded_msg_t dmsg;
     pfcp_offending_ie_t *err = NULL;
 
-    // Decode request to dmesg so we can reencode it as new request
+    /* Decode request to dmesg so we can reencode it as new request */
     pfcp_decode_msg (req->data, vec_len (req->data), &dmsg, &err);
     upf_pfcp_server_send_session_request(sx, &dmsg);
     pfcp_free_dmsg_contents (&dmsg);
 
-    upf_pfcp_server_stop_request(req); // stop old request
+    /* stop old request */
+    upf_pfcp_server_stop_request(req);
     return;
   }
 
@@ -532,10 +533,12 @@ request_t1_expired (u32 seq_no)
     {
       u8 type = pfcp_msg_type (req->data);
 
-      // FIXME: here in pool_is_free_index we check for node index which can be reused
-      // as soon as node goes back. Instead we should stop all requests as soon
-      // as node is stopped. It should be easier to track since we can have
-      // only one heartbeat request at time
+      /*
+        FIXME: here in pool_is_free_index we check for node index which can be reused
+        as soon as node goes back. Instead we should stop all requests as soon
+        as node is stopped. It should be easier to track since we can have
+        only one heartbeat request at time
+      */
       if (type == PFCP_HEARTBEAT_REQUEST
 	  && !pool_is_free_index (gtm->nodes, req->node))
 	{
@@ -564,9 +567,11 @@ request_t1_expired (u32 seq_no)
 
       upf_pfcp_server_stop_request(req);
 
-      // TODO: this pool_is_free_index is invalid since pool id can be reused
-      // instead we should do checking based on persistent key or instead we
-      // could track or requests of node and forget them as soon as association is lost
+      /*
+        TODO: this pool_is_free_index is invalid since pool id can be reused
+        instead we should do checking based on persistent key or instead we
+        could track or requests of node and forget them as soon as association is lost
+      */
       if (type == PFCP_HEARTBEAT_REQUEST
 	  && !pool_is_free_index (gtm->nodes, node))
 	{
@@ -1636,7 +1641,7 @@ static uword
 
 	ASSERT (msg->expires_at);
 
-        // TODO: this is crazy, replace this workaround
+        /* TODO: replace this workaround with proper msg removal inplace */
 	if (!hash_get (psm->free_msgs_by_node, msg->node))
 	  {
 	    /*

--- a/upf/upf_pfcp_server.c
+++ b/upf/upf_pfcp_server.c
@@ -493,7 +493,10 @@ request_t1_expired (u32 seq_no)
         pfcp_decoded_msg_t dmsg;
         pfcp_offending_ie_t *err = NULL;
 
-        pfcp_decode_msg(msg->data, vec_len (msg->data), &dmsg, &err);
+        pfcp_decode_msg (msg->data, vec_len (msg->data), &dmsg, &err);
+
+        hash_unset (psm->request_q, msg->seq_no);
+        pfcp_msg_pool_put (psm, msg);
 
         // TODO: TODO: TODO: TODO: TODO:
         // dmsg.session_report_request.old_cp_f_seid = ses->cp_seid;

--- a/upf/upf_pfcp_server.c
+++ b/upf/upf_pfcp_server.c
@@ -483,7 +483,7 @@ request_t1_expired (u32 seq_no)
   msg = pfcp_msg_pool_elt_at_index (psm, p[0]);
   upf_debug ("Msg Seq No: %u, %p, n1 %u\n", msg->seq_no, msg, msg->n1);
 
-  // make sure to resent reports to new peer if it changed
+  // make sure to resent reports to new peer if peer changed
   if (pfcp_msg_type(msg->data) == PFCP_SESSION_REPORT_REQUEST) {
     if (msg->session_index != ~0) { // FIXME: can be assert instead?
       upf_session_t *ses = pool_elt_at_index (gtm->sessions, msg->session_index);
@@ -494,7 +494,6 @@ request_t1_expired (u32 seq_no)
         pfcp_offending_ie_t *err = NULL;
 
         pfcp_decode_msg (msg->data, vec_len (msg->data), &dmsg, &err);
-
         hash_unset (psm->request_q, msg->seq_no);
         pfcp_msg_pool_put (psm, msg);
 

--- a/upf/upf_pfcp_server.h
+++ b/upf/upf_pfcp_server.h
@@ -187,7 +187,7 @@ void upf_pfcp_server_session_usage_report (upf_event_urr_data_t * uev);
 
 clib_error_t *pfcp_server_main_init (vlib_main_t * vm);
 
-UPF_LLIST_TEMPLATE_DEFINITIONS(upf_session_requests_list, pfcp_msg_t, session.anchor)
+UPF_LLIST_TEMPLATE_DEFINITIONS(upf_session_requests_list, pfcp_msg_t, session.anchor);
 
 static inline void
 init_pfcp_msg (pfcp_msg_t * m)

--- a/upf/upf_pfcp_server.h
+++ b/upf/upf_pfcp_server.h
@@ -74,7 +74,8 @@ typedef struct
 
   u32 node;
 
-  struct {
+  struct
+  {
     // request can lost session attachment in-flight if session was removed
     // while request is being answered
     u32 idx;
@@ -88,7 +89,8 @@ typedef struct
   u32 n1;
   u32 t1;
 
-  struct {
+  struct
+  {
     u8 is_valid_pool_item:1;
     u8 is_migrated_in_smfset:1;
     u8 is_stopped:1;
@@ -187,7 +189,8 @@ void upf_pfcp_server_session_usage_report (upf_event_urr_data_t * uev);
 
 clib_error_t *pfcp_server_main_init (vlib_main_t * vm);
 
-UPF_LLIST_TEMPLATE_DEFINITIONS(upf_session_requests_list, pfcp_msg_t, session.anchor);
+UPF_LLIST_TEMPLATE_DEFINITIONS (upf_session_requests_list, pfcp_msg_t,
+				session.anchor);
 
 static inline void
 init_pfcp_msg (pfcp_msg_t * m)
@@ -199,7 +202,7 @@ init_pfcp_msg (pfcp_msg_t * m)
   m->node = ~0;
   m->session.idx = ~0;
   m->timer = ~0;
-  upf_session_requests_list_anchor_init(m);
+  upf_session_requests_list_anchor_init (m);
 }
 
 static inline void
@@ -278,9 +281,10 @@ _pfcp_msg_pool_put (pfcp_server_main_t * psm, pfcp_msg_t * m)
 {
   ASSERT (m->flags.is_valid_pool_item);
 
-  if (m->session.idx != ~0) {
-    ASSERT (!upf_session_requests_list_el_is_part_of_list(m) );
-  }
+  if (m->session.idx != ~0)
+    {
+      ASSERT (!upf_session_requests_list_el_is_part_of_list (m));
+    }
 
   vec_free (m->data);
 #if CLIB_DEBUG > 0

--- a/upf/upf_pfcp_server.h
+++ b/upf/upf_pfcp_server.h
@@ -135,7 +135,7 @@ typedef struct
 typedef struct
 {
   uword session_idx;
-  u64 cp_seid;
+  u64 up_seid;
   ip46_address_t ue;
   u8 status;
 } upf_event_urr_hdr_t;
@@ -181,6 +181,7 @@ init_pfcp_msg (pfcp_msg_t * m)
   memset (m, 0, sizeof (*m));
   m->is_valid_pool_item = is_valid_pool_item;
   m->node = ~0;
+  m->session_index = ~0;
 }
 
 static inline void

--- a/upf/upf_pfcp_server.h
+++ b/upf/upf_pfcp_server.h
@@ -76,8 +76,10 @@ typedef struct
 
   struct
   {
-    // request can lost session attachment in-flight if session was removed
-    // while request is being answered
+    /*
+      request can lost session in-flight if session was removed
+      while request is being answered
+    */
     u32 idx;
     upf_session_requests_list_anchor_t anchor;
   } session;

--- a/upf/upf_pfcp_server.h
+++ b/upf/upf_pfcp_server.h
@@ -77,9 +77,9 @@ typedef struct
   struct
   {
     /*
-      request can lost session in-flight if session was removed
-      while request is being answered
-    */
+       request can lost session in-flight if session was removed
+       while request is being answered
+     */
     u32 idx;
     upf_session_requests_list_anchor_t anchor;
   } session;

--- a/upf/upf_pfcp_server.h
+++ b/upf/upf_pfcp_server.h
@@ -75,6 +75,8 @@ typedef struct
   u32 node;
 
   struct {
+    // request can lost session attachment in-flight if session was removed
+    // while request is being answered
     u32 idx;
     upf_session_requests_anchor_t anchor;
   } session;

--- a/upf/upf_pfcp_server.h
+++ b/upf/upf_pfcp_server.h
@@ -78,7 +78,7 @@ typedef struct
     // request can lost session attachment in-flight if session was removed
     // while request is being answered
     u32 idx;
-    upf_session_requests_anchor_t anchor;
+    upf_session_requests_list_anchor_t anchor;
   } session;
 
   u64 up_seid;
@@ -187,7 +187,7 @@ void upf_pfcp_server_session_usage_report (upf_event_urr_data_t * uev);
 
 clib_error_t *pfcp_server_main_init (vlib_main_t * vm);
 
-UPF_LLIST_TEMPLATE_DEFINITIONS(upf_session_requests, pfcp_msg_t, session.anchor)
+UPF_LLIST_TEMPLATE_DEFINITIONS(upf_session_requests_list, pfcp_msg_t, session.anchor)
 
 static inline void
 init_pfcp_msg (pfcp_msg_t * m)
@@ -199,7 +199,7 @@ init_pfcp_msg (pfcp_msg_t * m)
   m->node = ~0;
   m->session.idx = ~0;
   m->timer = ~0;
-  upf_session_requests_anchor_init(m);
+  upf_session_requests_list_anchor_init(m);
 }
 
 static inline void
@@ -279,7 +279,7 @@ _pfcp_msg_pool_put (pfcp_server_main_t * psm, pfcp_msg_t * m)
   ASSERT (m->flags.is_valid_pool_item);
 
   if (m->session.idx != ~0) {
-    ASSERT (!upf_session_requests_el_is_part_of_list(m) );
+    ASSERT (!upf_session_requests_list_el_is_part_of_list(m) );
   }
 
   vec_free (m->data);

--- a/upf/upf_pfcp_server.h
+++ b/upf/upf_pfcp_server.h
@@ -77,7 +77,7 @@ typedef struct
   struct
   {
     /*
-       request can lost session in-flight if session was removed
+       request can loose session in-flight if session was removed
        while request is being answered
      */
     u32 idx;

--- a/upf/upf_pfcp_server.h
+++ b/upf/upf_pfcp_server.h
@@ -81,13 +81,18 @@ typedef struct
     upf_session_requests_anchor_t anchor;
   } session;
 
-  u64 seid;
+  u64 up_seid;
 
   f64 expires_at;		/* message timestamp */
   u32 timer;
   u32 n1;
   u32 t1;
-  u8 is_valid_pool_item;
+
+  struct {
+    u8 is_valid_pool_item:1;
+    u8 is_migrated_in_smfset:1;
+    u8 is_stopped:1;
+  } flags;
 
 #if CLIB_DEBUG > 0
   char pool_put_loc[128];
@@ -170,6 +175,8 @@ void upf_pfcp_server_stop_msg_timer (pfcp_msg_t * msg);
 void upf_pfcp_server_stop_heartbeat_timer (upf_node_assoc_t * n);
 void upf_pfcp_server_deferred_free_msgs_by_node (u32 node);
 
+void upf_pfcp_server_stop_request (pfcp_msg_t * req);
+
 int upf_pfcp_send_request (upf_session_t * sx, pfcp_decoded_msg_t * dmsg);
 
 int upf_pfcp_send_response (pfcp_msg_t * req, pfcp_decoded_msg_t * dmsg);
@@ -185,12 +192,13 @@ UPF_LLIST_TEMPLATE_DEFINITIONS(upf_session_requests, pfcp_msg_t, session.anchor)
 static inline void
 init_pfcp_msg (pfcp_msg_t * m)
 {
-  u8 is_valid_pool_item = m->is_valid_pool_item;
+  u8 is_valid_pool_item = m->flags.is_valid_pool_item;
 
   memset (m, 0, sizeof (*m));
-  m->is_valid_pool_item = is_valid_pool_item;
+  m->flags.is_valid_pool_item = is_valid_pool_item;
   m->node = ~0;
   m->session.idx = ~0;
+  m->timer = ~0;
   upf_session_requests_anchor_init(m);
 }
 
@@ -238,7 +246,7 @@ pfcp_msg_pool_get (pfcp_server_main_t * psm)
     }
 
   init_pfcp_msg (m);
-  m->is_valid_pool_item = 1;
+  m->flags.is_valid_pool_item = 1;
   return m;
 }
 
@@ -249,7 +257,7 @@ pfcp_msg_pool_add (pfcp_server_main_t * psm, pfcp_msg_t * m)
 
   msg = pfcp_msg_pool_get (psm);
   clib_memcpy_fast (msg, m, sizeof (*m));
-  msg->is_valid_pool_item = 1;
+  msg->flags.is_valid_pool_item = 1;
 #if CLIB_DEBUG > 0
   msg->pool_put_loc[0] = 0;
 #endif
@@ -268,7 +276,7 @@ pfcp_msg_pool_add (pfcp_server_main_t * psm, pfcp_msg_t * m)
 static inline void
 _pfcp_msg_pool_put (pfcp_server_main_t * psm, pfcp_msg_t * m)
 {
-  ASSERT (m->is_valid_pool_item);
+  ASSERT (m->flags.is_valid_pool_item);
 
   if (m->session.idx != ~0) {
     ASSERT (!upf_session_requests_el_is_part_of_list(m) );
@@ -278,7 +286,7 @@ _pfcp_msg_pool_put (pfcp_server_main_t * psm, pfcp_msg_t * m)
 #if CLIB_DEBUG > 0
   clib_memset (m, 0xfa, sizeof (pfcp_msg_t));
 #endif
-  m->is_valid_pool_item = 0;
+  m->flags.is_valid_pool_item = 0;
   vec_add1 (psm->msg_pool_free, m - psm->msg_pool);
 }
 
@@ -288,7 +296,7 @@ pfcp_msg_pool_is_free_index (pfcp_server_main_t * psm, u32 index)
   if (!pool_is_free_index (psm->msg_pool, index))
     {
       pfcp_msg_t *m = pool_elt_at_index (psm->msg_pool, index);
-      return !m->is_valid_pool_item;
+      return !m->flags.is_valid_pool_item;
     }
   return 0;
 }
@@ -298,7 +306,7 @@ pfcp_msg_pool_elt_at_index (pfcp_server_main_t * psm, u32 index)
 {
   pfcp_msg_t *m = pool_elt_at_index (psm->msg_pool, index);
 #if CLIB_DEBUG > 0
-  if (!m->is_valid_pool_item)
+  if (!m->flags.is_valid_pool_item)
     {
       clib_warning ("ERROR: accessing a PFCP msg that was freed at: %s",
 		    m->pool_put_loc);

--- a/upf/upf_pfcp_server.h
+++ b/upf/upf_pfcp_server.h
@@ -268,6 +268,10 @@ _pfcp_msg_pool_put (pfcp_server_main_t * psm, pfcp_msg_t * m)
 {
   ASSERT (m->is_valid_pool_item);
 
+  if (m->session.idx != ~0) {
+    ASSERT (!upf_session_requests_el_is_part_of_list(m) );
+  }
+
   vec_free (m->data);
 #if CLIB_DEBUG > 0
   clib_memset (m, 0xfa, sizeof (pfcp_msg_t));

--- a/upf/upf_proxy_accept.c
+++ b/upf/upf_proxy_accept.c
@@ -72,7 +72,7 @@ typedef enum
 typedef struct
 {
   u32 session_index;
-  u64 cp_seid;
+  u64 up_seid;
   u32 pdr_idx;
   u8 packet_data[64 - 1 * sizeof (u32)];
 }
@@ -88,8 +88,8 @@ format_upf_proxy_accept_trace (u8 * s, va_list * args)
 
   s =
     format (s,
-	    "upf_session%d cp-seid 0x%016" PRIx64
-	    " pdr %d\n%U%U", t->session_index, t->cp_seid,
+	    "upf_session%d up-seid 0x%016" PRIx64
+	    " pdr %d\n%U%U", t->session_index, t->up_seid,
 	    t->pdr_idx, format_white_space, indent,
 	    format_ip4_header, t->packet_data, sizeof (t->packet_data));
   return s;

--- a/upf/upf_proxy_input.c
+++ b/upf/upf_proxy_input.c
@@ -72,7 +72,7 @@ typedef enum
 typedef struct
 {
   u32 session_index;
-  u64 cp_seid;
+  u64 up_seid;
   u8 packet_data[64 - 1 * sizeof (u32)];
 }
 upf_proxy_input_trace_t;
@@ -85,8 +85,8 @@ format_upf_proxy_input_trace (u8 * s, va_list * args)
   upf_proxy_input_trace_t *t = va_arg (*args, upf_proxy_input_trace_t *);
   u32 indent = format_get_indent (s);
 
-  s = format (s, "upf_session%d cp-seid 0x%016" PRIx64 "\n%U%U",
-	      t->session_index, t->cp_seid,
+  s = format (s, "upf_session%d up-seid 0x%016" PRIx64 "\n%U%U",
+	      t->session_index, t->up_seid,
 	      format_white_space, indent,
 	      format_ip4_header, t->packet_data, sizeof (t->packet_data));
   return s;
@@ -495,7 +495,7 @@ upf_proxy_input (vlib_main_t * vm, vlib_node_runtime_t * node,
 	      sidx = upf_buffer_opaque (b)->gtpu.session_index;
 	      sess = pool_elt_at_index (gtm->sessions, sidx);
 	      tr->session_index = sidx;
-	      tr->cp_seid = sess->cp_seid;
+	      tr->up_seid = sess->up_seid;
 	      clib_memcpy (tr->packet_data, vlib_buffer_get_current (b),
 			   sizeof (tr->packet_data));
 	    }

--- a/upf/upf_proxy_output.c
+++ b/upf/upf_proxy_output.c
@@ -76,7 +76,7 @@ typedef enum
 typedef struct
 {
   u32 session_index;
-  u64 cp_seid;
+  u64 up_seid;
   u32 flow_id;
   u32 pdr_idx;
   u8 packet_data[64 - 1 * sizeof (u32)];
@@ -91,9 +91,9 @@ format_upf_proxy_output_trace (u8 * s, va_list * args)
   upf_proxy_output_trace_t *t = va_arg (*args, upf_proxy_output_trace_t *);
   u32 indent = format_get_indent (s);
 
-  s = format (s, "upf_session%d cp-seid 0x%016" PRIx64 " Flow %u PDR Idx %u\n"
+  s = format (s, "upf_session%d up-seid 0x%016" PRIx64 " Flow %u PDR Idx %u\n"
 	      "%U%U",
-	      t->session_index, t->cp_seid, t->flow_id, t->pdr_idx,
+	      t->session_index, t->up_seid, t->flow_id, t->pdr_idx,
 	      format_white_space, indent,
 	      format_ip4_header, t->packet_data, sizeof (t->packet_data));
   return s;
@@ -357,7 +357,7 @@ upf_proxy_output (vlib_main_t * vm, vlib_node_runtime_t * node,
 	      sidx = upf_buffer_opaque (b)->gtpu.session_index;
 	      sess = pool_elt_at_index (gtm->sessions, sidx);
 	      tr->session_index = sidx;
-	      tr->cp_seid = sess->cp_seid;
+	      tr->up_seid = sess->up_seid;
 	      tr->flow_id = upf_buffer_opaque (b)->gtpu.flow_id;
 	      tr->pdr_idx = upf_buffer_opaque (b)->gtpu.pdr_idx;
 	      clib_memcpy (tr->packet_data, vlib_buffer_get_current (b),

--- a/upf/upf_session_dpo.c
+++ b/upf/upf_session_dpo.c
@@ -171,7 +171,7 @@ format_upf_session_dpo (u8 * s, va_list * ap)
   upf_session_t *sx = upf_session_dpo_get (index);
 
   s =
-    format (s, "UPF session: UP SEID: 0x%016" PRIx64 " (@%p)", sx->cp_seid,
+    format (s, "UPF session: UP SEID: 0x%016" PRIx64 " (@%p)", sx->up_seid,
 	    sx);
   return (s);
 }
@@ -288,7 +288,7 @@ typedef enum
 typedef struct
 {
   u32 session_index;
-  u64 cp_seid;
+  u64 up_seid;
   u8 packet_data[64 - 1 * sizeof (u32)];
 }
 upf_session_dpo_trace_t;
@@ -302,7 +302,7 @@ format_upf_session_dpo_trace (u8 * s, va_list * args)
   u32 indent = format_get_indent (s);
 
   s = format (s, "upf_session%d seid %d \n%U%U",
-	      t->session_index, t->cp_seid,
+	      t->session_index, t->up_seid,
 	      format_white_space, indent,
 	      format_ip4_header, t->packet_data, sizeof (t->packet_data));
   return s;
@@ -441,7 +441,7 @@ VLIB_NODE_FN (upf_ip4_session_dpo_node) (vlib_main_t * vm,
 	      upf_session_dpo_trace_t *tr =
 		vlib_add_trace (vm, node, b, sizeof (*tr));
 	      tr->session_index = sidx;
-	      tr->cp_seid = sess->cp_seid;
+	      tr->up_seid = sess->up_seid;
 	      clib_memcpy (tr->packet_data, vlib_buffer_get_current (b),
 			   sizeof (tr->packet_data));
 	    }
@@ -573,7 +573,7 @@ VLIB_NODE_FN (upf_ip6_session_dpo_node) (vlib_main_t * vm,
 	      upf_session_dpo_trace_t *tr =
 		vlib_add_trace (vm, node, b, sizeof (*tr));
 	      tr->session_index = sidx;
-	      tr->cp_seid = sess->cp_seid;
+	      tr->up_seid = sess->up_seid;
 	      clib_memcpy (tr->packet_data, vlib_buffer_get_current (b),
 			   sizeof (tr->packet_data));
 	    }

--- a/upf/upf_tcp_forward.c
+++ b/upf/upf_tcp_forward.c
@@ -67,7 +67,7 @@ typedef enum
 typedef struct
 {
   u32 session_index;
-  u64 cp_seid;
+  u64 up_seid;
   u32 flow_id;
   u32 pdr_idx;
   u8 packet_data[64 - 1 * sizeof (u32)];
@@ -82,9 +82,9 @@ format_upf_tcp_forward_trace (u8 * s, va_list * args)
   upf_tcp_forward_trace_t *t = va_arg (*args, upf_tcp_forward_trace_t *);
   u32 indent = format_get_indent (s);
 
-  s = format (s, "upf_session%d cp-seid 0x%016" PRIx64 " Flow %u PDR Idx %u\n"
+  s = format (s, "upf_session%d up-seid 0x%016" PRIx64 " Flow %u PDR Idx %u\n"
 	      "%U%U",
-	      t->session_index, t->cp_seid, t->flow_id, t->pdr_idx,
+	      t->session_index, t->up_seid, t->flow_id, t->pdr_idx,
 	      format_white_space, indent,
 	      format_ip4_header, t->packet_data, sizeof (t->packet_data));
   return s;
@@ -322,7 +322,7 @@ upf_tcp_forward (vlib_main_t * vm, vlib_node_runtime_t * node,
 	      sidx = upf_buffer_opaque (b)->gtpu.session_index;
 	      sess = pool_elt_at_index (gtm->sessions, sidx);
 	      tr->session_index = sidx;
-	      tr->cp_seid = sess->cp_seid;
+	      tr->up_seid = sess->up_seid;
 	      tr->flow_id = upf_buffer_opaque (b)->gtpu.flow_id;
 	      tr->pdr_idx = upf_buffer_opaque (b)->gtpu.pdr_idx;
 	      clib_memcpy (tr->packet_data, vlib_buffer_get_current (b),


### PR DESCRIPTION
Implement SMFSet and migration of session to new SMF association from SMFSet when old association is released. And resend in-flight request to new SMF when old SMF goes down to not lose reports.

Session doesn't aware if association setup it's part of is SMFSet or not except for case when association released and session cp_fseid becomes invalid until new SMF updates it, but even this part handled in pfcp messaging. Only major change of existing logic is in association release code, which for SMFSet case doesn't remove sessions, but trying to redistribute sessions across remaining associations in this SMFSet. Other changes mostly bookkeeping.

Directly unrelated change to MPAS:
- Separate up_seid and cp_seid in code and test. Use cp_seid only when we send messages, in other cases use up_seid. Previously UPF used cp_seid as up_seid, but with migration it can be possible that new SMF will set different cp_seid and we wouldn't be able to used it as up_seid since we can't change up_seid
- Add tracking of cp_f_seid to detect cp_f_seid collisions. cp_f_seid ip addresses cached in separated pool to not increase memory usage per session noticeably
- Tracking of sent request per session to resend them when we migrate between SMFs
- Unification of tracking of sessions per association using common linked list implementation
- Do not create spinlock for session if it will not be used (in macro) to decrease memory usage.