### PR TITLE
[BACKPORT][CENNSO-871] fix: use doubly linked list for flows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ set(UPF_PLUGIN_HEADER_FILES
   upf/upf_ipfix_templates.h
   upf/upf_gtpu_error.def
   upf/version.h
+  upf/llist.h
 )
 
 set(UPF_API_TEST_SOURCE_FILES

--- a/upf/flowtable.c
+++ b/upf/flowtable.c
@@ -364,7 +364,7 @@ flowtable_entry_lookup_create (flowtable_main_t * fm,
 			       clib_bihash_kv_48_8_t * kv,
 			       u64 timestamp_ns, u32 const now,
 			       u8 is_reverse, u16 generation,
-			       u32 next_session_flow_index, int *created)
+			       u32 session_index, int *created)
 {
   flow_entry_t *f;
   dlist_elt_t *timer_entry;
@@ -423,7 +423,7 @@ flowtable_entry_lookup_create (flowtable_main_t * fm,
   flow_last_exported (f, FT_ORIGIN) = now;
   flow_last_exported (f, FT_REVERSE) = now;
   f->ps_index = ~0;
-  f->next_session_flow_index = next_session_flow_index;
+  session_flows_list_anchor_init (f);
 
   /* insert in timer list */
   pool_get (fmt->timers, timer_entry);

--- a/upf/flowtable.h
+++ b/upf/flowtable.h
@@ -28,6 +28,7 @@
 #include <vppinfra/vec.h>
 
 #include "flowtable_tcp.h"
+#include "llist.h"
 
 #define foreach_flowtable_error				\
   _(HIT, "packets with an existing flow")		\
@@ -112,6 +113,8 @@ typedef struct flow_tc
   u32 thread_index;
 } flow_tc_t;
 
+UPF_LLIST_TEMPLATE_TYPES (session_flows_list);
+
 typedef struct flow_entry
 {
   /* Required for pool_get_aligned  */
@@ -158,14 +161,16 @@ typedef struct flow_entry
   u32 last_exported[FT_ORDER_MAX];
   u32 ipfix_info_index[FT_ORDER_MAX];
 
-  /* Linkage to the next flow for the same session */
-  u32 next_session_flow_index;
+  session_flows_list_anchor_t session_list_anchor;
 
   /* Generation ID that must match the session's if this flow is up to date */
   u16 generation;
   u32 cpu_index;
   u16 nat_sport;
 } flow_entry_t;
+
+UPF_LLIST_TEMPLATE_DEFINITIONS (session_flows_list, flow_entry_t,
+				session_list_anchor);
 
 /* accessor helper */
 #define flow_member(F, M, D)   (F)->M[(D) ^ (F)->is_reverse]
@@ -323,7 +328,7 @@ flowtable_entry_lookup_create (flowtable_main_t * fm,
 			       clib_bihash_kv_48_8_t * kv,
 			       u64 timestamp_ns, u32 const now,
 			       u8 is_reverse, u16 generation,
-			       u32 next_session_flow_index, int *created);
+			       u32 session_index, int *created);
 
 void
 timer_wheel_index_update (flowtable_main_t * fm,

--- a/upf/llist.h
+++ b/upf/llist.h
@@ -1,0 +1,209 @@
+#include "vppinfra/error_bootstrap.h"
+#include "vppinfra/types.h"
+#include "vppinfra/clib.h"
+#include "vppinfra/pool.h"
+#include <stdbool.h>
+
+/*
+This is analog of vpp dlist, but intrusive version with anchor.
+Also this implementation can create typed helpers.
+*/
+
+#if CLIB_ASSERT_ENABLE
+  /* llist debug adds count field to list to verify it's length */
+  #define UPF_LLIST_DEBUG
+#endif
+
+typedef struct {
+  /*
+    if empty, then ~0
+    if non empty, then idx of element
+  */
+  u32 head;
+#ifdef UPF_LLIST_DEBUG
+  u32 count;
+#endif
+} upf_llist_t;
+
+typedef struct {
+  /*
+    if not in a list, next = ~0 and prev = ~0
+    if single element in list next = this el, prev = this el
+    if in list next = next el, prev = prev el
+  */
+  u32 next;
+  u32 prev;
+} upf_llist_anchor_t;
+
+#ifdef UPF_LLIST_DEBUG
+  #define _UPF_LLIST_LIST_ASSERT_CHANGE_COUNT(LIST, CHANGE) do { \
+    LIST->count += (CHANGE); \
+    ASSERT(LIST->count + 1 != 0); \
+  } while (0)
+#else
+  #define _UPF_LLIST_LIST_ASSERT_CHANGE_COUNT(LIST, CHANGE) {}
+#endif
+
+static void
+upf_llist_init(upf_llist_t *list) {
+  list->head = ~0;
+#ifdef UPF_LLIST_DEBUG
+  list->count = 0;
+#endif
+}
+
+static bool
+upf_llist_list_is_empty(upf_llist_t *list) {
+#ifdef UPF_LLIST_DEBUG
+  ASSERT((list->head != ~0) == (list->count != 0));
+#endif
+  return list->head == ~0;
+}
+
+static void
+_upf_llist_anchor_init(upf_llist_anchor_t *anchor) {
+  anchor->next = ~0;
+  anchor->prev = ~0;
+}
+
+static bool
+_upf_llist_anchor_inserted(upf_llist_anchor_t *anchor) {
+#ifdef UPF_LLIST_DEBUG
+  ASSERT((anchor->next != ~0) == (anchor->prev != ~0));
+#endif
+  return anchor->next != ~0;
+}
+
+/*
+  Conflicts with pfcp msg pool
+  #define __upf_llist_get(POOL, INDEX) (pool_elt_at_index(POOL, INDEX))
+*/
+#define __upf_llist_get(POOL, INDEX) (&POOL[INDEX])
+#define upf_llist_anchor_init(ANCHOR, ELEMENT) _upf_llist_anchor_init(&ELEMENT->ANCHOR);
+#define upf_llist_el_is_part_of_list(ANCHOR, ELEMENT) _upf_llist_anchor_inserted(&ELEMENT->ANCHOR)
+
+#define upf_llist_insert_tail(POOL, ANCHOR, LIST, NEW) \
+do { \
+  typeof(POOL) __new_el = NEW; \
+  u32 __new_idx = __new_el - POOL; \
+  \
+  ASSERT(LIST); \
+  ASSERT(POOL); \
+  ASSERT(NEW); \
+  if (0) { ASSERT(!pool_is_free_index(POOL, __new_idx)); /* Conflicts with pfcp msg pool */ } \
+  ASSERT(!upf_llist_el_is_part_of_list(ANCHOR, __new_el)); \
+  \
+  if (upf_llist_list_is_empty(LIST)) { \
+    __new_el->ANCHOR.next = __new_idx; \
+    __new_el->ANCHOR.prev = __new_idx; \
+    LIST->head = __new_idx; \
+  } else { \
+    u32 __first_idx = LIST->head; \
+    typeof(POOL) __first_el = __upf_llist_get(POOL, __first_idx); \
+    u32 __last_idx = __first_el->ANCHOR.prev; \
+    typeof(POOL) __last_el = __upf_llist_get(POOL, __last_idx); \
+    \
+    ASSERT(upf_llist_el_is_part_of_list(ANCHOR, __first_el)); \
+    ASSERT(upf_llist_el_is_part_of_list(ANCHOR, __last_el)); \
+    \
+    __last_el->ANCHOR.next = __new_idx; \
+    __first_el->ANCHOR.prev = __new_idx; \
+    __new_el->ANCHOR.next = __first_idx; \
+    __new_el->ANCHOR.prev = __last_idx; \
+  } \
+  \
+  _UPF_LLIST_LIST_ASSERT_CHANGE_COUNT(LIST, 1); \
+} while(0)
+
+#define upf_llist_remove(POOL, ANCHOR, LIST, ELEMENT) \
+do { \
+  typeof(POOL) __el = ELEMENT; \
+  u32 __el_idx = __el - POOL; \
+  \
+  ASSERT(LIST); \
+  ASSERT(POOL); \
+  ASSERT(ELEMENT); \
+  ASSERT(__el->ANCHOR.next != ~0); \
+  ASSERT(__el->ANCHOR.prev != ~0); \
+  ASSERT(LIST->head != ~0); \
+  if (0) { ASSERT(!pool_is_free_index(POOL, __el_idx)); /* Conflicts with pfcp msg pool */ } \
+  ASSERT(upf_llist_el_is_part_of_list(ANCHOR, __el)); \
+  ASSERT(!upf_llist_list_is_empty(LIST)); \
+  \
+  /* If list has only one element */ \
+  if (__el->ANCHOR.next == __el_idx) { \
+    LIST->head = ~0; \
+  } else { \
+    typeof(POOL) __next_el = __upf_llist_get(POOL, __el->ANCHOR.next); \
+    typeof(POOL) __prev_el = __upf_llist_get(POOL, __el->ANCHOR.prev); \
+    ASSERT(upf_llist_el_is_part_of_list(ANCHOR, __next_el)); \
+    ASSERT(upf_llist_el_is_part_of_list(ANCHOR, __prev_el)); \
+    \
+    /* __next and __prev can be same element, */ \
+    __next_el->ANCHOR.prev = __el->ANCHOR.prev; \
+    __prev_el->ANCHOR.next = __el->ANCHOR.next; \
+    \
+    if (LIST->head == __el_idx) { \
+      LIST->head = __next_el - POOL; \
+    } \
+  } \
+  upf_llist_anchor_init(ANCHOR, ELEMENT); \
+  \
+  _UPF_LLIST_LIST_ASSERT_CHANGE_COUNT(LIST, -1); \
+} while(0)
+
+/* Should be safe to remove current VAR element in this loop body */
+#define upf_llist_foreach(VAR, POOL, ANCHOR, LIST, BODY) \
+do { \
+  upf_llist_t *__list = LIST; \
+  /* Save head in case it's removed inside loop */ \
+  if (!upf_llist_list_is_empty(__list)) { \
+    u32 __head_idx = __list->head; \
+    typeof(POOL) __head_el = __upf_llist_get(POOL, __head_idx); \
+    u32 __last_idx = __head_el->ANCHOR.prev; \
+    u32 __next_idx = __head_idx; \
+    u32 __cur_idx; \
+    do { \
+      __cur_idx = __next_idx; \
+      typeof(POOL) __cur_el = __upf_llist_get(POOL, __cur_idx); \
+      __next_idx = __cur_el->ANCHOR.next; \
+      ASSERT(upf_llist_el_is_part_of_list(ANCHOR, __cur_el)); \
+      do { \
+        typeof(POOL) VAR = __cur_el; \
+        BODY; \
+      } while (0); \
+    } while (__cur_idx != __last_idx); \
+  } \
+} while (0)
+
+/* Create type aliases for specific type */
+#define UPF_LLIST_TEMPLATE_TYPES(NAME) \
+typedef upf_llist_t NAME ## _t; \
+typedef upf_llist_anchor_t NAME ## _anchor_t; \
+
+/* Create methods instead of macros for type verification */
+#define UPF_LLIST_TEMPLATE_DEFINITIONS(NAME, TYPE, ANCHOR) \
+static inline void __clib_unused \
+NAME ## _init(NAME ## _t *list) { \
+  upf_llist_init(list); \
+} \
+static void __clib_unused \
+NAME ## _anchor_init(TYPE *el) { \
+  upf_llist_anchor_init(ANCHOR, el); \
+} \
+static bool __clib_unused \
+NAME ## _is_empty(NAME ## _t *list) { \
+  return upf_llist_list_is_empty(list); \
+} \
+static bool __clib_unused \
+NAME ## _el_is_part_of_list(TYPE *el) { \
+  return upf_llist_el_is_part_of_list(ANCHOR, el); \
+} \
+static void __clib_unused \
+NAME ## _insert_tail(TYPE *pool, NAME ## _t *list, TYPE *el) { \
+  upf_llist_insert_tail(pool, ANCHOR, list, el); \
+} \
+static void __clib_unused \
+NAME ## _remove(TYPE *pool, NAME ## _t *list, TYPE *el) { \
+  upf_llist_remove(pool, ANCHOR, list, el); \
+}

