### PR TITLE
[CENNSO-1762] fix: reliable out of volume quota handling

### DIFF
--- a/upf/upf.h
+++ b/upf/upf.h
@@ -596,6 +596,7 @@ typedef struct
 #define URR_OVER_QUOTA            BIT (0)
 #define URR_AFTER_MONITORING_TIME BIT (1)
 #define URR_REPORTED              BIT (2)
+#define URR_OVER_VOLUME_THRESHOLD BIT (3)
 
   u8 update_flags;
 #define PFCP_URR_UPDATE_VOLUME_QUOTA        BIT (0)

--- a/upf/upf_pfcp_api.c
+++ b/upf/upf_pfcp_api.c
@@ -1939,7 +1939,8 @@ handle_update_urr (upf_session_t *sx, pfcp_ie_update_urr_t *update_urr,
       update->methods = urr->measurement_method;
       update->triggers = OPT (urr, UPDATE_URR_REPORTING_TRIGGERS,
                               reporting_triggers, update->triggers);
-      update->status &= ~(URR_OVER_QUOTA | URR_REPORTED);
+      update->status &=
+        ~(URR_OVER_QUOTA | URR_OVER_VOLUME_THRESHOLD | URR_REPORTED);
 
       if (ISSET_BIT (urr->grp.fields, UPDATE_URR_MEASUREMENT_PERIOD))
         {


### PR DESCRIPTION
Instead of trying to catch moment when traffic counter is stepped over quota/threshold, track quota/threshold statuses to more reliably catch case when we out of quota/threshold after URR update.