### PR TITLE
Fix retry logic in UP-seid generation

### DIFF
--- a/upf/upf_pfcp_api.c
+++ b/upf/upf_pfcp_api.c
@@ -2561,7 +2561,7 @@ handle_session_establishment_request (pfcp_msg_t *msg,
         {
           /* try to generate random seid */
           up_seid = random_u64 (&seed);
-          if (up_seid == 0 || up_seid == ~0)
+          if (up_seid == 0 || up_seid == ~(u64)0)
             {
               continue;
             }
@@ -2571,7 +2571,7 @@ handle_session_establishment_request (pfcp_msg_t *msg,
               break;
             }
         }
-      while (retry_cnt--);
+      while (--retry_cnt);
 
       if (retry_cnt == 0)
         {


### PR DESCRIPTION
`~0` is usually `(i32) 0xffffffff`. We should compare `up_seid (u64)` to `(u64) 0xffffffffffffffff` instead.

Additionally, adjust loop termination statement such that after exhausting retry limit, `retry_cnt == 0` rather than `-1`, fixing subsequent if statement.