--- a/upf/upf.h
+++ b/upf/upf.h
@@ -797,8 +797,7 @@ typedef struct
 
   pfcp_user_id_t user_id;
 
-  /* per-session flow list linkage */
-  u32 first_flow_index;
+  session_flows_list_t flows;
 
   u16 generation;
 } upf_session_t;

--- a/upf/upf_pfcp.c
+++ b/upf/upf_pfcp.c
@@ -605,7 +605,7 @@ pfcp_create_session (upf_node_assoc_t * assoc,
   sx->teid_by_chid =
     sparse_vec_new ( /*elt bytes */ sizeof (u32), /*bits in index */ 8);
 
-  sx->first_flow_index = ~0;
+  session_flows_list_init (&sx->flows);
 
   vlib_worker_thread_barrier_release (vm);
 
@@ -1147,7 +1147,6 @@ pfcp_free_session (upf_session_t * sx)
   vlib_main_t *vm = vlib_get_main ();
   upf_main_t *gtm = &upf_main;
   flowtable_main_t *fm = &flowtable_main;
-  u32 flow_index, next;
   u32 now = (u32) vlib_time_now (vm);
 
   vlib_worker_thread_barrier_sync (vm);
@@ -1156,14 +1155,16 @@ pfcp_free_session (upf_session_t * sx)
    * Remove the flows belonging to the session before freeing the
    * session, so flow reporting can still be done on these flows
    */
-  for (flow_index = sx->first_flow_index; flow_index != ~0; flow_index = next)
-    {
-      flow_entry_t *f = flowtable_get_flow (fm, flow_index);
-      next = f->next_session_flow_index;
-      flowtable_entry_remove (fm, f, now);
-      /* make sure session_flow_unlink_handler has been called */
-      ASSERT (sx->first_flow_index == next);
-    }
+  /* *INDENT-OFF* */
+  upf_llist_foreach(f, fm->flows, session_list_anchor, &sx->flows, {
+    flowtable_entry_remove (fm, f, now);
+
+    /* make sure session_flow_unlink_handler has been called */
+    ASSERT (!session_flows_list_el_is_part_of_list (f));
+  });
+  /* *INDENT-ON* */
+
+  ASSERT (session_flows_list_is_empty (&sx->flows));
 
   for (size_t i = 0; i < ARRAY_LEN (sx->rules); i++)
     pfcp_free_rules (sx, i);
@@ -1186,39 +1187,13 @@ session_flow_unlink_handler (flowtable_main_t * fm, flow_entry_t * flow,
 			     flow_direction_t direction, u32 now)
 {
   upf_main_t *gtm = &upf_main;
+  ASSERT (flow->session_index != ~0);
   upf_session_t *sx = pool_elt_at_index (gtm->sessions, flow->session_index);
   u32 flow_index = flow - fm->flows;
   ASSERT (!pool_is_free_index (fm->flows, flow_index));
 
-  if (sx->first_flow_index == flow_index)
-    sx->first_flow_index = flow->next_session_flow_index;
-  else
-    {
-      /*
-       * We could use a doubly-linked list for the session flows,
-       * making this part faster, but that would further enlarge the
-       * flow_entry_t structure, lowering cache efficiency, or would
-       * require a separate list for the session flow linkage. For
-       * now, we consider that the session shouldn't have too many
-       * flows in it to traverse that list upon flow expiration
-       */
-      u32 cur_flow_index;
-      flow_entry_t *cur_flow;
-      for (cur_flow_index = sx->first_flow_index; cur_flow_index != ~0;
-	   cur_flow_index = cur_flow->next_session_flow_index)
-	{
-	  cur_flow = flowtable_get_flow (fm, cur_flow_index);
-	  if (cur_flow->next_session_flow_index == flow_index)
-	    {
-	      cur_flow->next_session_flow_index =
-		flow->next_session_flow_index;
-	      break;
-	    }
-	}
+  session_flows_list_remove (fm->flows, &sx->flows, flow);
 
-      /* make sure the flow was present in the list */
-      ASSERT (cur_flow_index != ~0);
-    }
   return 0;
 }
 


### PR DESCRIPTION
Backport [CENNSO-871] fix: use doubly linked list for flows

With singly linked list we have complexity of O(n) for deletion what caused overload in case if single session had lots of flows. Especially because most of flows usually expire near end of list.

[CENNSO-871]: https://travelping.atlassian.net/browse/CENNSO-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