### PR TITLE
Update FPP-VPP to 22.10.11

### DIFF
--- a/vpp.spec
+++ b/vpp.spec
@@ -1,2 +1,1 @@
-VPP_IMAGE_BASE=quay.io/travelping/fpp-vpp:v22.10.10
-
+VPP_IMAGE_BASE=quay.io/travelping/fpp-vpp:v22.10.11


### PR DESCRIPTION
A new build of FPP-VPP includes CG-NAT fix for selecting RX FIB as TX FIB.