### PR TITLE
build: create compile_commands.json on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ upf/version.h
 build-root
 test/e2e/bin
 .cache
+compile_commands.json

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ attic
 upf/version.h
 build-root
 test/e2e/bin
+.cache

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,0 +1,1 @@
+build-root/compile_commands.json

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,1 +1,0 @@
-build-root/compile_commands.json

--- a/hack/build-internal.sh
+++ b/hack/build-internal.sh
@@ -22,6 +22,6 @@ case "${BUILD_TYPE}" in
      ;;
 esac
 
-cmake -DCMAKE_BUILD_TYPE="${btype}" -DCMAKE_INSTALL_PREFIX=/usr /src
+cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_BUILD_TYPE="${btype}" -DCMAKE_INSTALL_PREFIX=/usr /src
 
 make -C /src/build-root "$@"


### PR DESCRIPTION
adding compile_commands.json to gitignore and creating it with cmake enables editors to use LSP.
You can now symlink it to build dir or copy/modify it in repo root.