### PR TITLE
Update FPP-VPP to 22.10.12: fix constant traffic drop

### DIFF
--- a/vpp.spec
+++ b/vpp.spec
@@ -1,1 +1,1 @@
-VPP_IMAGE_BASE=quay.io/travelping/fpp-vpp:v22.10.11
+VPP_IMAGE_BASE=quay.io/travelping/fpp-vpp:v22.10.12


### PR DESCRIPTION
FPP-VPP 22.10.12 improves the constant 1% loss even under low traffic. It is done by collecting heap stats in contant time.