### PR TITLE
build: disable "address-of-packed-member" compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,9 +158,9 @@ endif (NOT CMAKE_BUILD_TYPE)
 SET(UPF_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR} CACHE STRING "upf_install_prefix")
 
 if (CMAKE_BUILD_TYPE STREQUAL "Release")
-   set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Wall -march=corei7 -mtune=corei7-avx -O3 -g")
+   set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Wall -Wno-address-of-packed-member -march=corei7 -mtune=corei7-avx -O3 -g")
 elseif (CMAKE_BUILD_TYPE STREQUAL "Debug")
-   set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -march=corei7 -mtune=corei7-avx -O0 -g")
+   set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -Wno-address-of-packed-member -march=corei7 -mtune=corei7-avx -O0 -g")
    add_definitions(-DCLIB_DEBUG -DVLIB_BUFFER_TRACE_TRAJECTORY -fPIC -fstack-protector-all)
 endif()
 


### PR DESCRIPTION
This warning spammed a lot and mostly related to ip address alignment in packed structures which is part of VPP and we can't control it much. For now disable it, because spam of this warning makes it impossible to analyze other warnings which can be important.