### PR TITLE
[CENNSO-1947] fix: Error indication report crash

### DIFF
--- a/test/e2e/framework/gtpu.go
+++ b/test/e2e/framework/gtpu.go
@@ -22,6 +22,8 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+	"github.com/wmnsk/go-gtp/gtpv1/ie"
+	"github.com/wmnsk/go-gtp/gtpv1/message"
 
 	"github.com/sirupsen/logrus"
 
@@ -146,6 +148,14 @@ func (gtpu *GTPU) Stop() error {
 	}
 
 	return gtpu.up.Stop()
+}
+
+func (gtpu *GTPU) SendErrorIndication(teid uint32, seq uint16, IEs ...*ie.IE) error {
+	dst := net.UDPAddr{
+		IP:   gtpu.cfg.PGWIP,
+		Port: 2152,
+	}
+	return gtpu.up.WriteTo(&dst, message.NewErrorIndication(teid, seq, IEs...))
 }
 
 func (gtpu *GTPU) Context(parent context.Context) context.Context {

--- a/test/e2e/pfcp/pfcp.go
+++ b/test/e2e/pfcp/pfcp.go
@@ -918,8 +918,10 @@ func (pc *PFCPConnection) sendSessionReportResponse(req *message.SessionReportRe
 
 			up_seid = ses.up_seid
 		}
+	} else if sess := pc.sessions[SEID(req.SEID())]; sess != nil {
+		up_seid = sess.up_seid
 	} else {
-		up_seid = pc.sessions[SEID(req.SEID())].up_seid
+		return pc.send(message.NewSessionReportResponse(0, 0, 0, req.SequenceNumber, 0, ie.NewCause(ie.CauseSessionContextNotFound)))
 	}
 	ies = append(ies, ie.NewRecoveryTimeStamp(pc.timestamp))
 	return pc.send(message.NewSessionReportResponse(0, 0, uint64(up_seid), req.SequenceNumber, 0, ies...))

--- a/upf/upf_pfcp_api.c
+++ b/upf/upf_pfcp_api.c
@@ -2953,6 +2953,13 @@ handle_session_report_response (pfcp_msg_t *msg, pfcp_decoded_msg_t *dmsg)
       return -1;
     }
 
+  if (pool_is_free_index (gtm->sessions, msg->session.idx))
+    {
+      /* Precaution against buggy code */
+      ASSERT (0);
+      return -1;
+    }
+
   upf_session_t *sx = pool_elt_at_index (gtm->sessions, msg->session.idx);
 
   if (msg->up_seid != sx->up_seid)

--- a/upf/upf_pfcp_server.c
+++ b/upf/upf_pfcp_server.c
@@ -1499,8 +1499,10 @@ pfcp_process (vlib_main_t *vm, vlib_node_runtime_t *rt, vlib_frame_t *f)
                 pfcp_msg_t *tx = (pfcp_msg_t *) event_data[i];
                 // Handle case when session was removed before
                 // receiving this event
-
-                if (!pool_is_free_index (gtm->nodes, tx->node))
+                if (!pool_is_free_index (gtm->nodes, tx->node) &&
+                    !pool_is_free_index (gtm->sessions, tx->session.idx) &&
+                    pool_elt_at_index (gtm->sessions, tx->session.idx)
+                        ->up_seid == tx->up_seid)
                   {
                     pfcp_msg_t *msg;
 
@@ -1509,6 +1511,7 @@ pfcp_process (vlib_main_t *vm, vlib_node_runtime_t *rt, vlib_frame_t *f)
                   }
                 else
                   {
+                    upf_debug ("ignored tx event because session deleted");
                     vec_free (tx->data);
                   }
 


### PR DESCRIPTION
Report message could contain invalid session handler if send the same moment as deletion request for this session. This resulted in crash in session report response.