### PR TITLE
[CENNSO-1366] feat: optional ipfix intermediate export

### DIFF
--- a/test/e2e/ipfix_e2e.go
+++ b/test/e2e/ipfix_e2e.go
@@ -210,6 +210,7 @@ func describeIPFIX(title string, mode framework.UPGMode, ipMode framework.UPGIPM
 				f := framework.NewDefaultFramework(mode, ipMode)
 				v := &ipfixVerifier{f: f}
 				v.withNWIIPFIXPolicy("default")
+				v.withReportingInterval(5)
 				v.withIPFIXHandler()
 
 				ginkgo.BeforeEach(func() {

--- a/upf/upf_cli.c
+++ b/upf/upf_cli.c
@@ -430,7 +430,7 @@ upf_nwi_add_del_command_fn (vlib_main_t * vm,
       else if (unformat (line_input, "ipfix-collector-ip %U",
 			 unformat_ip_address, &ipfix_collector_ip))
 	;
-      else if (unformat (line_input, "ipfix-report-interval %d",
+      else if (unformat (line_input, "ipfix-report-interval %u",
 			 &ipfix_report_interval))
 	;
       else

--- a/upf/upf_cli.c
+++ b/upf/upf_cli.c
@@ -430,7 +430,7 @@ upf_nwi_add_del_command_fn (vlib_main_t * vm,
       else if (unformat (line_input, "ipfix-collector-ip %U",
 			 unformat_ip_address, &ipfix_collector_ip))
 	;
-      else if (unformat (line_input, "ipfix-report-interval %u",
+      else if (unformat (line_input, "ipfix-report-interval %d",
 			 &ipfix_report_interval))
 	;
       else

--- a/upf/upf_ipfix.c
+++ b/upf/upf_ipfix.c
@@ -484,11 +484,8 @@ upf_ipfix_flow_stats_update_handler (flowtable_main_t * _fm,
     return 0;
 
   info = pool_elt_at_index (fm->infos, iidx);
-  if (info->report_interval != ~0)
-    {
-      if (now > flow_last_exported(f, direction) + info->report_interval)
-        upf_ipfix_export_entry (vm, f, direction, now, false);
-    }
+  if (now > flow_last_exported(f, direction) + info->report_interval)
+    upf_ipfix_export_entry (vm, f, direction, now, false);
 
   return 0;
 }
@@ -672,7 +669,7 @@ upf_ensure_ref_ipfix_info (upf_ipfix_info_key_t *key)
   else
     clib_warning ("non-existent egress NWI at index %u", key->info_nwi_index);
 
-  if (info->report_interval == 0)
+  if (info->report_interval == 0 || info->report_interval == ~0)
     info->report_interval = UPF_IPFIX_DEFAULT_REPORT_INTERVAL;
 
   context_key.policy = key->policy;

--- a/upf/upf_ipfix.c
+++ b/upf/upf_ipfix.c
@@ -47,7 +47,7 @@
 #endif
 
 /* Default report interval in seconds */
-#define UPF_IPFIX_DEFAULT_REPORT_INTERVAL 5
+#define UPF_IPFIX_DEFAULT_REPORT_INTERVAL 900
 
 upf_ipfix_main_t upf_ipfix_main;
 uword upf_ipfix_walker_process (vlib_main_t * vm, vlib_node_runtime_t * rt,
@@ -484,8 +484,11 @@ upf_ipfix_flow_stats_update_handler (flowtable_main_t * _fm,
     return 0;
 
   info = pool_elt_at_index (fm->infos, iidx);
-  if (now > flow_last_exported(f, direction) + info->report_interval)
-    upf_ipfix_export_entry (vm, f, direction, now, false);
+  if (info->report_interval != ~0)
+    {
+      if (now > flow_last_exported(f, direction) + info->report_interval)
+        upf_ipfix_export_entry (vm, f, direction, now, false);
+    }
 
   return 0;
 }
@@ -669,7 +672,7 @@ upf_ensure_ref_ipfix_info (upf_ipfix_info_key_t *key)
   else
     clib_warning ("non-existent egress NWI at index %u", key->info_nwi_index);
 
-  if (info->report_interval == 0 || info->report_interval == ~0)
+  if (info->report_interval == 0)
     info->report_interval = UPF_IPFIX_DEFAULT_REPORT_INTERVAL;
 
   context_key.policy = key->policy;

--- a/upf/upf_ipfix.c
+++ b/upf/upf_ipfix.c
@@ -46,9 +46,6 @@
   do { } while (0)
 #endif
 
-/* Default report interval in seconds */
-#define UPF_IPFIX_DEFAULT_REPORT_INTERVAL 900
-
 upf_ipfix_main_t upf_ipfix_main;
 uword upf_ipfix_walker_process (vlib_main_t * vm, vlib_node_runtime_t * rt,
 				vlib_frame_t * f);
@@ -484,8 +481,9 @@ upf_ipfix_flow_stats_update_handler (flowtable_main_t * _fm,
     return 0;
 
   info = pool_elt_at_index (fm->infos, iidx);
-  if (now > flow_last_exported(f, direction) + info->report_interval)
-    upf_ipfix_export_entry (vm, f, direction, now, false);
+  if (info->report_interval)
+      if (PREDICT_FALSE(now > flow_last_exported(f, direction) + info->report_interval))
+        upf_ipfix_export_entry (vm, f, direction, now, false);
 
   return 0;
 }
@@ -669,8 +667,8 @@ upf_ensure_ref_ipfix_info (upf_ipfix_info_key_t *key)
   else
     clib_warning ("non-existent egress NWI at index %u", key->info_nwi_index);
 
-  if (info->report_interval == 0 || info->report_interval == ~0)
-    info->report_interval = UPF_IPFIX_DEFAULT_REPORT_INTERVAL;
+  if (info->report_interval == ~0)
+    info->report_interval = 0;
 
   context_key.policy = key->policy;
   context_key.is_ip4 = key->is_ip4;


### PR DESCRIPTION
Change default value of 0 to mean "do not send intermediate reports" instead of 5s

After trying to figure out how to use ~0 I think this one is more logical solution