### PR TITLE
[CENNSO-771] Fix overflow behavior of flowtable and cleanup

### DIFF
--- a/upf/flowtable.c
+++ b/upf/flowtable.c
@@ -250,7 +250,7 @@ flowtable_entry_lookup_create (flowtable_main_t *fm,
     }
 
   /* create new flow */
-  if (fm->flows_created_count >= fm->flows_max)
+  if (fm->current_flows_count >= fm->flows_max)
     {
       return ~0;
     }
@@ -298,7 +298,7 @@ flowtable_entry_lookup_create (flowtable_main_t *fm,
   upf_debug ("Flow Created: fidx %d timer_slot %d", f - fm->flows,
              f->timer_slot);
 
-  fm->flows_created_count += 1;
+  fm->current_flows_count += 1;
   vlib_increment_simple_counter (&gtm->upf_simple_counters[UPF_FLOW_COUNTER],
                                  vlib_get_thread_index (), 0, 1);
 

--- a/upf/flowtable.c
+++ b/upf/flowtable.c
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-#include <vppinfra/dlist.h>
 #include <vppinfra/types.h>
 #include <vppinfra/vec.h>
 #include <vnet/ip/ip4_packet.h>
@@ -58,93 +57,19 @@ flowtable_add_event_handler (flowtable_main_t *fm, flow_event_t event,
 }
 
 always_inline void
-flow_entry_cache_fill (flowtable_main_t *fm, flowtable_main_per_cpu_t *fmt)
-{
-  u32 cpu_index = os_get_thread_index ();
-  int i;
-  flow_entry_t *f;
-
-  if (pthread_spin_lock (&fm->flows_lock) == 0)
-    {
-      if (PREDICT_FALSE (fm->flows_cpt > fm->flows_max))
-        {
-          pthread_spin_unlock (&fm->flows_lock);
-          return;
-        }
-
-      for (i = 0; i < FLOW_CACHE_SZ; i++)
-        {
-          pool_get_aligned (fm->flows, f, CLIB_CACHE_LINE_BYTES);
-          f->cpu_index = cpu_index;
-          vec_add1 (fmt->flow_cache, f - fm->flows);
-        }
-      fm->flows_cpt += FLOW_CACHE_SZ;
-
-      pthread_spin_unlock (&fm->flows_lock);
-    }
-}
-
-always_inline void
-flow_entry_cache_empty (flowtable_main_t *fm, flowtable_main_per_cpu_t *fmt)
-{
-#if CLIB_DEBUG > 0
-  u32 cpu_index = os_get_thread_index ();
-#endif
-  int i;
-
-  if (pthread_spin_lock (&fm->flows_lock) == 0)
-    {
-      for (i = vec_len (fmt->flow_cache) - 1; i > FLOW_CACHE_SZ; i--)
-        {
-          u32 f_index = vec_pop (fmt->flow_cache);
-
-          upf_debug ("releasing flow %p, index %u",
-                     pool_elt_at_index (fm->flows, f_index), f_index);
-#if CLIB_DEBUG > 0
-          ASSERT (pool_elt_at_index (fm->flows, f_index)->cpu_index ==
-                  cpu_index);
-#endif
-
-          pool_put_index (fm->flows, f_index);
-        }
-      fm->flows_cpt -= FLOW_CACHE_SZ;
-
-      pthread_spin_unlock (&fm->flows_lock);
-    }
-}
-
-always_inline flow_entry_t *
-flow_entry_alloc (flowtable_main_t *fm, flowtable_main_per_cpu_t *fmt)
-{
-  u32 f_index;
-  flow_entry_t *f;
-
-  if (vec_len (fmt->flow_cache) == 0)
-    flow_entry_cache_fill (fm, fmt);
-
-  if (PREDICT_FALSE ((vec_len (fmt->flow_cache) == 0)))
-    return NULL;
-
-  f_index = vec_pop (fmt->flow_cache);
-  f = pool_elt_at_index (fm->flows, f_index);
-  ASSERT (f->cpu_index == os_get_thread_index ());
-
-  return f;
-}
-
-always_inline void
 flow_entry_free (flowtable_main_t *fm, flowtable_main_per_cpu_t *fmt,
                  flow_entry_t *f)
 {
+  /* timer should be already removed */
+  ASSERT (!flow_timeout_list_el_is_part_of_list (f));
+  ASSERT (f->timer_slot == (u16) ~0);
+
   ASSERT (f->cpu_index == os_get_thread_index ());
 
   if (f->app_uri)
     vec_free (f->app_uri);
 
-  vec_add1 (fmt->flow_cache, f - fm->flows);
-
-  if (vec_len (fmt->flow_cache) > 2 * FLOW_CACHE_SZ)
-    flow_entry_cache_empty (fm, fmt);
+  pool_put (fm->flows, f);
 }
 
 always_inline void
@@ -159,30 +84,30 @@ flowtable_entry_remove_internal (flowtable_main_t *fm,
   flowtable_handle_event (fm, f, FLOW_EVENT_REMOVE, FT_ORIGIN, now);
   flowtable_handle_event (fm, f, FLOW_EVENT_UNLINK, FT_ORIGIN, now);
 
-  /* timers unlink */
-  clib_dlist_remove (fmt->timers, f->timer_index);
-  pool_put_index (fmt->timers, f->timer_index);
+  /* timer unlink */
+  flowtable_timeout_stop_entry (fm, fmt, f);
 
   /* hashtable unlink */
   clib_memcpy (kv.key, f->key.key, sizeof (kv.key));
   clib_bihash_add_del_48_8 (&fmt->flows_ht, &kv, 0 /* is_add */);
 
-  /* free to flow cache && pool (last) */
   flow_entry_free (fm, fmt, f);
 }
 
+/* return true if flow was removed */
 always_inline bool
-expire_single_flow (flowtable_main_t *fm, flowtable_main_per_cpu_t *fmt,
-                    flow_entry_t *f, dlist_elt_t *e, u32 now)
+try_expire_single_flow (flowtable_main_t *fm, flowtable_main_per_cpu_t *fmt,
+                        flow_entry_t *f, flow_timeout_list_t *e, u32 now)
 {
   bool keep = f->active + f->lifetime > now;
-  ASSERT (f->timer_index == (e - fmt->timers));
+  ASSERT (f->timer_slot == (e - fmt->timers));
   ASSERT (f->active <= now);
 
   upf_debug ("Flow Timeout Check %d: %u (%u) > %u (%u)", f - fm->flows,
              f->active + f->lifetime,
-             (f->active + f->lifetime) % fm->timer_max_lifetime, now,
+             (f->active + f->lifetime) % FLOW_TIMER_MAX_LIFETIME, now,
              fmt->time_index);
+
   if (!keep &&
       flowtable_handle_event (fm, f, FLOW_EVENT_EXPIRE, FT_ORIGIN, now) != 0)
     {
@@ -197,21 +122,8 @@ expire_single_flow (flowtable_main_t *fm, flowtable_main_per_cpu_t *fmt,
     {
       /* There was activity on the entry, so the idle timeout
          has not passed. Enqueue for another time period. */
-      u32 timer_slot_head_index;
-
-      timer_slot_head_index =
-        (f->active + f->lifetime) % fm->timer_max_lifetime;
-      if (timer_slot_head_index != f->timer_index)
-        {
-          upf_debug ("Flow Reshedule %d to %u", f - fm->flows,
-                     timer_slot_head_index);
-          /* timers unlink */
-          clib_dlist_remove (fmt->timers, f->timer_index);
-          clib_dlist_addtail (fmt->timers, timer_slot_head_index,
-                              f->timer_index);
-          return true;
-        }
-
+      flowtable_timeout_stop_entry (fm, fmt, f);
+      flowtable_timeout_start_entry (fm, fmt, f, now);
       return false;
     }
   else
@@ -226,17 +138,13 @@ flowtable_timer_expire (flowtable_main_t *fm, flowtable_main_per_cpu_t *fmt,
                         u32 now)
 {
   u32 t;
-  flow_entry_t *f;
-  dlist_elt_t *time_slot_curr;
-  u32 index;
-  dlist_elt_t *e;
   u64 expire_cpt = 0;
 
   /*
    * Must call flowtable_timer_expire() only after timer_wheel_index_update()
    * with the same 'now' value
    */
-  ASSERT (now % fm->timer_max_lifetime == fmt->time_index);
+  ASSERT (now % FLOW_TIMER_MAX_LIFETIME == fmt->time_index);
 
   /*
    * In case some of the time slots were skipped e.g. due to low traffic
@@ -244,7 +152,7 @@ flowtable_timer_expire (flowtable_main_t *fm, flowtable_main_per_cpu_t *fmt,
    * process all of the skipped entries, but don't expire too many
    * of them to avoid any pauses. We can expire more of the flows
    * if there's low traffic currently, though, so we apply
-   * TIMER_MAX_EXPIRE limit per step, not per this function run.
+   * FLOW_TIMER_MAX_EXPIRE limit per step, not per this function run.
    */
 
   t = now;
@@ -266,31 +174,27 @@ flowtable_timer_expire (flowtable_main_t *fm, flowtable_main_per_cpu_t *fmt,
 
   for (; t <= now; t++)
     {
-      u32 time_slot_curr_index = t % fm->timer_max_lifetime;
-      if (PREDICT_TRUE (!dlist_is_empty (fmt->timers, time_slot_curr_index)))
+
+      flow_timeout_list_t *timer_list =
+        vec_elt_at_index (fmt->timers, flowtable_time_to_timer_slot (t));
+
+      /* clang-format off */
+      upf_llist_foreach (f, fm->flows, timer_anchor, timer_list,
         {
-          time_slot_curr =
-            pool_elt_at_index (fmt->timers, time_slot_curr_index);
+          if (try_expire_single_flow (fm, fmt, f, timer_list, now))
+            expire_cpt++;
 
-          index = time_slot_curr->next;
-          while (index != time_slot_curr_index &&
-                 expire_cpt < TIMER_MAX_EXPIRE)
-            {
-              e = pool_elt_at_index (fmt->timers, index);
-              f = pool_elt_at_index (fm->flows, e->value);
-
-              index = e->next;
-              if (expire_single_flow (fm, fmt, f, e, now))
-                expire_cpt++;
-            }
-        }
+          if (expire_cpt >= FLOW_TIMER_MAX_EXPIRE)
+            break;
+        });
+      /* clang-format on */
 
       /*
        * If max N of expirations has been reached, the timer wheel
        * entry corresponding to this moment will be revisited upon
        * the next flowtable_timer_expire() call
        */
-      if (expire_cpt == TIMER_MAX_EXPIRE)
+      if (expire_cpt >= FLOW_TIMER_MAX_EXPIRE)
         break;
     }
 
@@ -322,37 +226,6 @@ flowtable_lifetime_calculate (flowtable_main_t *fm, flow_key_t const *key)
   return fm->timer_lifetime[FT_TIMEOUT_TYPE_UNKNOWN];
 }
 
-static void
-recycle_flow (flowtable_main_t *fm, flowtable_main_per_cpu_t *fmt, u32 now)
-{
-  u32 next;
-
-  next = (now + 1) % fm->timer_max_lifetime;
-  while (PREDICT_FALSE (next != now))
-    {
-      flow_entry_t *f;
-      u32 slot_index = next;
-
-      if (PREDICT_FALSE (dlist_is_empty (fmt->timers, slot_index)))
-        {
-          next = (next + 1) % fm->timer_max_lifetime;
-          continue;
-        }
-      dlist_elt_t *head = pool_elt_at_index (fmt->timers, slot_index);
-      dlist_elt_t *e = pool_elt_at_index (fmt->timers, head->next);
-
-      f = pool_elt_at_index (fm->flows, e->value);
-      expire_single_flow (fm, fmt, f, e, now);
-    }
-
-  /*
-   * unreachable:
-   * this should be called if there is no free flows, so we're bound to have
-   * at least *one* flow within the timer wheel (cpu cache is filled at init).
-   */
-  clib_error ("recycle_flow did not find any flow to recycle !");
-}
-
 void
 flowtable_entry_remove (flowtable_main_t *fm, flow_entry_t *f, u32 now)
 {
@@ -369,7 +242,6 @@ flowtable_entry_lookup_create (flowtable_main_t *fm,
                                u32 session_index, int *created)
 {
   flow_entry_t *f;
-  dlist_elt_t *timer_entry;
   upf_main_t *gtm = &upf_main;
 
   if (PREDICT_FALSE (clib_bihash_search_inline_48_8 (&fmt->flows_ht, kv) == 0))
@@ -378,24 +250,15 @@ flowtable_entry_lookup_create (flowtable_main_t *fm,
     }
 
   /* create new flow */
-  f = flow_entry_alloc (fm, fmt);
-  if (PREDICT_FALSE (f == NULL))
+  if (fm->flows_created_count >= fm->flows_max)
     {
-      recycle_flow (fm, fmt, now);
-      f = flow_entry_alloc (fm, fmt);
-      if (PREDICT_FALSE (f == NULL))
-        {
-          clib_error ("flowtable failed to recycle a flow");
-
-          vlib_node_increment_counter (fm->vlib_main, upf_flow_node.index,
-                                       FLOWTABLE_ERROR_RECYCLE, 1);
-          return ~0;
-        }
+      return ~0;
     }
 
   *created = 1;
 
-  memset (f, 0, sizeof (*f));
+  pool_get_zero (fm->flows, f);
+
   clib_memcpy (f->key.key, kv->key, sizeof (f->key.key));
   f->is_reverse = is_reverse;
   f->lifetime = flowtable_lifetime_calculate (fm, &f->key);
@@ -424,16 +287,18 @@ flowtable_entry_lookup_create (flowtable_main_t *fm,
   flow_last_exported (f, FT_ORIGIN) = now;
   flow_last_exported (f, FT_REVERSE) = now;
   f->ps_index = ~0;
+
   session_flows_list_anchor_init (f);
+  flow_timeout_list_anchor_init (f);
+  f->timer_slot = ~0;
 
   /* insert in timer list */
-  pool_get (fmt->timers, timer_entry);
-  timer_entry->value = f - fm->flows;         /* index within the flow pool */
-  f->timer_index = timer_entry - fmt->timers; /* index within the timer pool */
-  timer_wheel_insert_flow (fm, fmt, f);
-  upf_debug ("Flow Created: fidx %d timer_index %d", f - fm->flows,
-             f->timer_index);
+  flowtable_timeout_start_entry (fm, fmt, f, now);
 
+  upf_debug ("Flow Created: fidx %d timer_slot %d", f - fm->flows,
+             f->timer_slot);
+
+  fm->flows_created_count += 1;
   vlib_increment_simple_counter (&gtm->upf_simple_counters[UPF_FLOW_COUNTER],
                                  vlib_get_thread_index (), 0, 1);
 
@@ -448,7 +313,7 @@ void
 timer_wheel_index_update (flowtable_main_t *fm, flowtable_main_per_cpu_t *fmt,
                           u32 now)
 {
-  fmt->time_index = now % fm->timer_max_lifetime;
+  fmt->time_index = now % FLOW_TIMER_MAX_LIFETIME;
 }
 
 u8 *

--- a/upf/flowtable.h
+++ b/upf/flowtable.h
@@ -193,8 +193,7 @@ typedef struct
   /* hashtable */
   clib_bihash_48_8_t flows_ht;
 
-  /* timers */
-  /* this is vector of max_ */
+  /* vector of FLOW_TIMER_MAX_LIFETIME timers lists */
   flow_timeout_list_t *timers;
 
   u32 time_index;

--- a/upf/flowtable.h
+++ b/upf/flowtable.h
@@ -208,8 +208,8 @@ typedef struct
   u32 log2_size;
   u32 flows_max;
   flow_entry_t *flows;
+  u32 current_flows_count;
 
-  u32 flows_created_count;
   u16 timer_lifetime[FT_TIMEOUT_TYPE_MAX];
 
   /* per cpu */

--- a/upf/flowtable.h
+++ b/upf/flowtable.h
@@ -23,7 +23,6 @@
 #include <vnet/vnet.h>
 #include <vnet/ip/ip.h>
 #include <vppinfra/bihash_48_8.h>
-#include <vppinfra/dlist.h>
 #include <vppinfra/pool.h>
 #include <vppinfra/vec.h>
 
@@ -34,10 +33,10 @@
   _ (HIT, "packets with an existing flow")                                    \
   _ (THRU, "packets gone through")                                            \
   _ (CREATED, "packets which created a new flow")                             \
-  _ (UNHANDLED, "unhandled (non-ip)  packet")                                 \
+  _ (NO_SESSION, "packet without session")                                 \
   _ (TIMER_EXPIRE, "flows that have expired")                                 \
   _ (COLLISION, "hashtable collisions")                                       \
-  _ (RECYCLE, "flow recycled")
+  _ (OVERFLOW, "dropped due to flowtable overflow")
 
 typedef enum
 {
@@ -79,13 +78,6 @@ typedef struct
   };
 } flow_key_t;
 
-/* dlist helpers */
-#define dlist_is_empty(pool, head_index)                                      \
-  ({                                                                          \
-    dlist_elt_t *head = pool_elt_at_index ((pool), (head_index));             \
-    (head->next == (u32) ~0 || head->next == (head_index));                   \
-  })
-
 typedef struct
 {
   u32 pkts;
@@ -114,6 +106,7 @@ typedef struct flow_tc
 } flow_tc_t;
 
 UPF_LLIST_TEMPLATE_TYPES (session_flows_list);
+UPF_LLIST_TEMPLATE_TYPES (flow_timeout_list);
 
 typedef struct flow_entry
 {
@@ -131,7 +124,7 @@ typedef struct flow_entry
   u8 dont_splice : 1;
   u8 app_detection_done : 1;
   u8 exported : 1;
-  u16 tcp_state;
+  u8 tcp_state;
   u32 ps_index;
 
   /* stats */
@@ -140,7 +133,8 @@ typedef struct flow_entry
   /* timers */
   u32 active;      /* last activity ts */
   u16 lifetime;    /* in seconds */
-  u32 timer_index; /* index in the timer pool */
+  u16 timer_slot;  /* timer list index in the timer lists pool */
+  flow_timeout_list_anchor_t timer_anchor;
 
   /* UPF data */
   u32 application_id;        /* L7 app index */
@@ -171,6 +165,8 @@ typedef struct flow_entry
 
 UPF_LLIST_TEMPLATE_DEFINITIONS (session_flows_list, flow_entry_t,
                                 session_list_anchor);
+UPF_LLIST_TEMPLATE_DEFINITIONS (flow_timeout_list, flow_entry_t,
+                                timer_anchor);
 
 /* accessor helper */
 #define flow_member(F, M, D)     (F)->M[(D) ^ (F)->is_reverse]
@@ -185,13 +181,13 @@ UPF_LLIST_TEMPLATE_DEFINITIONS (session_flows_list, flow_entry_t,
 #define flow_ipfix_info(F, D)    flow_member ((F), ipfix_info_index, (D))
 
 /* Timers (in seconds) */
-#define TIMER_DEFAULT_LIFETIME (60)
-#define TIMER_MAX_LIFETIME     (600)
+#define FLOW_TIMER_DEFAULT_LIFETIME (60)
+#define FLOW_TIMER_MAX_LIFETIME     (600)
 
 /* Default max number of flows to expire during one run.
  * 256 is the max number of packets in a vector, so this is a minimum
  * if all packets create a flow. */
-#define TIMER_MAX_EXPIRE (1 << 8)
+#define FLOW_TIMER_MAX_EXPIRE (1 << 8)
 
 typedef struct
 {
@@ -199,15 +195,11 @@ typedef struct
   clib_bihash_48_8_t flows_ht;
 
   /* timers */
-  dlist_elt_t *timers;
+  /* this is vector of max_ */
+  flow_timeout_list_t *timers;
+
   u32 time_index;
   u32 next_check;
-
-  /* flow cache
-   * set cache size to 256 so that the worst node run fills the cache at most
-   * once */
-#define FLOW_CACHE_SZ 256
-  u32 *flow_cache;
 } flowtable_main_per_cpu_t;
 
 #define FLOWTABLE_DEFAULT_LOG2_SIZE 22
@@ -218,11 +210,9 @@ typedef struct
   u32 log2_size;
   u32 flows_max;
   flow_entry_t *flows;
-  pthread_spinlock_t flows_lock;
-  u64 flows_cpt;
 
+  u32 flows_created_count;
   u16 timer_lifetime[FT_TIMEOUT_TYPE_MAX];
-  u16 timer_max_lifetime;
 
   /* per cpu */
   flowtable_main_per_cpu_t *per_cpu;
@@ -301,7 +291,6 @@ u8 *format_flow (u8 *, va_list *);
 
 clib_error_t *flowtable_lifetime_update (flowtable_timeout_type_t type,
                                          u16 value);
-clib_error_t *flowtable_max_lifetime_update (u16 value);
 clib_error_t *flowtable_init (vlib_main_t *vm);
 
 static inline u16
@@ -332,6 +321,37 @@ void timer_wheel_index_update (flowtable_main_t *fm,
 
 u64 flowtable_timer_expire (flowtable_main_t *fm,
                             flowtable_main_per_cpu_t *fmt, u32 now);
+
+always_inline u16
+flowtable_time_to_timer_slot (u32 when_seconds) {
+  return when_seconds % FLOW_TIMER_MAX_LIFETIME;
+}
+
+always_inline void
+flowtable_timeout_stop_entry (flowtable_main_t *fm, flowtable_main_per_cpu_t *fmt, flow_entry_t *f) {
+  ASSERT(f->timer_slot != (u16) ~0);
+
+  flow_timeout_list_remove(fm->flows, vec_elt_at_index(fmt->timers, f->timer_slot), f);
+  f->timer_slot = ~0;
+};
+
+// returns timers slot which was used for flow
+always_inline u16
+flowtable_timeout_start_entry (flowtable_main_t *fm, flowtable_main_per_cpu_t *fmt, flow_entry_t *f, u32 now) {
+  ASSERT(f->timer_slot == (u16) ~0);
+
+  /*
+    * Make sure we're not scheduling this flow "in the past",
+    * otherwise it may add the period of the "wheel turn" to its
+    * expiration time
+    */
+  ASSERT (fmt->next_check == ~0 || now + f->lifetime >= fmt->next_check);
+
+  u16 timer_slot = flowtable_time_to_timer_slot(now + f->lifetime);
+  flow_timeout_list_insert_tail(fm->flows, vec_elt_at_index(fmt->timers, timer_slot), f);
+  f->timer_slot = timer_slot;
+  return timer_slot;
+}
 
 static inline void
 parse_packet_protocol (udp_header_t *udp, uword is_reverse, flow_key_t *key)
@@ -415,7 +435,7 @@ flow_mk_key (u64 up_seid, u8 *header, u8 is_ip4, uword *is_reverse,
 }
 
 always_inline void
-flow_tcp_update_lifetime (flow_entry_t *f, tcp_header_t *hdr)
+flow_tcp_update_lifetime (flow_entry_t *f, tcp_header_t *hdr, u32 now)
 {
   tcp_f_state_t old_state, new_state;
 
@@ -429,23 +449,13 @@ flow_tcp_update_lifetime (flow_entry_t *f, tcp_header_t *hdr)
       flowtable_main_t *fm = &flowtable_main;
       u32 cpu_index = os_get_thread_index ();
       flowtable_main_per_cpu_t *fmt = &fm->per_cpu[cpu_index];
-      u32 timer_slot_head_index;
 
-      /*
-       * Make sure we're not scheduling this flow "in the past",
-       * otherwise it may add the period of the "wheel turn" to its
-       * expiration time
-       */
-      ASSERT (fmt->next_check == ~0 ||
-              f->active + f->lifetime >= fmt->next_check);
       f->tcp_state = new_state;
       f->lifetime = tcp_lifetime[new_state];
-      /* reschedule */
-      clib_dlist_remove (fmt->timers, f->timer_index);
 
-      timer_slot_head_index =
-        (f->active + f->lifetime) % fm->timer_max_lifetime;
-      clib_dlist_addtail (fmt->timers, timer_slot_head_index, f->timer_index);
+      /* reschedule */
+      flowtable_timeout_stop_entry(fm, fmt, f);
+      flowtable_timeout_start_entry(fm, fmt, f, now);
     }
 }
 
@@ -461,7 +471,7 @@ flow_update (vlib_main_t *vm, flow_entry_t *f, u8 *iph, u8 is_ip4, u16 len,
       tcp_header_t *hdr =
         (tcp_header_t *) (is_ip4 ? ip4_next_header ((ip4_header_t *) iph) :
                                    ip6_next_header ((ip6_header_t *) iph));
-      flow_tcp_update_lifetime (f, hdr);
+      flow_tcp_update_lifetime (f, hdr, now);
     }
 }
 
@@ -505,17 +515,6 @@ flow_update_stats (vlib_main_t *vm, vlib_buffer_t *b, flow_entry_t *f,
   f->flow_end_time = timestamp_ns;
 
   flowtable_handle_event (fm, f, FLOW_EVENT_STATS_UPDATE, direction, now);
-}
-
-always_inline void
-timer_wheel_insert_flow (flowtable_main_t *fm, flowtable_main_per_cpu_t *fmt,
-                         flow_entry_t *f)
-{
-  u32 timer_slot_head_index;
-
-  timer_slot_head_index =
-    (fmt->time_index + f->lifetime) % fm->timer_max_lifetime;
-  clib_dlist_addtail (fmt->timers, timer_slot_head_index, f->timer_index);
 }
 
 extern vlib_node_registration_t flowtable_process_node;

--- a/upf/flowtable_init.c
+++ b/upf/flowtable_init.c
@@ -15,7 +15,6 @@
 
 #include <vnet/plugin/plugin.h>
 #include <vppinfra/bihash_8_8.h>
-#include <vppinfra/dlist.h>
 #include <vppinfra/pool.h>
 #include <vppinfra/types.h>
 #include <vppinfra/vec.h>
@@ -41,7 +40,7 @@ flowtable_lifetime_update (flowtable_timeout_type_t type, u16 value)
 {
   flowtable_main_t *fm = &flowtable_main;
 
-  if (value > fm->timer_max_lifetime)
+  if (value > FLOW_TIMER_MAX_LIFETIME)
     return clib_error_return (0, "value is too big");
 
   if (type >= FT_TIMEOUT_TYPE_MAX)
@@ -52,28 +51,10 @@ flowtable_lifetime_update (flowtable_timeout_type_t type, u16 value)
   return 0;
 }
 
-clib_error_t *
-flowtable_max_lifetime_update (u16 value)
-{
-  /*
-   * TODO: need to do range check on the value (> 0)
-   * and also reschedule the current flows, if any
-   */
-  clib_error_t *error = 0;
-  flowtable_main_t *fm = &flowtable_main;
-
-  fm->timer_max_lifetime = value;
-
-  return error;
-}
-
 static clib_error_t *
 flowtable_init_cpu (flowtable_main_t *fm, u32 cpu_index)
 {
-  int i;
-  flow_entry_t *f;
   clib_error_t *error = 0;
-  dlist_elt_t *timer_slot;
   flowtable_main_per_cpu_t *fmt = &fm->per_cpu[cpu_index];
   /*
    * As advised in the thread below :
@@ -93,38 +74,13 @@ flowtable_init_cpu (flowtable_main_t *fm, u32 cpu_index)
   fmt->time_index = ~0;
   fmt->next_check = ~0;
 
-  /* alloc TIMER_MAX_LIFETIME heads from the timers pool and fill them with
-   * defaults */
-  for (u32 n = 0; n < TIMER_MAX_LIFETIME; n++)
-    {
-      dlist_elt_t *timer;
-      pool_get (fmt->timers, timer);
-      ASSERT (timer - fmt->timers == n);
-    }
-  upf_debug ("POOL SIZE %u", pool_elts (fmt->timers));
-
-  pool_foreach (timer_slot, fmt->timers)
-    {
-      u32 timer_slot_head_index = timer_slot - fmt->timers;
-
-      clib_dlist_init (fmt->timers, timer_slot_head_index);
-    }
-
-  /* fill flow entry cache */
-  if (pthread_spin_lock (&fm->flows_lock) == 0)
-    {
-      for (i = 0; i < FLOW_CACHE_SZ; i++)
-        {
-          pool_get_aligned (fm->flows, f, CLIB_CACHE_LINE_BYTES);
-#if CLIB_DEBUG > 0
-          f->cpu_index = cpu_index;
-#endif
-          vec_add1 (fmt->flow_cache, f - fm->flows);
-        }
-      fm->flows_cpt += FLOW_CACHE_SZ;
-
-      pthread_spin_unlock (&fm->flows_lock);
-    }
+  fmt->timers = 0;
+  vec_validate (fmt->timers, FLOW_TIMER_MAX_LIFETIME - 1);
+  {
+    flow_timeout_list_t *l;
+    vec_foreach (l, fmt->timers)
+      flow_timeout_list_init (l);
+  }
 
   return error;
 }
@@ -144,13 +100,11 @@ flowtable_init (vlib_main_t *vm)
   fm->flows_max = 1 << fm->log2_size;
   upf_debug ("flows_max %u", fm->flows_max);
   pool_alloc_aligned (fm->flows, fm->flows_max, CLIB_CACHE_LINE_BYTES);
-  pthread_spin_init (&fm->flows_lock, PTHREAD_PROCESS_PRIVATE);
-  fm->flows_cpt = 0;
+  fm->flows_created_count = 0;
 
   for (flowtable_timeout_type_t i = FT_TIMEOUT_TYPE_UNKNOWN;
        i < FT_TIMEOUT_TYPE_MAX; i++)
-    fm->timer_lifetime[i] = TIMER_DEFAULT_LIFETIME;
-  fm->timer_max_lifetime = TIMER_MAX_LIFETIME;
+    fm->timer_lifetime[i] = FLOW_TIMER_DEFAULT_LIFETIME;
 
   /* Init flows counter per cpu */
   vlib_validate_simple_counter (&gtm->upf_simple_counters[UPF_FLOW_COUNTER],

--- a/upf/flowtable_init.c
+++ b/upf/flowtable_init.c
@@ -100,7 +100,7 @@ flowtable_init (vlib_main_t *vm)
   fm->flows_max = 1 << fm->log2_size;
   upf_debug ("flows_max %u", fm->flows_max);
   pool_alloc_aligned (fm->flows, fm->flows_max, CLIB_CACHE_LINE_BYTES);
-  fm->flows_created_count = 0;
+  fm->current_flows_count = 0;
 
   for (flowtable_timeout_type_t i = FT_TIMEOUT_TYPE_UNKNOWN;
        i < FT_TIMEOUT_TYPE_MAX; i++)

--- a/upf/upf.c
+++ b/upf/upf.c
@@ -515,7 +515,7 @@ flow_remove_counter_handler (flowtable_main_t *fm, flow_entry_t *flow,
 {
   upf_main_t *gtm = &upf_main;
 
-  fm->flows_created_count -= 1;
+  fm->current_flows_count -= 1;
   vlib_decrement_simple_counter (&gtm->upf_simple_counters[UPF_FLOW_COUNTER],
                                  vlib_get_thread_index (), 0, 1);
 

--- a/upf/upf.c
+++ b/upf/upf.c
@@ -515,6 +515,7 @@ flow_remove_counter_handler (flowtable_main_t *fm, flow_entry_t *flow,
 {
   upf_main_t *gtm = &upf_main;
 
+  fm->flows_created_count -= 1;
   vlib_decrement_simple_counter (&gtm->upf_simple_counters[UPF_FLOW_COUNTER],
                                  vlib_get_thread_index (), 0, 1);
 

--- a/upf/upf_flow_node.c
+++ b/upf/upf_flow_node.c
@@ -346,7 +346,7 @@ upf_flow_process (vlib_main_t *vm, vlib_node_runtime_t *node,
 
               /* TODO: see comment in dual loop */
 
-              CPT_UNHANDLED++;
+              CPT_NO_SESSION++;
               next0 = FT_NEXT_DROP;
 
               goto stats1;
@@ -367,19 +367,14 @@ upf_flow_process (vlib_main_t *vm, vlib_node_runtime_t *node,
             sx0->generation, sx0 - gtm->sessions, &created);
           if (created)
             {
-              flow_entry_t *f = pool_elt_at_index (fm->flows, flow_idx);
-              ASSERT (!session_flows_list_el_is_part_of_list (f));
-
               session_flows_list_insert_tail (
                 fm->flows, &sx0->flows,
                 pool_elt_at_index (fm->flows, flow_idx));
-
-              ASSERT (session_flows_list_el_is_part_of_list (f));
             }
 
           if (PREDICT_FALSE (~0 == flow_idx))
             {
-              CPT_UNHANDLED++;
+              CPT_OVERFLOW++;
               next0 = FT_NEXT_DROP;
 
               goto stats1;

--- a/upf/upf_flow_node.c
+++ b/upf/upf_flow_node.c
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-#include <vppinfra/dlist.h>
 #include <vppinfra/types.h>
 #include <vppinfra/vec.h>
 #include <vnet/ip/ip4_packet.h>


### PR DESCRIPTION
Remove logic of flow recycle during flow table overflow, since it was broken (crash or hang depending on situation), and also contradicts with NAT case (RFC6888 REQ-11). Also:
- Remove flow entries per thread cache. It's not needed in new multithreading design
- Make max flow lifetime to be constant 600 sec, since we do not have api to dynamically change it anyways
- Use `upf_llist` intrusive linked list for timers instead of dlist for consistency and clearer interface
- Change in flow node counters:
  - `dropped due to flowtable overflow` added
  - `flow recycled` removed, since we do not recycle flows anymore
  - `unhandled (non-ip)  packet` renamed to more suitable `packet without session`