### PR TITLE
[CENNSO-1566] test: fix ipfix test reporting interval timing

### DIFF
--- a/test/e2e/ipfix_e2e.go
+++ b/test/e2e/ipfix_e2e.go
@@ -300,19 +300,21 @@ func describeIPFIX(title string, mode framework.UPGMode, ipMode framework.UPGIPM
 			v := &ipfixVerifier{f: f}
 			v.withNWIIPFIXPolicy("dest")
 			v.withIPFIXHandler()
-			v.withReportingInterval(7)
+			const INTERVAL = 7 // 7 seconds so we receive ipfix flow description
+			const MIN_REPORTS_FOR_CHECK = 4
+			v.withReportingInterval(INTERVAL)
 			ginkgo.It("can be set via NWI", func() {
 				trafficCfg := smallVolumeHTTPConfig(nil)
 				// Make sure the flow lasts long enough to measure the intervals
-				trafficCfg.ChunkCount = 50
-				trafficCfg.ChunkDelay = 500 * time.Millisecond
+				trafficCfg.ChunkCount = MIN_REPORTS_FOR_CHECK * (INTERVAL + 1)
+				trafficCfg.ChunkDelay = time.Second
 				v.verifyIPFIX(ipfixVerifierCfg{
 					trafficCfg:          trafficCfg,
 					protocol:            layers.IPProtocolTCP,
 					expectedTrafficPort: 80,
 				})
 				v.verifyIPFIXDestRecords()
-				v.verifyReportingInterval(7)
+				v.verifyReportingInterval(INTERVAL)
 			})
 		})
 	})


### PR DESCRIPTION
This test requires at least 4 reports and UDP traffic generation wasn't running long enough to supply them